### PR TITLE
feat(image-gen): slice E8 — compositeImage() layer-based dispatch + backward-compat

### DIFF
--- a/lib/__tests__/image-composite-image-dispatch.unit.test.ts
+++ b/lib/__tests__/image-composite-image-dispatch.unit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for E8 — compositeImage() dispatch + backward-compat.
+ *
+ * Verifies:
+ *  - schema_version=2 input → layer-based renderer path
+ *  - legacy input (no schema_version) → existing sharp-renderer path
+ *  - CompositeResult shape is consistent across both paths
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(Buffer.from("")),
+}));
+vi.mock("sharp", () => ({ default: vi.fn() }));
+
+// Mock the two downstream compositors so we can track which one is called.
+const mockCompositeSharp = vi.fn().mockResolvedValue({
+  storagePath: "legacy/path.jpg",
+  provider: "sharp_native",
+  durationMs: 10,
+});
+vi.mock("@/lib/image/compositing/sharp-renderer", () => ({
+  compositeSharp: mockCompositeSharp,
+}));
+
+const mockCompositeLayerBased = vi.fn().mockResolvedValue({
+  storagePath: "layer/path.png",
+  provider: "sharp_layer_native",
+  durationMs: 20,
+});
+vi.mock("@/lib/image/compositing/layer-composite", () => ({
+  compositeLayerBased: mockCompositeLayerBased,
+}));
+
+import { compositeImage } from "@/lib/image/compositing/index";
+import type { CompositeInput, LayerCompositeInput } from "@/lib/image/compositing/index";
+import { TEMPLATE_SCHEMA_VERSION } from "@/lib/image/template-model";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const LEGACY_INPUT: CompositeInput = {
+  backgroundStoragePath: "company/generated/123-bg.jpg",
+  textZones: [],
+  logo: null,
+  outputFormat: "jpeg",
+  outputWidth: 1280,
+  outputHeight: 720,
+};
+
+const LAYER_TEMPLATE = {
+  width: 400, height: 200,
+  background_color: "#000000",
+  layers: [],
+  render_settings: { format: "png" as const, quality: 100, scale: 1, dpi: 72 },
+};
+
+const LAYER_INPUT: LayerCompositeInput = {
+  schema_version: 2,
+  template: LAYER_TEMPLATE,
+  outputStoragePath: "company/layer-composite/test.png",
+};
+
+// ─── Dispatch ─────────────────────────────────────────────────────────────────
+
+describe("compositeImage dispatch", () => {
+  beforeEach(() => {
+    mockCompositeSharp.mockClear();
+    mockCompositeLayerBased.mockClear();
+  });
+
+  it("routes legacy input (no schema_version) to compositeSharp", async () => {
+    await compositeImage(LEGACY_INPUT);
+    expect(mockCompositeSharp).toHaveBeenCalledTimes(1);
+    expect(mockCompositeLayerBased).not.toHaveBeenCalled();
+  });
+
+  it("routes schema_version=2 input to compositeLayerBased", async () => {
+    await compositeImage(LAYER_INPUT);
+    expect(mockCompositeLayerBased).toHaveBeenCalledTimes(1);
+    expect(mockCompositeSharp).not.toHaveBeenCalled();
+  });
+
+  it("passes the full input to compositeSharp unchanged", async () => {
+    await compositeImage(LEGACY_INPUT);
+    expect(mockCompositeSharp).toHaveBeenCalledWith(LEGACY_INPUT);
+  });
+
+  it("passes the full input to compositeLayerBased unchanged", async () => {
+    await compositeImage(LAYER_INPUT);
+    expect(mockCompositeLayerBased).toHaveBeenCalledWith(LAYER_INPUT);
+  });
+
+  it("returns the CompositeResult from the legacy path", async () => {
+    const result = await compositeImage(LEGACY_INPUT);
+    expect(result.storagePath).toBe("legacy/path.jpg");
+    expect(result.provider).toBe("sharp_native");
+    expect(typeof result.durationMs).toBe("number");
+  });
+
+  it("returns the CompositeResult from the layer-based path", async () => {
+    const result = await compositeImage(LAYER_INPUT);
+    expect(result.storagePath).toBe("layer/path.png");
+    expect(result.provider).toBe("sharp_layer_native");
+    expect(typeof result.durationMs).toBe("number");
+  });
+
+  it("TEMPLATE_SCHEMA_VERSION=2 matches the schema_version discriminator", () => {
+    expect(TEMPLATE_SCHEMA_VERSION).toBe(2);
+    expect(LAYER_INPUT.schema_version).toBe(TEMPLATE_SCHEMA_VERSION);
+  });
+});
+
+// ─── LayerCompositeInput shape ────────────────────────────────────────────────
+
+describe("LayerCompositeInput shape", () => {
+  it("accepts optional modifications", async () => {
+    const input: LayerCompositeInput = {
+      ...LAYER_INPUT,
+      modifications: [{ name: "title", text: "New Text" }],
+    };
+    await compositeImage(input);
+    expect(mockCompositeLayerBased).toHaveBeenCalledWith(input);
+  });
+
+  it("accepts optional variantKey", async () => {
+    const input: LayerCompositeInput = {
+      ...LAYER_INPUT,
+      variantKey: "instagram_square",
+    };
+    await compositeImage(input);
+    expect(mockCompositeLayerBased).toHaveBeenCalledWith(input);
+  });
+
+  it("accepts optional outputFormat override", async () => {
+    const input: LayerCompositeInput = {
+      ...LAYER_INPUT,
+      outputFormat: "jpeg",
+    };
+    await compositeImage(input);
+    expect(mockCompositeLayerBased).toHaveBeenCalledWith(input);
+  });
+});

--- a/lib/image/compositing/index.ts
+++ b/lib/image/compositing/index.ts
@@ -1,4 +1,5 @@
 import type { TextZone } from "./text-zones";
+import type { RenderTemplateInput } from "./layer-renderer";
 
 export type { TextZone };
 export { TEXT_ZONE_MAP } from "./text-zones";
@@ -10,6 +11,7 @@ export interface LogoConfig {
   padding: number;
 }
 
+/** Legacy fixed-zone input (schema_version=1, A-NEW-3 format). */
 export interface CompositeInput {
   backgroundStoragePath: string;
   textZones: (TextZone & { text: string; maxFontSize: number; fontFamily?: string; colour: "white" | "dark" | "overlay" })[];
@@ -17,6 +19,24 @@ export interface CompositeInput {
   outputFormat: "jpeg" | "png";
   outputWidth: number;
   outputHeight: number;
+}
+
+/**
+ * Layer-based input (schema_version=2, v2 editor format).
+ *
+ * Callers provide a fully-resolved Template object (from D3 get_template())
+ * plus optional modifications and variant key.
+ * The output is uploaded to `outputStoragePath` in the generated-images bucket.
+ */
+export interface LayerCompositeInput {
+  schema_version: 2;
+  template: RenderTemplateInput["template"];
+  modifications?: RenderTemplateInput["modifications"];
+  variantKey?: string;
+  /** Destination path in the generated-images bucket (caller-supplied). */
+  outputStoragePath: string;
+  /** Output format; defaults to template.render_settings.format. */
+  outputFormat?: "jpeg" | "png";
 }
 
 export interface CompositeResult {
@@ -29,11 +49,16 @@ export interface CompositeResult {
 // Compositing abstraction — product code ONLY calls this function.
 //
 // A-NEW-4: Bannerbear and Placid are removed. Always uses the sharp renderer.
-// Templates are resolved from the image_templates database table.
+// E8: Dispatches to the layer-based renderer for schema_version=2 templates;
+//     falls back to the fixed-zone renderer for unmigrated (schema_version=1).
 // ---------------------------------------------------------------------------
 export async function compositeImage(
-  input: CompositeInput,
+  input: CompositeInput | LayerCompositeInput,
 ): Promise<CompositeResult> {
+  if ("schema_version" in input && input.schema_version === 2) {
+    const { compositeLayerBased } = await import("./layer-composite");
+    return compositeLayerBased(input);
+  }
   const { compositeSharp } = await import("./sharp-renderer");
-  return compositeSharp(input);
+  return compositeSharp(input as CompositeInput);
 }

--- a/lib/image/compositing/layer-composite.ts
+++ b/lib/image/compositing/layer-composite.ts
@@ -1,0 +1,80 @@
+/**
+ * layer-composite — Supabase Storage upload wrapper for layer-based renders.
+ *
+ * Called by compositeImage() (index.ts) when the input carries schema_version=2.
+ * Delegates rendering to renderTemplate() (layer-renderer.ts) then uploads
+ * the PNG/JPEG output to the generated-images bucket.
+ *
+ * Does NOT touch sharp-renderer.ts (the fixed-zone v1 path).
+ */
+
+import "server-only";
+
+import sharp from "sharp";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { LayerCompositeInput, CompositeResult } from "./index";
+
+const BUCKET = process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
+
+/**
+ * Render a layer-based template and upload the output to Supabase Storage.
+ * Returns a CompositeResult matching the shape returned by compositeSharp().
+ */
+export async function compositeLayerBased(
+  input: LayerCompositeInput,
+): Promise<CompositeResult> {
+  const startMs = Date.now();
+  const { renderTemplate } = await import("./layer-renderer");
+
+  // 1. Render template → PNG buffer.
+  const { png } = await renderTemplate({
+    template: input.template,
+    modifications: input.modifications,
+    variantKey: input.variantKey,
+  });
+
+  // 2. Convert to output format (default: PNG; lossy if jpeg requested).
+  const fmt = input.outputFormat ?? "png";
+  let outputBuf: Buffer;
+  if (fmt === "jpeg") {
+    const quality = input.template.render_settings.quality ?? 90;
+    outputBuf = await sharp(png).jpeg({ quality }).toBuffer();
+  } else {
+    outputBuf = png;
+  }
+
+  const contentType = fmt === "jpeg" ? "image/jpeg" : "image/png";
+
+  // 3. Upload to Storage.
+  const svc = getServiceRoleClient();
+  const { error } = await svc.storage
+    .from(BUCKET)
+    .upload(input.outputStoragePath, outputBuf, {
+      contentType,
+      upsert: true,
+    });
+
+  if (error) {
+    logger.error("image.compositor.layer.upload_failed", {
+      path: input.outputStoragePath,
+      error: error.message,
+    });
+    throw new Error(`Layer compositor: storage upload failed (${error.message})`);
+  }
+
+  const durationMs = Date.now() - startMs;
+  logger.info("image.compositor.layer.completed", {
+    storagePath: input.outputStoragePath,
+    format: fmt,
+    durationMs,
+    layers: input.template.layers.length,
+  });
+
+  return {
+    storagePath: input.outputStoragePath,
+    provider: "sharp_layer_native",
+    durationMs,
+  };
+}


### PR DESCRIPTION
## Summary

Extends `compositeImage()` to dispatch between the new layer-based renderer (E2-E7) and the legacy fixed-zone renderer, based on `schema_version`.

- **`LayerCompositeInput`** — new type in `index.ts`: `{ schema_version: 2, template, modifications?, variantKey?, outputStoragePath, outputFormat? }`.
- **`compositeImage()`** — now accepts `CompositeInput | LayerCompositeInput`. Dispatches on `schema_version in input`: layer-based if `=2`, legacy fixed-zone otherwise. **No existing callers are broken** — `CompositeInput` is unchanged.
- **`layer-composite.ts`** — `compositeLayerBased()`: renders via `renderTemplate()` → optional JPEG conversion → Supabase Storage upload. Returns `CompositeResult` with `provider='sharp_layer_native'`.

Does NOT touch `sharp-renderer.ts`. The fixed-zone path (`compositeSharp()`) is completely unchanged.

## Backward-compat guarantee

Any caller passing a plain `CompositeInput` (without `schema_version`) continues to route to `compositeSharp()` unchanged. This is the "falls back to old fixed-zone for unmigrated templates" requirement. Callers migrate to `LayerCompositeInput` when their template is upgraded to `schema_version=2` (Stream D).

## Working analog

Dispatch pattern matches the existing `compositeImage()` → `compositeSharp()` dynamic import — same deferred import pattern, same return type. `layer-composite.ts` mirrors `sharp-renderer.ts`'s storage upload logic.

## Risks identified and mitigated

- **index.ts modification**: minimal additive change (new type + union parameter). No logic change for existing callers.
- **Tab 1 conflict**: `sharp-renderer.ts` untouched. `layer-composite.ts` is a new file.

## Pre-PR checklist
- [x] Typecheck clean
- [x] `test:unit` — 10/10 pass
- [x] PR under 500 net lines (256 insertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)