### PR TITLE
feat(image-gen): slice D1 — schema_version column on image_templates

### DIFF
--- a/lib/image/templates/index.ts
+++ b/lib/image/templates/index.ts
@@ -38,6 +38,12 @@ export interface ImageTemplate {
   aspectRatio: AspectRatio;
   definition: TemplateDefinition;
   version: number;
+  /**
+   * Added by migration 0166 (D1).
+   * 1 = fixed-zone format (A-NEW-3, routes to compositeSharp).
+   * 2 = layer-based format (v2 editor, routes to compositeLayerBased).
+   */
+  schemaVersion: number;
   isActive: boolean;
   createdAt: string;
   updatedAt: string;
@@ -51,6 +57,7 @@ interface TemplateRow {
   aspect_ratio: string;
   definition: TemplateDefinition;
   version: number;
+  schema_version: number;
   is_active: boolean;
   created_at: string;
   updated_at: string;
@@ -64,6 +71,7 @@ function toTemplate(row: TemplateRow): ImageTemplate {
     aspectRatio: row.aspect_ratio as AspectRatio,
     definition: row.definition,
     version: row.version,
+    schemaVersion: row.schema_version ?? 1,
     isActive: row.is_active,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/supabase/migrations/0166_image_templates_schema_version.sql
+++ b/supabase/migrations/0166_image_templates_schema_version.sql
@@ -1,0 +1,32 @@
+-- 0166: D1 — add schema_version to image_templates (v2 editor programme).
+--
+-- Design spec: docs/briefs/image-generator/v2-editor/MASS_IMAGE_GEN_EDITOR_v2_BUILD_BRIEF.md §D1
+--
+-- Schema version discriminates between the two template definition formats:
+--   1 = fixed-zone format (A-NEW-3 / compositeSharp() path)
+--   2 = layer-based format (v2 editor / compositeLayerBased() path)
+--
+-- ADD COLUMN ... DEFAULT is instant on Postgres 11+ (no table rewrite, no
+-- data scan). All existing rows receive schema_version=1, which correctly
+-- identifies them as the legacy fixed-zone format requiring no migration.
+--
+-- image_template_versions also gains the column so the version-history audit
+-- trail records which schema was in effect at each write.
+
+ALTER TABLE image_templates
+  ADD COLUMN schema_version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE image_template_versions
+  ADD COLUMN schema_version INTEGER NOT NULL DEFAULT 1;
+
+-- Fast path: the E8 compositeImage() dispatcher reads schema_version to route
+-- to compositeLayerBased() vs compositeSharp(). Index speeds that lookup.
+CREATE INDEX IF NOT EXISTS idx_image_templates_schema_version
+  ON image_templates(schema_version)
+  WHERE is_active = true;
+
+COMMENT ON COLUMN image_templates.schema_version IS
+  '1=fixed-zone (A-NEW-3), 2=layer-based (v2 editor). Drives compositeImage() dispatch.';
+
+COMMENT ON COLUMN image_template_versions.schema_version IS
+  'Schema version at the time this history row was written.';


### PR DESCRIPTION
## Summary

Migration 0166 adds `schema_version INTEGER NOT NULL DEFAULT 1` to `image_templates` and `image_template_versions`. This is the discriminator that drives the `compositeImage()` dispatch added in E8.

- **schema_version = 1** — fixed-zone format (A-NEW-3), routes to `compositeSharp()`
- **schema_version = 2** — layer-based format (v2 editor), routes to `compositeLayerBased()`

`ADD COLUMN` with a constant default is instant on Postgres 11+ (no table rewrite, no data scan). All 5 seeded global templates correctly receive `schema_version=1`.

Index `idx_image_templates_schema_version` added on `(schema_version) WHERE is_active = true` for the dispatch read path.

TypeScript: `ImageTemplate.schemaVersion` + `TemplateRow.schema_version` added; `toTemplate()` maps with `?? 1` fallback so reads before migration apply cleanly.

**D3** updates `get_template()` to return the layer-based `Template` shape and convert v1 definitions on read. **D4** updates the `update_image_template()` RPC to accept and store `schema_version=2` definitions.

## Risks identified and mitigated

- **Non-breaking**: `?? 1` fallback in `toTemplate()` means code deployed before this migration applies will still read correctly (column absent → fallback to 1).
- **No data migration needed**: DEFAULT 1 is the correct classification for all existing templates.
- **write path unchanged**: `update_image_template()` RPC doesn't set `schema_version` yet — templates stay at v1 until D4 ships.

## Pre-PR checklist
- [x] Typecheck clean
- [x] All 262 image unit tests pass
- [x] Migration is additive-only (no DROP, no data change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)