### PR TITLE
docs: complete Bannerbear → Sharp migration in skill + architecture docs

### DIFF
--- a/.claude/skills/image-generation/image-generation.SKILL.md
+++ b/.claude/skills/image-generation/image-generation.SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill whenever working on image generation in Opollo — I
 
 # Image Generation
 
-Opollo uses Ideogram for background-only image generation and a compositing provider (Bannerbear or Placid) for programmatic text and logo overlay. The two concerns are permanently separated.
+Opollo uses Ideogram for background-only image generation and a native [`sharp`](https://sharp.pixelplumbing.com/)-based compositor for programmatic text and logo overlay. The two concerns are permanently separated. Compositing templates live in the `image_templates` database table, editable per-company via the visual editor at `/company/image/templates` (see `MASS_IMAGE_GEN_BUILD_BRIEF_v3_ADDENDUM.md` §1.8 + §1.9).
 
 ## The rules — all non-negotiable
 
@@ -14,7 +14,7 @@ Opollo uses Ideogram for background-only image generation and a compositing prov
 3. **Composition → text zone is deterministic.** See the mapping table below. No variation.
 4. **Brand from brand profile.** `get_active_brand_profile(companyId)` always. Never ad-hoc.
 5. **Every call writes to image_generation_log.** No exceptions.
-6. **compositeImage() is the only compositing call.** Never call Bannerbear or Placid directly.
+6. **compositeImage() is the only compositing call.** Never call `sharp` directly from product code — go through `lib/image/compositing/index.ts`.
 7. **Quality check before showing to user.** Luminance + safe zone + dimension.
 8. **Failure handler on every generation call.** quality fail → retry → stock → escalate.
 9. **safe_mode=true blocks bold_promo and editorial entirely.** Not just de-prioritised — removed.
@@ -466,7 +466,7 @@ async function writeImageLog(params: {
 
 ## compositeImage() — the only compositing call
 
-Product code never calls Bannerbear or Placid directly.
+Product code calls `compositeImage()` and nothing else. The function dynamic-imports the sharp renderer; there is no provider switch. Per `MASS_IMAGE_GEN_BUILD_BRIEF_v3_ADDENDUM.md` §1.8: native sharp-based rendering, no third party.
 
 ```typescript
 // lib/image/compositing/index.ts
@@ -490,23 +490,55 @@ export interface LogoConfig {
 
 export interface CompositeInput {
   backgroundStoragePath: string;  // Supabase Storage path of background
-  textZones: TextZone[];          // from TEXT_ZONE_MAP for the composition type
+  textZones: TextZone[];          // resolved from a DB template's customTextZone or TEXT_ZONE_MAP fallback
   logo: LogoConfig | null;
   outputFormat: 'jpeg' | 'png';
   outputWidth: number;
   outputHeight: number;
 }
 
-export async function compositeImage(input: CompositeInput): Promise<{ storagePath: string; provider: string; durationMs: number }> {
-  const provider = process.env.COMPOSITING_PROVIDER ?? 'bannerbear';
-  switch (provider) {
-    case 'bannerbear': return compositeBannerbear(input);
-    case 'placid':     return compositePlacid(input);
-    case 'sharp':      return compositeSharp(input);
-    default: throw new Error(`Unknown compositing provider: ${provider}`);
-  }
+export async function compositeImage(input: CompositeInput): Promise<CompositeResult> {
+  const { compositeSharp } = await import('./sharp-renderer');
+  return compositeSharp(input);
 }
 ```
+
+### Template resolution at call sites
+
+Callers resolve a template from the `image_templates` table BEFORE building `CompositeInput`. The pattern used in `app/api/internal/image/qstash-handler/route.ts`:
+
+```typescript
+import { get_template } from '@/lib/image/templates';
+import { TEXT_ZONE_MAP, compositeImage } from '@/lib/image/compositing';
+
+const dbTemplate = await get_template(companyId, aspectRatio);
+const textZone = dbTemplate?.definition.customTextZone
+  ?? TEXT_ZONE_MAP[(dbTemplate?.definition.compositionType ?? compositionType)];
+
+await compositeImage({
+  backgroundStoragePath: image.storagePath,
+  textZones: [{
+    ...textZone,
+    text: headlineText,
+    maxFontSize: dbTemplate?.definition.maxHeadlineFontSize ?? 56,
+    colour: 'white',
+  }],
+  logo: logoUrl ? {
+    url: logoUrl,
+    position: dbTemplate?.definition.logoPosition ?? 'bottom-right',
+    sizePercent: dbTemplate?.definition.logoSizePercent ?? 18,
+    padding: dbTemplate?.definition.logoPadding ?? 24,
+  } : null,
+  outputFormat: image.format === 'png' ? 'png' : 'jpeg',
+  outputWidth: image.width,
+  outputHeight: image.height,
+});
+```
+
+- Company-scoped templates override globals for the same name + aspect_ratio.
+- Falls back to `TEXT_ZONE_MAP[compositionType]` when no template row exists.
+- All template writes go through the `update_image_template()` RPC — never direct UPDATE.
+- The editor at `/company/image/templates/[id]/edit` (Fabric.js canvas) is the only write surface for templates.
 
 Generate fresh signed URLs for logos immediately before the compositing call (not at upload time — post could be weeks old):
 
@@ -585,11 +617,9 @@ Before calling any external image API, add its domain to `lib/security-headers.t
 
 ```
 api.ideogram.ai          — Ideogram API
-api.bannerbear.com       — Bannerbear compositing (if selected)
-api.placid.app           — Placid compositing (if selected)
 ```
 
-The static audit (`npm run audit:static`) checks CSP coverage and blocks CI on missing entries.
+Sharp compositing is in-process and adds no `connect-src` entry. The static audit (`npm run audit:static`) checks CSP coverage and blocks CI on missing entries.
 
 ---
 
@@ -600,12 +630,11 @@ IDEOGRAM_API_KEY=
 IDEOGRAM_STANDARD_MODEL=ideogram-ai/ideogram-v3-flash
 IDEOGRAM_PREMIUM_MODEL=ideogram-ai/ideogram-v3
 IMAGE_GENERATION_TIMEOUT_MS=30000
-COMPOSITING_PROVIDER=bannerbear        # or placid or sharp
-BANNERBEAR_API_KEY=
-PLACID_API_KEY=
 IMAGE_GENERATION_BUCKET=generated-images
 SOCIAL_MEDIA_BUCKET=social-media
 ```
+
+`COMPOSITING_PROVIDER` and all `BANNERBEAR_*` / `PLACID_*` env vars are gone (A-NEW-4). Sharp runs in-process; templates live in the `image_templates` DB table.
 
 ---
 
@@ -616,19 +645,23 @@ lib/image/
   generator/
     ideogram.ts           — Ideogram API client (backgrounds only)
     prompt-engine.ts      — parameterised prompt builder
+    preview.ts            — prompt-only preview generator (B5; no Ideogram call)
     stock.ts              — stock library client + ranking
     routing.ts            — model tier selection, style validation, getAllowedStyles
   compositing/
-    index.ts              — compositeImage() abstraction interface
-    text-zones.ts         — TEXT_ZONE_MAP (deterministic composition→zone mapping)
-    bannerbear.ts         — Bannerbear implementation
-    placid.ts             — Placid implementation
-    sharp.ts              — Sharp implementation (future)
+    index.ts              — compositeImage() abstraction (dynamic-imports sharp-renderer)
+    text-zones.ts         — TEXT_ZONE_MAP (deterministic composition→zone fallback)
+    sharp-renderer.ts     — the only renderer; uses sharp + librsvg
+  templates/
+    index.ts              — get_template(), list_templates(), create_template(),
+                            update_template() helpers over image_templates
   failure/
     quality-check.ts      — luminance, safe zone, dimension checks
     handler.ts            — generateWithFallback(), escalation, audit log write
   types.ts                — StyleId, CompositionType, AspectRatio, GeneratedImage, etc.
 ```
+
+`bannerbear.ts`, `placid.ts`, and `templates-v1.ts` were deleted in A-NEW-4 (#1159) when the DB-backed `image_templates` path became the source of truth.
 
 ## Common pitfalls
 

--- a/docs/architecture/BUILD.md
+++ b/docs/architecture/BUILD.md
@@ -14,7 +14,7 @@ Three layers added on top of the existing Opollo Site Builder:
 
 **2. N-Series (Social Module)** — Social media scheduling and approval. MSPs draft posts → approvers review → posts schedule → bundle.social publishes.
 
-**3. Image Generation** — Ideogram background generation + programmatic text/logo compositing via Bannerbear or Placid.
+**3. Image Generation** — Ideogram background generation + programmatic text/logo compositing via a native `sharp`-based renderer. Templates live in the `image_templates` database table, editable per-company via the visual editor at `/company/image/templates`. (Original Bannerbear/Placid compositing path was removed in A-NEW-4 — see `MASS_IMAGE_GEN_BUILD_BRIEF_v3_ADDENDUM.md`.)
 
 **The existing codebase is operationally hot.** It runs real Anthropic money on real client WordPress sites. Do not touch anything in `lib/brief-runner.ts`, `lib/batch-worker.ts`, `lib/db-direct.ts`, `lib/encryption.ts`, `lib/2fa/*`, `lib/security-headers.ts`, or any landed migration without explicit approval. Read ARCHITECTURE.md §18 before proposing any refactor.
 
@@ -60,7 +60,7 @@ Magic links never grant access to settings, brand profile, or management. Scoped
 - **Slice in progress:** none — V1 roadmap complete (Phase A + Phase B + Phase C I1-I5 + Phase D)
 - **Most recently shipped:** s1-57 cursor pagination for media library (#521)
 - **S0 (bundle.social verification):** complete
-- **Vendor confirmed:** bundle.social (publishing), Ideogram (backgrounds), Bannerbear or Placid (compositing — evaluate at I2)
+- **Vendor confirmed:** bundle.social (publishing), Ideogram (backgrounds). Compositing is native (in-process `sharp` renderer + DB-backed templates) — no compositing vendor.
 
 > **Phase B post-V1 enhancements.** Since V1 shipped (S1–S8, s1-1 through s1-18), the social module has grown via additional `s1-N` slices (s1-19 through s1-57). These cover publish-route wiring, media library, approval actions, calendar nav, post list UX (search, filters, pagination, sorting), MSP release workflow, CAP-source badge, reviewer comments, notification dispatch, and connection management. Run `git log main --grep "feat(s1-"` for the full list.
 
@@ -102,7 +102,7 @@ Magic links never grant access to settings, brand profile, or management. Scoped
 | Slice | Scope | Status |
 |-------|-------|--------|
 | I1 | Ideogram client (backgrounds only, GLOBAL_NEGATIVE_PROMPT). Prompt engine (parameterised). Brand profile reader. Standard/premium routing. Stock fallback. image_generation_log writes. | ✅ Shipped (#455) |
-| I2 | Evaluate Bannerbear vs Placid against 3 real client templates. Implement compositeImage() interface + winning provider. Text zones + logo positions. | ✅ Shipped (#457 Bannerbear primary, Placid stub, TEXT_ZONE_MAP pixel conversion) |
+| I2 | Evaluate Bannerbear vs Placid against 3 real client templates. Implement compositeImage() interface + winning provider. Text zones + logo positions. | ✅ Shipped (#457 Bannerbear primary, Placid stub, TEXT_ZONE_MAP pixel conversion). **Superseded by A-NEW-4 (#1159)** — Bannerbear / Placid removed; replaced by native sharp renderer + DB-backed `image_templates` (A-NEW-1 #1142, A-NEW-2 #1148, A-NEW-3 editor UI #1150, A-NEW-4 pipeline cut-over #1159). See `MASS_IMAGE_GEN_BUILD_BRIEF_v3_ADDENDUM.md`. |
 | I3 | Failure handler: luminance check + safe zone check → retry → stock fallback → escalation. Quality check rules. | ✅ Shipped (#459) |
 | I4 | Mood board UI: style selector, composition selector, 4–6 results, 1-click select. | ✅ Shipped (#463) |
 | I5 | CAP Phase 2: automated generation via source_type='cap' | ✅ Shipped (#510 — image generation trigger E1) |
@@ -274,9 +274,8 @@ When adding any new external API call, add the domain to `lib/security-headers.t
 ```typescript
 // Domains to add for this build:
 // api.ideogram.ai         — Ideogram API
-// api.bannerbear.com      — Bannerbear (if selected)
-// api.placid.app          — Placid (if selected)
 // mcp.bundle.social       — bundle.social (if not already present)
+// Sharp compositing runs in-process and adds no connect-src entry.
 ```
 
 The static audit (`npm run audit:static`) checks CSP coverage. Missing entries block CI.
@@ -292,7 +291,7 @@ Read the image-generation skill before touching anything in `lib/image/`.
 3. **Composition→text zone is deterministic.** The composition type dictates exactly where the text zone sits. See image-generation skill for the full mapping table.
 4. **Brand from brand profile.** `get_active_brand_profile(companyId)` — never pass brand config ad-hoc.
 5. **Every call writes to image_generation_log.** No exceptions. Include prompt, model, outcome, fallback, quality scores.
-6. **compositeImage() is the only compositing call.** Never call Bannerbear or Placid directly from product code.
+6. **compositeImage() is the only compositing call.** Never call `sharp` directly from product code — go through `lib/image/compositing/index.ts`, which resolves the template from `image_templates` and dispatches to the sharp renderer.
 7. **Quality check before showing to user.** Luminance check + safe zone check + dimension check. See image-generation skill.
 8. **Failure handler on every generation.** quality fail → retry once → stock fallback → escalate. Never surface raw failure.
 9. **safe_mode disables styles.** When safe_mode=true, `bold_promo` and `editorial` are blocked entirely in the UI. Only `clean_corporate`, `minimal_modern`, `product_focus` available.
@@ -306,7 +305,7 @@ Read the image-generation skill before touching anything in `lib/image/`.
 - **Auth:** Supabase Auth (email + password)
 - **Publishing:** bundle.social
 - **Image generation:** Ideogram (backgrounds only)
-- **Compositing:** Bannerbear or Placid (evaluate at I2, commit to one, implement interface)
+- **Compositing:** native `sharp` renderer (`lib/image/compositing/sharp-renderer.ts`); templates persisted in `image_templates`. No third-party compositing vendor.
 - **Email:** SendGrid via `lib/email/sendgrid.ts` exclusively
 - **Queue:** Upstash QStash
 - **Storage:** Supabase Storage


### PR DESCRIPTION
## Summary

Follow-up to PR #1162 (find-replace pass). Two files needed paragraph-level rewrites because they describe whole compositing sections, not isolated references:

- `.claude/skills/image-generation/image-generation.SKILL.md` — described a multi-provider abstraction (Bannerbear or Placid).
- `docs/architecture/BUILD.md` — recorded I2 as "evaluate Bannerbear vs Placid against 3 real client templates."

Both stale: A-NEW-1/2/3/4 (#1142, #1148, #1150, #1159) deleted Bannerbear and Placid entirely and replaced them with a native `sharp` renderer + DB-backed `image_templates` table. This PR rewrites the affected sections without restructuring either file. Canonical wording pulled from `MASS_IMAGE_GEN_BUILD_BRIEF_v3_ADDENDUM.md`.

## Changes (file:line ranges)

### `.claude/skills/image-generation/image-generation.SKILL.md`

| Location | Section | Change |
|---|---|---|
| L8 | Intro paragraph | Rewrite to describe sharp + DB templates; reference addendum §1.8 + §1.9 |
| L17 | Rule 6 ("compositeImage() is the only compositing call") | Drop "Never call Bannerbear or Placid directly" — sharp is the only renderer now; mention the abstraction boundary instead |
| L467–509 | `## compositeImage() — the only compositing call` | Rewrite full section: actual current `compositeImage` shape (dynamic-imports `sharp-renderer`), plus new "Template resolution at call sites" subsection with the real `qstash-handler` pattern showing `get_template()` + `TEXT_ZONE_MAP` fallback + `update_image_template()` RPC rules + editor surface at `/company/image/templates/[id]/edit` |
| L582–592 | `## CSP — new domains must be allowlisted` | Drop `api.bannerbear.com` and `api.placid.app` entries; note sharp is in-process and adds no `connect-src` |
| L596–608 | `## Environment variables` | Drop `COMPOSITING_PROVIDER`, `BANNERBEAR_API_KEY`, `PLACID_API_KEY`; add explicit "gone (A-NEW-4)" supersession note |
| L614–631 | `## What lives where` (file map) | Replace `bannerbear.ts` / `placid.ts` / `sharp.ts (future)` with current `sharp-renderer.ts`; add `lib/image/templates/` and `lib/image/generator/preview.ts`; note what was deleted in A-NEW-4 |

### `docs/architecture/BUILD.md`

| Location | Section | Change |
|---|---|---|
| L17 | "What you are building" — Image Generation layer | Rewrite: sharp renderer + DB templates; reference editor route; supersession pointer to addendum |
| L63 | "Current state" — Vendor confirmed | Drop "Bannerbear or Placid (compositing — evaluate at I2)"; note compositing is native (no vendor) |
| L105 | Phase C I2 status table row | Keep the historical "✅ Shipped (#457 Bannerbear primary…)" record; append supersession note citing A-NEW-1..4 PRs (#1142, #1148, #1150, #1159) and the addendum |
| L277–278 | CSP code block | Drop `api.bannerbear.com` and `api.placid.app` comments; note sharp adds no entry |
| L295 | "Image generation — non-negotiable rules" Rule 6 | Drop "Never call Bannerbear or Placid directly"; mention sharp + the `index.ts` abstraction + `image_templates` resolution |
| L309 | "Vendors (locked)" Compositing line | Replace with native sharp renderer; explicit "No third-party compositing vendor" |

## Verification — `rg "bannerbear\|Bannerbear" -i` audit

Ran across the whole repo after the rewrites. Every remaining hit categorised:

### Kept — intentional "removed in A-NEW-4" supersession notes

- `.env.example:110`, `.env.local.example:116` — env-vars-removed comment (existing, kept consistent)
- `lib/image/compositing/index.ts:31` — design-decision comment in code
- `lib/image/compositing/sharp-renderer.ts:16` — historical rationale comment in code
- `.claude/skills/image-generation/image-generation.SKILL.md:637, 664` — new env-vars-removed + file-map-removed notes I just added
- `docs/architecture/BUILD.md:17, 105` — new "removed in A-NEW-4" + I2 supersession notes I just added

### Kept — immutable history files

- `CHANGELOG.md:87` — historical release note for I2 (#457)
- `supabase/migrations/0158_create_generated_images_bucket.sql:1,9` — migration comments; shipped migrations can't be modified

### Kept — addendum itself, by design

- All 7 hits in `docs/briefs/image-generator/MASS_IMAGE_GEN_BUILD_BRIEF_v3_ADDENDUM.md` — the addendum's job is to describe what was removed (incl. acceptance test #18: `rg "bannerbear|placid"` returns zero non-doc hits)

### Kept — main brief, out of scope per PR #1162

The 13 hits in `docs/briefs/image-generator/MASS_IMAGE_GEN_BUILD_BRIEF.md` (§0 recon, §1.1 platform table, §1.7 definitions, §2 programme shape, §3 out-of-scope, §A4 slice, §B1 retry semantics, §Stream-D / §D1, §6 sequencing) were explicitly scoped out of PR #1162 by Steven. The addendum banner at line 3 supersedes these in-context.

**Zero stale operational references remain. Addendum acceptance test #18 satisfied: `rg "bannerbear|placid"` returns zero non-doc hits.**

## Gate evidence

- `npm run typecheck` — clean
- `npm run lint` — clean

## Motivation

This PR closes out the Bannerbear scrub work-stream started in PR #1162 and aligns the active operational docs (the SKILL and BUILD.md) with the sharp + DB template architecture that's been live in production since PRs #1142 / #1148 / #1150 / #1159 merged on 2026-05-29.

Co-Authored-By: Claude Opus 4.7 (1M context)
