### PR TITLE
docs(backlog): add v1-launch-blockers — restore e2e as required check

### DIFF
--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -6,6 +6,7 @@ struck-through — ship-state lives in git log.
 | File | Scope |
 |---|---|
 | [ux-debt.md](ux-debt.md) | Operator-facing jargon and label cleanups |
+| [v1-launch-blockers.md](v1-launch-blockers.md) | Items that MUST be resolved before any client gets v1 |
 
 For broader project state, see `docs/BACKLOG.md` (different scope —
 project-wide) and the milestone-specific docs under `docs/plans/`.

--- a/docs/backlog/v1-launch-blockers.md
+++ b/docs/backlog/v1-launch-blockers.md
@@ -1,0 +1,56 @@
+# v1 launch blockers — live items
+
+> Things that MUST be resolved before any client gets v1. Shipped items
+> are deleted, not struck-through — ship-state lives in git log.
+
+## E2E test suite — restore as required check
+
+**Status:** flaky, removed from required status checks during #1164.
+**Owner:** unassigned.
+**Source:** Steven, 2026-05-30 (post-PR #1166).
+
+Steven flagged this on 2026-05-30 after PR #1166 fixed a single
+time-bomb in `dashboard.spec.ts` ((F-1) calendar grid). The wider
+e2e suite has been systemically flaky, and #1164 removed it from
+main's required status checks so flake doesn't block routine merges.
+That's an acceptable short-term workaround but cannot persist into
+v1 — without e2e gating, regressions land silently.
+
+### Checklist (must all be complete before any client gets v1)
+
+- [ ] **Diagnose root cause of e2e flakiness.** Likely candidates:
+  - Timing (more `Date.now() + N` style time-bombs like #1166 fixed)
+  - Seed data drift between runs against shared staging Supabase
+  - Auth-fixture cookie / session-token expiry across runs
+  - Playwright concurrency / shared-state issues
+  - Non-deterministic third-party calls in test paths
+- [ ] **Fix or `test.fixme()` every inherently-flaky test.** Each
+  `test.fixme()` must link an open issue (per CLAUDE.md §"Seven-layer
+  test harness — Flaky / fixme tests": seven-day SLA on linked
+  issue or CI fails).
+- [ ] **Restore `e2e` as a required check** in main's branch
+  protection (Settings → Branches → main → Required status checks).
+- [ ] **Verify 3 consecutive PRs pass `e2e` cleanly** with the
+  restored required check, before declaring stable.
+
+### Why this is launch-critical
+
+E2E covers the customer-facing journeys (composer, calendar,
+approval, analytics modal, design discovery, …). Without it as a
+required check, a regression in any of those surfaces can ship to
+production without CI catching it. Pre-launch the operator sees
+nothing because there are no clients. Post-launch the first client
+becomes the canary.
+
+### References
+
+- PR #1164 — removed `e2e` from required checks
+- PR #1166 — fixed the `(F-1)` calendar-grid time-bomb (one
+  documented instance of the wider flake class)
+- `docs/recon/DEDUP_OR_PERSIST_AUDIT.md` — adjacent audit;
+  shape #7 (rate-limit atomic increment) and shape #4/#5 (cost-cap
+  + cron `recordHealthEvent` collisions) all interact with the
+  test-determinism problem
+- CLAUDE.md §"Decision policy" principle 3 — extended in PR #1167
+  to forbid `Date.now() + N` style offsets in tests whose
+  assertions depend on landing in a visible range


### PR DESCRIPTION
## Summary

Captures the v1 launch blocker Steven flagged 2026-05-30 (post-#1166): the e2e suite is systemically flaky and was removed from main's required status checks during PR #1164. That tradeoff (let flake not block merges) is acceptable pre-launch but cannot persist into v1 — without e2e gating, regressions in customer-facing surfaces ship silently.

## File added

\`docs/backlog/v1-launch-blockers.md\` — first entry in a new section of the backlog dedicated to launch-gating items.

## Checklist (must all complete before any client gets v1)

- [ ] Diagnose root cause of e2e flakiness (timing / seed drift / auth fixtures / Playwright concurrency / non-deterministic third-party calls)
- [ ] Fix or \`test.fixme()\` every inherently-flaky test, each with a linked open issue (CLAUDE.md §\"Seven-layer test harness\" enforces 7-day SLA)
- [ ] Restore \`e2e\` as a required check in main's branch protection
- [ ] Verify 3 consecutive PRs pass \`e2e\` cleanly before declaring stable

## Wider context

PR #1166 fixed one documented instance (the \`(F-1)\` calendar-grid time-bomb). DEDUP_OR_PERSIST_AUDIT items #4/#5/#7 also produce non-deterministic e2e behaviour under load. CLAUDE.md decision policy principle 3 was extended in PR #1167 to forbid \`Date.now() + N\` offsets in tests where the assertion depends on the result landing in a visible range — that's one row of the broader audit.

## Pointer added

\`docs/backlog/README.md\` updated with the new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)