### PR TITLE
fix(e2e): dashboard calendar grid test — investigation and fix

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -16,11 +16,24 @@ import { signInAsCompanyAdmin } from "./helpers";
 const COMPANY_ID = "11111111-2222-3333-4444-555555555555";
 const MOCK_POST_ID = "aaaaaaaa-bbbb-4ccc-8ddd-000000000001";
 
+// Calendar opens on the current month. Schedule the mocked post on the 15th
+// of the current month so the post-chip is always within the visible grid,
+// regardless of which weekday the month starts/ends on. (Previous "+2 days"
+// scheduling broke on the last 1-2 days of any month ending Fri/Sat/Sun —
+// buildGrid in SocialCalendarGrid.tsx renders no trailing-month overflow
+// cells when the month ends on Sunday, so a date in the next month wouldn't
+// render anywhere on the visible grid.)
+function dateInCurrentMonth(dayOfMonth = 15): string {
+  const now = new Date();
+  // Noon UTC avoids edge cases around the calendar's start-of-day comparisons.
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), dayOfMonth, 12, 0, 0)).toISOString();
+}
+
 function makePost(overrides: Record<string, unknown> = {}) {
   return {
     id: MOCK_POST_ID,
     state: "scheduled",
-    scheduled_at: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+    scheduled_at: dateInCurrentMonth(15),
     published_at: null,
     content_excerpt: "Test post for dashboard spec",
     primary_media_url: null,
@@ -137,7 +150,7 @@ test.describe("dashboard — calendar grid (PR F)", () => {
         body: JSON.stringify({
           ok: true,
           data: {
-            posts: [makePost({ scheduled_at: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString() })],
+            posts: [makePost({ scheduled_at: dateInCurrentMonth(15) })],
             range: { from: "2026-01-01", to: "2026-12-31" },
           },
           timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Investigation and fix for the failing `(F-1) month view renders calendar grid with day cells` test in `e2e/dashboard.spec.ts`. **Test fragility, not a code regression.** A time-bomb in the mock's `scheduled_at` computation fires on the last 1-2 days of any month that ends on Sunday (Monday-first locale).

## Investigation

### Failure shape (from PR #1165 CI runs at 01:35Z and 01:54Z on 2026-05-30)

```
1) [chromium] › e2e/dashboard.spec.ts:91:7 › dashboard — calendar grid (PR F)
     › (F-1) month view renders calendar grid with day cells

   Error: expect(locator).toBeVisible() failed
   Locator: getByTestId('post-chip').first()
   Expected: visible
   Timeout: 10000ms
   Error: element(s) not found
```

Critically, **all earlier assertions in the test passed** (`calendar-shell`, `month-label`, `calendar-grid`, `calendar-dnd-cell` all rendered with the expected counts). Only the `post-chip` was missing.

### Root cause

The mock's `makePost()` factory schedules the post at `Date.now() + 2 * 86400_000` (i.e. "today + 2 days"). For (F-1) on 2026-05-30, that's 2026-06-01.

`components/social/calendar/SocialCalendarGrid.tsx:33` builds the grid:

```ts
function buildGrid(year: number, month: number): Date[] {
  const first = new Date(year, month, 1);
  const last  = new Date(year, month + 1, 0);
  const firstDow = (first.getDay() + 6) % 7;
  const lastDow  = (last.getDay()  + 6) % 7;
  …
  const trailing = lastDow < 6 ? 6 - lastDow : 0;  // ← Sun (6) → 0 trailing cells
  for (let d = 1; d <= trailing; d++) cells.push(new Date(year, month + 1, d));
}
```

When a month ends on Sunday, `lastDow === 6`, so `trailing = 0` and **no next-month overflow cells are rendered**. May 2026 ends on Sunday May 31. June 1 is therefore not present in any visible grid cell. The post-chip has nowhere to render. The test waits 10s for an element that will never appear.

### Timeline confirming "recent and consistent, not a flake"

| When | Mock `scheduled_at` | In May grid? | CI result |
|---|---|---|---|
| 2026-05-29 23:13 UTC (PR #1163 merge) | 2026-05-31 (Sun, last day of May) | ✅ yes | green |
| 2026-05-30 ~01:35 UTC (PR #1165 first try) | 2026-06-01 | ❌ no | red |
| 2026-05-30 ~01:54 UTC (PR #1165 rerun) | 2026-06-01 | ❌ no | red |

Identical failure across two physically distinct CI runs at the same line. **No regression in calendar-grid code — the test would have broken at midnight UTC on 2026-05-30 regardless of which PR was running.** It's a time-bomb that fires whenever the test runs in the last 2 days of any month ending Fri/Sat/Sun (more days for Sat/Sun, fewer for Fri).

### Other instances of the same shape

`grep "Date\.now\(\)\s*\+.*24\s*\*"` on `e2e/`:
- `e2e/dashboard.spec.ts:153` — (F-4) drag test, same `makePost` factory but at +3 days. Same time-bomb; would have fired on the last 3 days of a Sun-ending month. **Fixed by this PR.**
- `e2e/optimiser-helpers.ts:237` — `expires_at = Date.now() + 14d` for credential expiry. Unrelated; no calendar-grid dependency. Not in scope.

## Fix

Introduce `dateInCurrentMonth(day = 15)` in `e2e/dashboard.spec.ts` that returns an ISO timestamp at noon UTC on a fixed day of the current month. Use it in both `makePost()` defaults (F-1, etc.) and the F-4 override.

```ts
function dateInCurrentMonth(dayOfMonth = 15): string {
  const now = new Date();
  return new Date(Date.UTC(
    now.getUTCFullYear(),
    now.getUTCMonth(),
    dayOfMonth,
    12, 0, 0,
  )).toISOString();
}
```

The 15th is always inside the visible grid regardless of which weekday the month starts or ends on. The post-chip always renders.

## Why a test fix and not a code fix

The `buildGrid` behaviour is correct per the Monday-first design — months ending Sunday genuinely don't need trailing-month cells because the row is already full. The test was making a wrong assumption about the visible date range. The right fix is in the test, not in the renderer.

If the goal were "always show 6 rows = 42 cells" (some calendar UIs do this), that would be a UX decision for Steven, not a test concern. Filing this here for the record but not changing `buildGrid` in this PR.

## Gate evidence

- `npm run typecheck` — clean
- `npm run lint` — clean
- Running the failing test locally would require a full dev-server + Supabase stack + auth fixtures; the analysis is deterministic enough to verify in CI. The fix is one file, ~15 lines.

## Verification plan

- CI's `e2e` job picks up the fix and (F-1) passes.
- (F-4) also benefits from the same factory change — no separate verification needed.
- A follow-up worth considering (NOT in scope here): replace the runtime date helpers with Playwright's `page.clock.install({ time: ... })` API to freeze time across all dashboard specs, eliminating this entire class of fragility.

## DO NOT auto-merge

Per Steven's instruction: production verification can wait, but a wrong e2e fix could hide a real bug. Holding for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
