### PR TITLE
feat(image-gen): slice E3 — sharp image layer renderer

### DIFF
--- a/lib/__tests__/image-layer-renderer-image.unit.test.ts
+++ b/lib/__tests__/image-layer-renderer-image.unit.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for the image-layer renderer functions (E3).
+ *
+ * Tests cover:
+ *   - resolveImageUrl: asset_id fallback, image_url passthrough, null handling
+ *   - buildSharpPosition: all 9 anchor combinations
+ *   - renderImageLayer: fetch failure, no-url null, successful render,
+ *     hide_when_empty, overlay position
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(Buffer.from("")),
+}));
+
+// Use vi.hoisted so sharpChain is defined before the vi.mock() factory is hoisted.
+const { sharpChain } = vi.hoisted(() => {
+  const chain = {
+    resize: vi.fn().mockReturnThis(),
+    png: vi.fn().mockReturnThis(),
+    composite: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from("FAKE_PNG")),
+  };
+  return { sharpChain: chain };
+});
+vi.mock("sharp", () => ({ default: vi.fn().mockReturnValue(sharpChain) }));
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import {
+  resolveImageUrl,
+  buildSharpPosition,
+  renderImageLayer,
+} from "@/lib/image/compositing/layer-renderer";
+import type { ImageLayer } from "@/lib/image/template-model";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeImageLayer(overrides: Partial<ImageLayer> = {}): ImageLayer {
+  return {
+    id: "layer_img_001",
+    name: "image-container",
+    type: "image",
+    x: 0, y: 0, width: 400, height: 300,
+    rotation: 0, rotate_x: 0, rotate_y: 0, rotate_z: 0,
+    skew_x: 0, skew_y: 0,
+    opacity: 1,
+    locked: false, hide: false, hide_when_empty: false,
+    lock_aspect_ratio: false,
+    description: "", group: null,
+    constraints: { horizontal: "left", vertical: "top" },
+    asset_id: null,
+    image_url: "https://example.com/photo.jpg",
+    fill: "cover",
+    anchor_x: "center",
+    anchor_y: "center",
+    tint_color: null,
+    border_radius: 0,
+    clip_path: null,
+    face_detect: false,
+    ...overrides,
+  };
+}
+
+// ─── resolveImageUrl ──────────────────────────────────────────────────────────
+
+describe("resolveImageUrl", () => {
+  it("returns image_url when asset_id is null", async () => {
+    const layer = makeImageLayer({ asset_id: null, image_url: "https://example.com/img.jpg" });
+    const url = await resolveImageUrl(layer);
+    expect(url).toBe("https://example.com/img.jpg");
+  });
+
+  it("returns image_url when asset_id is set (fallback path, logs warning)", async () => {
+    const layer = makeImageLayer({ asset_id: "asset_abc", image_url: "https://example.com/img.jpg" });
+    const url = await resolveImageUrl(layer);
+    expect(url).toBe("https://example.com/img.jpg");
+  });
+
+  it("returns null when both asset_id and image_url are null", async () => {
+    const layer = makeImageLayer({ asset_id: null, image_url: null });
+    const url = await resolveImageUrl(layer);
+    expect(url).toBeNull();
+  });
+});
+
+// ─── buildSharpPosition ───────────────────────────────────────────────────────
+
+describe("buildSharpPosition", () => {
+  it("center/center → 'centre'", () => {
+    expect(buildSharpPosition("center", "center")).toBe("centre");
+  });
+  it("left/top → 'northwest'", () => {
+    expect(buildSharpPosition("left", "top")).toBe("northwest");
+  });
+  it("right/top → 'northeast'", () => {
+    expect(buildSharpPosition("right", "top")).toBe("northeast");
+  });
+  it("left/bottom → 'southwest'", () => {
+    expect(buildSharpPosition("left", "bottom")).toBe("southwest");
+  });
+  it("right/bottom → 'southeast'", () => {
+    expect(buildSharpPosition("right", "bottom")).toBe("southeast");
+  });
+  it("center/top → 'north'", () => {
+    expect(buildSharpPosition("center", "top")).toBe("north");
+  });
+  it("center/bottom → 'south'", () => {
+    expect(buildSharpPosition("center", "bottom")).toBe("south");
+  });
+  it("left/center → 'west'", () => {
+    expect(buildSharpPosition("left", "center")).toBe("west");
+  });
+  it("right/center → 'east'", () => {
+    expect(buildSharpPosition("right", "center")).toBe("east");
+  });
+});
+
+// ─── renderImageLayer ─────────────────────────────────────────────────────────
+
+describe("renderImageLayer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sharpChain.resize.mockReturnThis();
+    sharpChain.png.mockReturnThis();
+    sharpChain.composite.mockReturnThis();
+    sharpChain.toBuffer.mockResolvedValue(Buffer.from("FAKE_PNG"));
+  });
+
+  function mockFetchOk(data = "IMAGE_BYTES") {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: async () => Buffer.from(data).buffer,
+    });
+  }
+
+  it("returns null when image_url is null and hide_when_empty is false", async () => {
+    const layer = makeImageLayer({ asset_id: null, image_url: null });
+    const result = await renderImageLayer(layer);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when image_url is null and hide_when_empty is true", async () => {
+    const layer = makeImageLayer({ asset_id: null, image_url: null, hide_when_empty: true });
+    const result = await renderImageLayer(layer);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fetch fails (4xx)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    const layer = makeImageLayer();
+    const result = await renderImageLayer(layer);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fetch throws (network error)", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("connection refused"));
+    const layer = makeImageLayer();
+    const result = await renderImageLayer(layer);
+    expect(result).toBeNull();
+  });
+
+  it("returns OverlayOptions with correct left/top on success", async () => {
+    mockFetchOk();
+    const layer = makeImageLayer({ x: 100, y: 200 });
+    const result = await renderImageLayer(layer);
+    expect(result).not.toBeNull();
+    expect(result?.left).toBe(100);
+    expect(result?.top).toBe(200);
+    expect(result?.input).toBeInstanceOf(Buffer);
+  });
+
+  it("rounds fractional layer.x / layer.y", async () => {
+    mockFetchOk();
+    const layer = makeImageLayer({ x: 10.7, y: 20.3 });
+    const result = await renderImageLayer(layer);
+    expect(result?.left).toBe(11);
+    expect(result?.top).toBe(20);
+  });
+
+  it("calls sharp resize with correct dimensions and cover mode", async () => {
+    mockFetchOk();
+    const layer = makeImageLayer({ width: 640, height: 480, fill: "cover" });
+    await renderImageLayer(layer);
+    expect(sharpChain.resize).toHaveBeenCalledWith(
+      640, 480,
+      expect.objectContaining({ fit: "cover" }),
+    );
+  });
+
+  it("uses contain fit for fill=fit", async () => {
+    mockFetchOk();
+    const layer = makeImageLayer({ fill: "fit" });
+    await renderImageLayer(layer);
+    expect(sharpChain.resize).toHaveBeenCalledWith(
+      expect.any(Number), expect.any(Number),
+      expect.objectContaining({ fit: "contain" }),
+    );
+  });
+
+  it("composites a mask when border_radius > 0", async () => {
+    mockFetchOk();
+    // Need multiple toBuffer calls for the pipeline
+    sharpChain.toBuffer
+      .mockResolvedValueOnce(Buffer.from("RESIZED"))   // resize
+      .mockResolvedValueOnce(Buffer.from("MASK_PNG"))  // mask SVG raster
+      .mockResolvedValueOnce(Buffer.from("CLIPPED")); // after dest-in
+    const layer = makeImageLayer({ border_radius: 8 });
+    const result = await renderImageLayer(layer);
+    expect(result).not.toBeNull();
+    expect(sharpChain.composite).toHaveBeenCalled();
+  });
+
+  it("composites a tint when tint_color is set", async () => {
+    mockFetchOk();
+    sharpChain.toBuffer
+      .mockResolvedValueOnce(Buffer.from("RESIZED"))
+      .mockResolvedValueOnce(Buffer.from("TINT_PNG"))
+      .mockResolvedValueOnce(Buffer.from("TINTED"));
+    const layer = makeImageLayer({ tint_color: "#FF0000" });
+    const result = await renderImageLayer(layer);
+    expect(result).not.toBeNull();
+    expect(sharpChain.composite).toHaveBeenCalled();
+  });
+
+  it("composites a clip_path mask when clip_path is set", async () => {
+    mockFetchOk();
+    sharpChain.toBuffer
+      .mockResolvedValueOnce(Buffer.from("RESIZED"))
+      .mockResolvedValueOnce(Buffer.from("CLIP_MASK"))
+      .mockResolvedValueOnce(Buffer.from("CLIPPED"));
+    const layer = makeImageLayer({ clip_path: "M0,0 L400,0 L300,300 L0,300 Z" });
+    const result = await renderImageLayer(layer);
+    expect(result).not.toBeNull();
+    expect(sharpChain.composite).toHaveBeenCalled();
+  });
+
+  it("anchor_x/y is passed to sharp resize position", async () => {
+    mockFetchOk();
+    const layer = makeImageLayer({ anchor_x: "left", anchor_y: "top" });
+    await renderImageLayer(layer);
+    expect(sharpChain.resize).toHaveBeenCalledWith(
+      expect.any(Number), expect.any(Number),
+      expect.objectContaining({ position: "northwest" }),
+    );
+  });
+});

--- a/lib/image/compositing/layer-renderer.ts
+++ b/lib/image/compositing/layer-renderer.ts
@@ -15,7 +15,7 @@
  *
  * Slice coverage:
  *   E2 — text layer: text-fit, secondary style parser, glyph-hugging bg
- *   E3 — image layer (added in separate slice)
+ *   E3 — image layer: asset resolver, fill/anchor, tint, border_radius, clip_path
  *   E4 — rectangle layer (added in separate slice)
  *   E5 — transforms: rotation, skew, opacity (added in separate slice)
  */
@@ -31,6 +31,9 @@ import type {
   TextFitOptions,
   TextBackground,
   SecondaryStyle,
+  ImageLayer,
+  ImageAnchorX,
+  ImageAnchorY,
 } from "@/lib/image/template-model";
 
 // ─── Font face declarations (shared with sharp-renderer) ─────────────────────
@@ -543,6 +546,178 @@ export async function renderTextLayer(
 
   return {
     input: png,
+    left: Math.round(layer.x),
+    top: Math.round(layer.y),
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// E3 — IMAGE LAYER (§3.4, §6.7)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ─── Asset resolver (§1.4) ────────────────────────────────────────────────────
+
+/**
+ * Resolve the concrete image URL for an image layer.
+ *
+ * Resolution order: asset_id (looked up at render time) → image_url.
+ * The full asset_id resolver is implemented in D-series once the assets
+ * table exists. For now, asset_id is logged and image_url is used as
+ * the fallback — no templates in V1 use asset_id yet.
+ */
+export async function resolveImageUrl(layer: ImageLayer): Promise<string | null> {
+  if (layer.asset_id) {
+    logger.warn("image.layer-renderer.image.asset_id_not_implemented", {
+      layerId: layer.id,
+      assetId: layer.asset_id,
+      name: layer.name,
+    });
+  }
+  return layer.image_url ?? null;
+}
+
+// ─── Anchor → sharp gravity ───────────────────────────────────────────────────
+
+/**
+ * Map ImageLayer anchor values to the sharp gravity/position string.
+ * Used for both `cover` and `contain` (fit) resize modes.
+ */
+export function buildSharpPosition(anchorX: ImageAnchorX, anchorY: ImageAnchorY): string {
+  const h = anchorX === "left" ? "west" : anchorX === "right" ? "east" : "";
+  const v = anchorY === "top" ? "north" : anchorY === "bottom" ? "south" : "";
+  if (v && h) return `${v}${h}`;   // e.g. "northwest"
+  if (v) return v;                  // "north" / "south"
+  if (h) return h;                  // "west" / "east"
+  return "centre";                  // center/center
+}
+
+// ─── Masking helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Apply a rounded-rectangle mask to clip an image to border_radius corners.
+ * Uses SVG + `dest-in` composite (alpha masking).
+ */
+async function applyBorderRadiusMask(
+  buf: Buffer,
+  w: number,
+  h: number,
+  radius: number,
+): Promise<Buffer> {
+  const maskSvg = Buffer.from(
+    `<svg width="${w}" height="${h}" xmlns="http://www.w3.org/2000/svg">` +
+    `<rect width="${w}" height="${h}" rx="${radius}" ry="${radius}" fill="white"/>` +
+    `</svg>`,
+  );
+  const maskPng = await sharp(maskSvg).png().toBuffer();
+  return sharp(buf).composite([{ input: maskPng, blend: "dest-in" }]).png().toBuffer();
+}
+
+/**
+ * Apply an SVG clip-path mask to the image.
+ * `clipPath` is an SVG path data string (e.g. a diagonal polygon).
+ * Used for split-layout diagonal cuts.
+ */
+async function applyClipPathMask(
+  buf: Buffer,
+  w: number,
+  h: number,
+  clipPath: string,
+): Promise<Buffer> {
+  const maskSvg = Buffer.from(
+    `<svg width="${w}" height="${h}" xmlns="http://www.w3.org/2000/svg">` +
+    `<path d="${escapeXml(clipPath)}" fill="white"/>` +
+    `</svg>`,
+  );
+  const maskPng = await sharp(maskSvg).png().toBuffer();
+  return sharp(buf).composite([{ input: maskPng, blend: "dest-in" }]).png().toBuffer();
+}
+
+/**
+ * Apply a multiply-blend tint overlay to an image.
+ * tintColor is a CSS colour string (e.g. "#FF0000" or "rgba(0,0,255,0.5)").
+ */
+async function applyTint(buf: Buffer, w: number, h: number, tintColor: string): Promise<Buffer> {
+  const tintSvg = Buffer.from(
+    `<svg width="${w}" height="${h}" xmlns="http://www.w3.org/2000/svg">` +
+    `<rect width="${w}" height="${h}" fill="${escapeXml(tintColor)}"/>` +
+    `</svg>`,
+  );
+  const tintPng = await sharp(tintSvg).png().toBuffer();
+  return sharp(buf).composite([{ input: tintPng, blend: "multiply" }]).png().toBuffer();
+}
+
+// ─── Public render function ───────────────────────────────────────────────────
+
+/**
+ * Render an ImageLayer into a sharp.OverlayOptions for compositing.
+ *
+ * Pipeline:
+ *   1. Resolve image URL (asset_id → image_url fallback)
+ *   2. Fetch the image bytes
+ *   3. Resize with fill mode + anchor gravity
+ *   4. Apply clip_path mask (if set)
+ *   5. Apply border_radius mask (if set)
+ *   6. Apply tint overlay (if set)
+ *
+ * Returns null if no image URL is available and hide_when_empty should apply.
+ * E5 adds rotation + skew transforms around this function.
+ */
+export async function renderImageLayer(
+  layer: ImageLayer,
+): Promise<sharp.OverlayOptions | null> {
+  const url = await resolveImageUrl(layer);
+
+  if (!url) {
+    if (layer.hide_when_empty) return null;
+    logger.warn("image.layer-renderer.image.no_url", { layerId: layer.id, name: layer.name });
+    return null;
+  }
+
+  // 1. Fetch image bytes.
+  let imgBuf: Buffer;
+  try {
+    const resp = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+    if (!resp.ok) {
+      logger.warn("image.layer-renderer.image.fetch_failed", {
+        layerId: layer.id, status: resp.status, url,
+      });
+      return null;
+    }
+    imgBuf = Buffer.from(await resp.arrayBuffer());
+  } catch (err) {
+    logger.warn("image.layer-renderer.image.fetch_error", {
+      layerId: layer.id,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  // 2. Resize to layer dimensions with fill mode and anchor.
+  const fit = layer.fill === "fit" ? "contain" : "cover";
+  const position = buildSharpPosition(layer.anchor_x, layer.anchor_y);
+
+  let buf = await sharp(imgBuf)
+    .resize(layer.width, layer.height, { fit, position })
+    .png()
+    .toBuffer();
+
+  // 3. Apply clip_path mask (before border_radius — clip first, round after).
+  if (layer.clip_path) {
+    buf = await applyClipPathMask(buf, layer.width, layer.height, layer.clip_path);
+  }
+
+  // 4. Apply border_radius mask.
+  if (layer.border_radius > 0) {
+    buf = await applyBorderRadiusMask(buf, layer.width, layer.height, layer.border_radius);
+  }
+
+  // 5. Apply tint overlay.
+  if (layer.tint_color) {
+    buf = await applyTint(buf, layer.width, layer.height, layer.tint_color);
+  }
+
+  return {
+    input: buf,
     left: Math.round(layer.x),
     top: Math.round(layer.y),
   };


### PR DESCRIPTION
## Summary

Extends `lib/image/compositing/layer-renderer.ts` with `renderImageLayer()` for the v2 `ImageLayer` type.

- **`resolveImageUrl()`** — `asset_id` → `image_url` fallback. Full resolver deferred to D-series (assets table doesn't exist yet); logs a warning and falls back to `image_url`. API shape matches §1.4 — no migration when full resolver lands.
- **`buildSharpPosition()`** — maps all 9 `anchor_x`/`anchor_y` combinations to sharp gravity strings (`northwest`, `north`, …, `centre`).
- **`renderImageLayer()`** — 5-step pipeline: fetch → resize (fill + anchor) → `clip_path` mask → `border_radius` mask → tint multiply blend. Returns `null` on missing URL or fetch failure; caller respects `hide_when_empty`.
- **Masking helpers** — `applyBorderRadiusMask()` (SVG rounded rect + `dest-in`), `applyClipPathMask()` (SVG path for diagonal cuts), `applyTint()` (solid colour + `multiply` blend). All use PNG round-trip through sharp to avoid librsvg alpha compositing artefacts.

Does NOT touch `sharp-renderer.ts`. E5 adds rotation/skew. E8 wires into `compositeImage()` dispatch.

## Working analog

Masking pattern (`dest-in` SVG composite) matches the existing `buildLogoLayer()` in `sharp-renderer.ts` — same library, same compositing model, extended for rounded corners and diagonal cuts.

## Risks identified and mitigated

- **Tab 1 conflict**: zero — only `layer-renderer.ts` extended; `sharp-renderer.ts` untouched.
- **asset_id not implemented**: resolver stub logs a warning; no silent data loss. Full resolver is the D-series work.
- **multiply blend on PNG with alpha**: sharp's `multiply` blend mode preserves transparency correctly when both operands are RGBA PNG — confirmed by sharp docs.

## Pre-PR checklist

- [x] Lint, typecheck clean
- [x] `test:unit` — 24/24 pass
- [x] PR under 500 net lines (431 insertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)