### PR TITLE
feat(image-gen): slice E4 — sharp rectangle layer renderer

### DIFF
--- a/lib/__tests__/image-layer-renderer-rectangle.unit.test.ts
+++ b/lib/__tests__/image-layer-renderer-rectangle.unit.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for the rectangle-layer renderer functions (E4).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(Buffer.from("")),
+}));
+
+const { sharpChain } = vi.hoisted(() => {
+  const chain = {
+    png: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from("FAKE_PNG")),
+  };
+  return { sharpChain: chain };
+});
+vi.mock("sharp", () => ({ default: vi.fn().mockReturnValue(sharpChain) }));
+
+import { buildRectangleLayerSvg, renderRectangleLayer } from "@/lib/image/compositing/layer-renderer";
+import type { RectangleLayer } from "@/lib/image/template-model";
+
+function makeRectLayer(overrides: Partial<RectangleLayer> = {}): RectangleLayer {
+  return {
+    id: "layer_rect_001",
+    name: "background",
+    type: "rectangle",
+    x: 0, y: 0, width: 300, height: 200,
+    rotation: 0, rotate_x: 0, rotate_y: 0, rotate_z: 0,
+    skew_x: 0, skew_y: 0,
+    opacity: 1,
+    locked: false, hide: false, hide_when_empty: false,
+    lock_aspect_ratio: false,
+    description: "", group: null,
+    constraints: { horizontal: "left", vertical: "top" },
+    color: "#7A1FA2",
+    gradient: null,
+    border_radius: 0,
+    border: null,
+    ...overrides,
+  };
+}
+
+// ─── buildRectangleLayerSvg ───────────────────────────────────────────────────
+
+describe("buildRectangleLayerSvg", () => {
+  it("returns an SVG string", () => {
+    const svg = buildRectangleLayerSvg(makeRectLayer());
+    expect(svg).toMatch(/^<svg /);
+    expect(svg).toMatch(/<\/svg>$/);
+  });
+
+  it("uses layer dimensions for svg width/height", () => {
+    const svg = buildRectangleLayerSvg(makeRectLayer({ width: 640, height: 360 }));
+    expect(svg).toContain('width="640"');
+    expect(svg).toContain('height="360"');
+  });
+
+  it("fills with solid color when no gradient", () => {
+    const svg = buildRectangleLayerSvg(makeRectLayer({ color: "#FF0000" }));
+    expect(svg).toContain('#FF0000');
+    expect(svg).not.toContain("linearGradient");
+    expect(svg).not.toContain("radialGradient");
+  });
+
+  it("uses transparent fill when color is null and no gradient", () => {
+    const svg = buildRectangleLayerSvg(makeRectLayer({ color: null }));
+    expect(svg).toContain('fill="transparent"');
+  });
+
+  it("adds rx/ry when border_radius > 0", () => {
+    const svg = buildRectangleLayerSvg(makeRectLayer({ border_radius: 12 }));
+    expect(svg).toContain('rx="12"');
+    expect(svg).toContain('ry="12"');
+  });
+
+  it("omits rx/ry when border_radius is 0", () => {
+    const svg = buildRectangleLayerSvg(makeRectLayer({ border_radius: 0 }));
+    expect(svg).not.toContain("rx=");
+  });
+
+  it("adds solid border stroke attributes", () => {
+    const svg = buildRectangleLayerSvg(
+      makeRectLayer({ border: { color: "#000000", width: 2, style: "solid" } }),
+    );
+    expect(svg).toContain('stroke="#000000"');
+    expect(svg).toContain('stroke-width="2"');
+    expect(svg).not.toContain("stroke-dasharray");
+  });
+
+  it("adds stroke-dasharray for dashed border", () => {
+    const svg = buildRectangleLayerSvg(
+      makeRectLayer({ border: { color: "#000", width: 2, style: "dashed" } }),
+    );
+    expect(svg).toContain("stroke-dasharray");
+  });
+
+  it("adds stroke-dasharray and stroke-linecap for dotted border", () => {
+    const svg = buildRectangleLayerSvg(
+      makeRectLayer({ border: { color: "#000", width: 2, style: "dotted" } }),
+    );
+    expect(svg).toContain("stroke-dasharray");
+    expect(svg).toContain('stroke-linecap="round"');
+  });
+
+  it("uses linearGradient for a linear gradient fill", () => {
+    const svg = buildRectangleLayerSvg(
+      makeRectLayer({
+        color: null,
+        gradient: {
+          type: "linear",
+          angle: 90,
+          stops: [
+            { color: "#FF0000", position: 0 },
+            { color: "#0000FF", position: 1 },
+          ],
+        },
+      }),
+    );
+    expect(svg).toContain("linearGradient");
+    expect(svg).toContain("url(#g0)");
+    expect(svg).toContain("#FF0000");
+    expect(svg).toContain("#0000FF");
+  });
+
+  it("uses radialGradient for a radial gradient fill", () => {
+    const svg = buildRectangleLayerSvg(
+      makeRectLayer({
+        color: null,
+        gradient: {
+          type: "radial",
+          stops: [
+            { color: "#FFFFFF", position: 0 },
+            { color: "#000000", position: 1 },
+          ],
+        },
+      }),
+    );
+    expect(svg).toContain("radialGradient");
+    expect(svg).toContain("cx=\"50%\"");
+  });
+
+  it("gradient stops have correct offset percentages", () => {
+    const svg = buildRectangleLayerSvg(
+      makeRectLayer({
+        color: null,
+        gradient: {
+          type: "linear",
+          angle: 0,
+          stops: [
+            { color: "#FF0000", position: 0 },
+            { color: "#0000FF", position: 0.5 },
+            { color: "#00FF00", position: 1 },
+          ],
+        },
+      }),
+    );
+    expect(svg).toContain('offset="0.0%"');
+    expect(svg).toContain('offset="50.0%"');
+    expect(svg).toContain('offset="100.0%"');
+  });
+
+  it("escapes XML special characters in color values", () => {
+    // Paranoia test: colors are typically safe, but test the escape path
+    const svg = buildRectangleLayerSvg(makeRectLayer({ color: "#ABCDEF" }));
+    expect(svg).not.toContain("&");  // safe color, no escaping needed
+    expect(svg).toContain("#ABCDEF");
+  });
+});
+
+// ─── renderRectangleLayer ─────────────────────────────────────────────────────
+
+describe("renderRectangleLayer", () => {
+  it("returns OverlayOptions with correct position", async () => {
+    const layer = makeRectLayer({ x: 50, y: 100 });
+    const result = await renderRectangleLayer(layer);
+    expect(result.left).toBe(50);
+    expect(result.top).toBe(100);
+    expect(result.input).toBeInstanceOf(Buffer);
+  });
+
+  it("rounds fractional coordinates", async () => {
+    const layer = makeRectLayer({ x: 10.7, y: 20.3 });
+    const result = await renderRectangleLayer(layer);
+    expect(result.left).toBe(11);
+    expect(result.top).toBe(20);
+  });
+});

--- a/lib/image/compositing/layer-renderer.ts
+++ b/lib/image/compositing/layer-renderer.ts
@@ -34,6 +34,8 @@ import type {
   ImageLayer,
   ImageAnchorX,
   ImageAnchorY,
+  RectangleLayer,
+  Gradient,
 } from "@/lib/image/template-model";
 
 // ─── Font face declarations (shared with sharp-renderer) ─────────────────────
@@ -718,6 +720,101 @@ export async function renderImageLayer(
 
   return {
     input: buf,
+    left: Math.round(layer.x),
+    top: Math.round(layer.y),
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// E4 — RECTANGLE LAYER (§3.5)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ─── Gradient SVG builder ─────────────────────────────────────────────────────
+
+function buildGradientDef(gradient: Gradient, w: number, h: number, id: string): string {
+  const stops = gradient.stops
+    .map((s) => `<stop offset="${(s.position * 100).toFixed(1)}%" stop-color="${escapeXml(s.color)}"/>`)
+    .join("");
+
+  if (gradient.type === "radial") {
+    return `<radialGradient id="${id}" cx="50%" cy="50%" r="50%" gradientUnits="objectBoundingBox">${stops}</radialGradient>`;
+  }
+
+  // Linear gradient: angle 0 = top-to-bottom; rotate around the rect centre.
+  const angle = gradient.angle ?? 0;
+  const rad = (angle * Math.PI) / 180;
+  const cx = w / 2;
+  const cy = h / 2;
+
+  // Compute gradient vector endpoints in SVG userSpaceOnUse coordinates.
+  // A unit vector at `angle` degrees from top:
+  //   angle=0   → top-to-bottom (x1=50%,y1=0,x2=50%,y2=100%)
+  //   angle=90  → left-to-right
+  //   angle=180 → bottom-to-top
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  // Half-diagonal of the bounding box
+  const d = Math.sqrt(cx * cx + cy * cy);
+  const x1 = (cx - sin * d).toFixed(2);
+  const y1 = (cy - cos * d).toFixed(2);
+  const x2 = (cx + sin * d).toFixed(2);
+  const y2 = (cy + cos * d).toFixed(2);
+
+  return (
+    `<linearGradient id="${id}" x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" gradientUnits="userSpaceOnUse">` +
+    stops +
+    `</linearGradient>`
+  );
+}
+
+// ─── Rectangle SVG builder ───────────────────────────────────────────────────
+
+/**
+ * Build the SVG string for a rectangle layer overlay.
+ * Supports solid colour, linear/radial gradient fill, border_radius, and border.
+ */
+export function buildRectangleLayerSvg(layer: RectangleLayer): string {
+  const { width: w, height: h } = layer;
+  const rx = layer.border_radius > 0 ? ` rx="${layer.border_radius}" ry="${layer.border_radius}"` : "";
+
+  let defs = "";
+  let fill: string;
+
+  if (layer.gradient) {
+    const gradId = "g0";
+    defs = `<defs>${buildGradientDef(layer.gradient, w, h, gradId)}</defs>`;
+    fill = `url(#${gradId})`;
+  } else {
+    fill = escapeXml(layer.color ?? "transparent");
+  }
+
+  let strokeAttrs = "";
+  if (layer.border) {
+    const { color, width: sw, style } = layer.border;
+    strokeAttrs = ` stroke="${escapeXml(color)}" stroke-width="${sw}"`;
+    if (style === "dashed") strokeAttrs += ` stroke-dasharray="${sw * 4} ${sw * 2}"`;
+    if (style === "dotted") strokeAttrs += ` stroke-dasharray="${sw} ${sw * 2}" stroke-linecap="round"`;
+  }
+
+  const rect =
+    `<rect x="0" y="0" width="${w}" height="${h}"${rx} fill="${fill}"${strokeAttrs}/>`;
+
+  return `<svg width="${w}" height="${h}" xmlns="http://www.w3.org/2000/svg">${defs}${rect}</svg>`;
+}
+
+// ─── Public render function ───────────────────────────────────────────────────
+
+/**
+ * Render a RectangleLayer into a sharp.OverlayOptions for compositing.
+ * E5 adds rotation + skew. E8 wires into compositeImage() dispatch.
+ */
+export async function renderRectangleLayer(
+  layer: RectangleLayer,
+): Promise<sharp.OverlayOptions> {
+  const svg = buildRectangleLayerSvg(layer);
+  const png = await sharp(Buffer.from(svg)).png().toBuffer();
+  return {
+    input: png,
     left: Math.round(layer.x),
     top: Math.round(layer.y),
   };


### PR DESCRIPTION
## Summary

Extends `layer-renderer.ts` with `renderRectangleLayer()` for the v2 `RectangleLayer` type.

- **`buildRectangleLayerSvg()`** — pure SVG with solid/gradient fill, `border_radius` (`rx`/`ry`), border (`solid`/`dashed`/`dotted` via `stroke-dasharray`).
- **`buildGradientDef()`** — linear (angle-aware, `userSpaceOnUse` coords computed from centre) and radial (`cx`/`cy` 50%, `objectBoundingBox`). Stop `position` (0–1) maps to SVG `offset%`.
- **`renderRectangleLayer()`** — SVG → sharp PNG → `OverlayOptions` at `(x, y)`.

## Working analog

SVG-to-PNG via sharp is the same pattern used by E2 (text) and E4 uses identical `escapeXml` and sharp `toBuffer` chain. `renderRectangleLayer` is structurally the same as `renderTextLayer`.

## Risks identified and mitigated

- **Gradient coordinate math**: linear gradient endpoints computed via `sin/cos` from the rect centre + half-diagonal. This gives correct perpendicular endpoints for any angle. Validated with 0°, 90°, 180° cases.
- **Tab 1 conflict**: zero — only `layer-renderer.ts` extended; `sharp-renderer.ts` untouched.

## Pre-PR checklist

- [x] Lint, typecheck clean
- [x] `test:unit` — 15/15 pass
- [x] PR under 500 net lines (290 insertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)