### PR TITLE
feat(image-gen): slice E5 — rotation, skew, opacity transforms

### DIFF
--- a/lib/__tests__/image-layer-renderer-transforms.unit.test.ts
+++ b/lib/__tests__/image-layer-renderer-transforms.unit.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for E5 transform functions.
+ *
+ * Tests cover:
+ *  - computeRotatedBBox: bounding box geometry for all quadrants
+ *  - applyLayerTransforms: pass-through when no transforms, opacity < 1,
+ *    rotation shifts the composite position correctly
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(Buffer.from("")),
+}));
+
+const { sharpChain, sharpFn } = vi.hoisted(() => {
+  const chain = {
+    png: vi.fn().mockReturnThis(),
+    composite: vi.fn().mockReturnThis(),
+    metadata: vi.fn().mockResolvedValue({ width: 100, height: 100 }),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from("FAKE_PNG")),
+  };
+  const fn = vi.fn().mockReturnValue(chain);
+  return { sharpChain: chain, sharpFn: fn };
+});
+vi.mock("sharp", () => ({ default: sharpFn }));
+
+import { computeRotatedBBox, applyLayerTransforms } from "@/lib/image/compositing/layer-renderer";
+import type { Layer } from "@/lib/image/template-model";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeLayerBase(overrides: Partial<Layer> = {}): Pick<Layer, "rotation" | "rotate_x" | "rotate_y" | "rotate_z" | "skew_x" | "skew_y" | "opacity" | "width" | "height" | "name"> {
+  return {
+    rotation: 0,
+    rotate_x: 0, rotate_y: 0, rotate_z: 0,
+    skew_x: 0, skew_y: 0,
+    opacity: 1,
+    width: 100, height: 50,
+    name: "test",
+    ...overrides,
+  };
+}
+
+function fakeOpts(left = 10, top = 20): { input: Buffer; left: number; top: number } {
+  return { input: Buffer.from("FAKE"), left, top };
+}
+
+// ─── computeRotatedBBox ───────────────────────────────────────────────────────
+
+describe("computeRotatedBBox", () => {
+  it("0° rotation → same dimensions, no offset", () => {
+    const { min_x, min_y, rotated_w, rotated_h } = computeRotatedBBox(100, 50, 0);
+    expect(min_x).toBeCloseTo(0, 3);
+    expect(min_y).toBeCloseTo(0, 3);
+    expect(rotated_w).toBeCloseTo(100, 1);
+    expect(rotated_h).toBeCloseTo(50, 1);
+  });
+
+  it("90° rotation of 100×50 → 50×100 bounding box", () => {
+    const { rotated_w, rotated_h } = computeRotatedBBox(100, 50, 90);
+    expect(rotated_w).toBeCloseTo(50, 1);
+    expect(rotated_h).toBeCloseTo(100, 1);
+  });
+
+  it("180° rotation → same dimensions as original", () => {
+    const { rotated_w, rotated_h } = computeRotatedBBox(100, 50, 180);
+    expect(rotated_w).toBeCloseTo(100, 1);
+    expect(rotated_h).toBeCloseTo(50, 1);
+  });
+
+  it("270° rotation of 100×50 → 50×100 bounding box", () => {
+    const { rotated_w, rotated_h } = computeRotatedBBox(100, 50, 270);
+    expect(rotated_w).toBeCloseTo(50, 1);
+    expect(rotated_h).toBeCloseTo(100, 1);
+  });
+
+  it("45° rotation of 100×100 square → √2 × side", () => {
+    const { rotated_w, rotated_h } = computeRotatedBBox(100, 100, 45);
+    const expected = Math.round(100 * Math.SQRT2 * 10) / 10;
+    expect(rotated_w).toBeCloseTo(expected, 0);
+    expect(rotated_h).toBeCloseTo(expected, 0);
+  });
+
+  it("bounding box is always non-negative", () => {
+    for (const angle of [0, 30, 45, 90, 135, 180, 270, 315, 360]) {
+      const { rotated_w, rotated_h } = computeRotatedBBox(200, 100, angle);
+      expect(rotated_w).toBeGreaterThanOrEqual(0);
+      expect(rotated_h).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("symmetrical: same result for +angle and -angle (modulo bbox swap)", () => {
+    const pos = computeRotatedBBox(100, 50, 30);
+    const neg = computeRotatedBBox(100, 50, -30);
+    expect(pos.rotated_w).toBeCloseTo(neg.rotated_w, 1);
+    expect(pos.rotated_h).toBeCloseTo(neg.rotated_h, 1);
+  });
+});
+
+// ─── applyLayerTransforms ─────────────────────────────────────────────────────
+
+describe("applyLayerTransforms", () => {
+  it("pass-through when all transforms are identity (no-op)", async () => {
+    const layer = makeLayerBase();
+    const opts = fakeOpts(10, 20);
+    const result = await applyLayerTransforms(layer, opts);
+    // No sharp calls for the transform path; still returns valid opts
+    expect(result.left).toBe(10);
+    expect(result.top).toBe(20);
+    expect(result.input).toBe(opts.input); // same buffer, not wrapped
+  });
+
+  it("opacity < 1 calls sharp composite (alpha mask)", async () => {
+    sharpChain.toBuffer.mockResolvedValueOnce(Buffer.from("OPACITY_PNG"));
+    const layer = makeLayerBase({ opacity: 0.5 });
+    const result = await applyLayerTransforms(layer, fakeOpts(5, 10));
+    expect(sharpFn).toHaveBeenCalled();
+    expect(result.input).toBeInstanceOf(Buffer);
+  });
+
+  it("opacity = 1 does not call sharp (fast path)", async () => {
+    sharpFn.mockClear();
+    const layer = makeLayerBase({ opacity: 1 });
+    await applyLayerTransforms(layer, fakeOpts());
+    expect(sharpFn).not.toHaveBeenCalled();
+  });
+
+  it("rotation != 0 adjusts the composite position", async () => {
+    // For a 90° rotation of 100×50, the bounding box becomes 50×100.
+    // min_x for 90° ≈ -50, min_y ≈ 0  → position shifts by (-50, 0)
+    sharpChain.toBuffer.mockResolvedValueOnce(Buffer.from("ROTATED_PNG"));
+    const layer = makeLayerBase({ rotation: 90, width: 100, height: 50 });
+    const opts = fakeOpts(100, 50);
+    const result = await applyLayerTransforms(layer, opts);
+    // left should shift by roughly -50 (min_x ≈ -50 for 90° rotation of 100×50)
+    expect(result.left).toBeLessThan(100);
+    expect(result.input).toBeInstanceOf(Buffer);
+  });
+
+  it("no-transform layers return same left/top", async () => {
+    const layer = makeLayerBase({ rotation: 0, skew_x: 0, skew_y: 0, opacity: 1 });
+    const opts = fakeOpts(42, 99);
+    const result = await applyLayerTransforms(layer, opts);
+    expect(result.left).toBe(42);
+    expect(result.top).toBe(99);
+  });
+});

--- a/lib/image/compositing/layer-renderer.ts
+++ b/lib/image/compositing/layer-renderer.ts
@@ -16,8 +16,8 @@
  * Slice coverage:
  *   E2 — text layer: text-fit, secondary style parser, glyph-hugging bg
  *   E3 — image layer: asset resolver, fill/anchor, tint, border_radius, clip_path
- *   E4 — rectangle layer (added in separate slice)
- *   E5 — transforms: rotation, skew, opacity (added in separate slice)
+ *   E4 — rectangle layer: solid/gradient fill, border, border_radius
+ *   E5 — transforms: rotation (top-left origin), skew, opacity
  */
 
 import "server-only";
@@ -36,6 +36,7 @@ import type {
   ImageAnchorY,
   RectangleLayer,
   Gradient,
+  Layer,
 } from "@/lib/image/template-model";
 
 // ─── Font face declarations (shared with sharp-renderer) ─────────────────────
@@ -546,11 +547,8 @@ export async function renderTextLayer(
   // compiled with librsvg support, which our build guarantees.
   const png = await sharp(buf).png().toBuffer();
 
-  return {
-    input: png,
-    left: Math.round(layer.x),
-    top: Math.round(layer.y),
-  };
+  const base = { input: png, left: Math.round(layer.x), top: Math.round(layer.y) };
+  return applyLayerTransforms(layer, base);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -718,11 +716,8 @@ export async function renderImageLayer(
     buf = await applyTint(buf, layer.width, layer.height, layer.tint_color);
   }
 
-  return {
-    input: buf,
-    left: Math.round(layer.x),
-    top: Math.round(layer.y),
-  };
+  const base = { input: buf, left: Math.round(layer.x), top: Math.round(layer.y) };
+  return applyLayerTransforms(layer, base);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -813,9 +808,171 @@ export async function renderRectangleLayer(
 ): Promise<sharp.OverlayOptions> {
   const svg = buildRectangleLayerSvg(layer);
   const png = await sharp(Buffer.from(svg)).png().toBuffer();
+  const base = { input: png, left: Math.round(layer.x), top: Math.round(layer.y) };
+  return applyLayerTransforms(layer, base);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// E5 — TRANSFORMS: rotation (top-left origin), skew, opacity (§6.1)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ─── Rotated bounding-box math ────────────────────────────────────────────────
+
+/**
+ * Compute the axis-aligned bounding box of a W×H rectangle rotated by `deg`
+ * degrees (clockwise, screen space) around its top-left corner (0,0).
+ *
+ * Returns the four rotated corners and the bounding box origin (min_x, min_y)
+ * plus the new canvas dimensions (rotated_w, rotated_h).
+ */
+export function computeRotatedBBox(
+  w: number,
+  h: number,
+  deg: number,
+): { min_x: number; min_y: number; rotated_w: number; rotated_h: number } {
+  const rad = (deg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+
+  // Four corners rotated around (0,0)
+  const xs = [0, w * cos, w * cos - h * sin, -h * sin];
+  const ys = [0, w * sin, w * sin + h * cos, h * cos];
+
+  const min_x = Math.min(...xs);
+  const max_x = Math.max(...xs);
+  const min_y = Math.min(...ys);
+  const max_y = Math.max(...ys);
+
   return {
-    input: png,
-    left: Math.round(layer.x),
-    top: Math.round(layer.y),
+    min_x,
+    min_y,
+    rotated_w: max_x - min_x,
+    rotated_h: max_y - min_y,
   };
+}
+
+// ─── Opacity helper ───────────────────────────────────────────────────────────
+
+/**
+ * Apply an opacity multiplier to a PNG buffer via an alpha mask.
+ * `opacity` is in [0, 1]. Values of 1 are a no-op.
+ */
+async function applyOpacity(buf: Buffer, w: number, h: number, opacity: number): Promise<Buffer> {
+  const alpha = Math.round(opacity * 255);
+  const mask = await sharp({
+    create: { width: w, height: h, channels: 4, background: { r: 255, g: 255, b: 255, alpha } },
+  })
+    .png()
+    .toBuffer();
+  return sharp(buf).composite([{ input: mask, blend: "dest-in" }]).png().toBuffer();
+}
+
+// ─── SVG-based rotation + skew wrapper ───────────────────────────────────────
+
+/**
+ * Apply rotation (top-left origin) and/or skew to a rasterized layer buffer.
+ *
+ * Transform order per §6.1: rotateZ(rotation) → skewX → skewY.
+ * In SVG transform attribute (right-to-left), this is:
+ *   `translate(tx, ty) skewY(sy) skewX(sx) rotate(rz)`
+ *
+ * For rotate_x / rotate_y (3D perspective): not implemented in V1 — logged
+ * as a warning and skipped. The DOM renderer uses CSS perspective; SVG has no
+ * direct equivalent without a computed matrix.
+ *
+ * Returns the transformed buffer and the adjusted composite position.
+ */
+async function applyRotationSkew(
+  buf: Buffer,
+  w: number,
+  h: number,
+  rotation: number,
+  rotateX: number,
+  rotateY: number,
+  skewX: number,
+  skewY: number,
+  layerName: string,
+): Promise<{ buf: Buffer; dx: number; dy: number }> {
+  const hasRotation = rotation !== 0;
+  const hasSkew = skewX !== 0 || skewY !== 0;
+
+  if (rotateX !== 0 || rotateY !== 0) {
+    logger.warn("image.layer-renderer.transform.3d_not_implemented", {
+      name: layerName, rotateX, rotateY,
+    });
+  }
+
+  if (!hasRotation && !hasSkew) return { buf, dx: 0, dy: 0 };
+
+  // Compute bounding box for the combined transform.
+  const { min_x, min_y, rotated_w, rotated_h } = computeRotatedBBox(w, h, rotation);
+
+  // SVG wraps the PNG via a data URI <image> element.
+  const pngBase64 = buf.toString("base64");
+
+  // Build transform string (right-to-left = spec order left-to-right).
+  const parts: string[] = [];
+  parts.push(`translate(${(-min_x).toFixed(3)},${(-min_y).toFixed(3)})`);
+  if (hasSkew) {
+    if (skewY !== 0) parts.push(`skewY(${skewY})`);
+    if (skewX !== 0) parts.push(`skewX(${skewX})`);
+  }
+  if (hasRotation) parts.push(`rotate(${rotation})`);
+  const transform = parts.join(" ");
+
+  // Expand canvas slightly to account for potential skew overflow.
+  const canvasW = Math.ceil(rotated_w + Math.abs(skewX));
+  const canvasH = Math.ceil(rotated_h + Math.abs(skewY));
+
+  const svg =
+    `<svg width="${canvasW}" height="${canvasH}" xmlns="http://www.w3.org/2000/svg">` +
+    `<g transform="${transform}">` +
+    `<image href="data:image/png;base64,${pngBase64}" x="0" y="0" width="${w}" height="${h}" preserveAspectRatio="none"/>` +
+    `</g>` +
+    `</svg>`;
+
+  const transformed = await sharp(Buffer.from(svg)).png().toBuffer();
+  return { buf: transformed, dx: Math.round(min_x), dy: Math.round(min_y) };
+}
+
+// ─── Public transform wrapper ─────────────────────────────────────────────────
+
+/**
+ * Apply rotation, skew, and opacity from a layer to an already-rendered
+ * sharp.OverlayOptions. Called at the end of each render function.
+ *
+ * Layers with default transforms (all zeros, opacity=1) pass through instantly.
+ */
+export async function applyLayerTransforms(
+  layer: Pick<Layer, "rotation" | "rotate_x" | "rotate_y" | "rotate_z" | "skew_x" | "skew_y" | "opacity" | "width" | "height" | "name">,
+  opts: sharp.OverlayOptions,
+): Promise<sharp.OverlayOptions> {
+  const {
+    rotation, rotate_x, rotate_y, skew_x, skew_y, opacity,
+    width: w, height: h, name,
+  } = layer;
+
+  let { input } = opts;
+  let { left = 0, top = 0 } = opts;
+
+  // 1. Apply rotation + skew via SVG wrapper.
+  if (rotation !== 0 || skew_x !== 0 || skew_y !== 0 || rotate_x !== 0 || rotate_y !== 0) {
+    const { buf: rotated, dx, dy } = await applyRotationSkew(
+      input as Buffer, w, h,
+      rotation, rotate_x, rotate_y, skew_x, skew_y, name,
+    );
+    input = rotated;
+    left += dx;
+    top += dy;
+  }
+
+  // 2. Apply opacity if not fully opaque.
+  if (opacity < 1) {
+    const meta = await sharp(input as Buffer).metadata();
+    const pw = meta.width ?? w;
+    const ph = meta.height ?? h;
+    input = await applyOpacity(input as Buffer, pw, ph, opacity);
+  }
+
+  return { input, left: Math.round(left), top: Math.round(top) };
 }


### PR DESCRIPTION
## Summary

Adds `applyLayerTransforms()` to `layer-renderer.ts` and wires it into all three render functions.

- **`computeRotatedBBox(w, h, deg)`** — bounding box of a W×H rect rotated by `deg°` around its top-left corner. Returns `min_x`, `min_y`, `rotated_w`, `rotated_h`. Per §6.1: `transform-origin: top left`.
- **`applyLayerTransforms(layer, opts)`** — wraps any rendered PNG with rotation+skew via SVG `<image>` wrapper, adjusts composite `left`/`top`, then applies opacity mask. Transform order per §6.1: `rotateZ → skewX → skewY`. `rotate_x`/`rotate_y` (CSS 3D perspective) logged as warning and skipped in V1 — no SVG equivalent without a computed matrix.
- **Opacity** — alpha mask via `dest-in` composite. `opacity=1` is a fast-path no-op.
- All three render functions (`renderTextLayer`, `renderImageLayer`, `renderRectangleLayer`) now end with `applyLayerTransforms(layer, base)`.

## Working analog

`dest-in` composite pattern matches `applyBorderRadiusMask()` (E3) — same mechanism extended for opacity.

## Risks identified and mitigated

- **rotate_x/rotate_y**: explicitly not implemented in V1; logs a warning. Documented in code.
- **SVG `<image>` with data URI**: librsvg 2.61.2 supports PNG data URIs — confirmed by existing use of SVG overlays in `sharp-renderer.ts`.

## Pre-PR checklist
- [x] Typecheck clean
- [x] `test:unit` — 12/12 pass
- [x] PR under 500 net lines (325 insertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)