### PR TITLE
feat(image-gen): slice D3 — get_template() returns layer-based shape for v2

### DIFF
--- a/lib/__tests__/image-templates-d3.unit.test.ts
+++ b/lib/__tests__/image-templates-d3.unit.test.ts
@@ -1,0 +1,161 @@
+/**
+ * D3 unit tests — get_template() schema_version dispatch + resolvedTemplate.
+ *
+ * Tests the toTemplate() conversion logic:
+ *  - schema_version=1 rows: resolvedTemplate absent, definition typed as TemplateDefinition
+ *  - schema_version=2 rows: resolvedTemplate populated from definition JSONB
+ *  - Missing schema_version column (pre-D1 reads): defaults to 1
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Mock supabase — we're testing the TypeScript mapping, not the DB.
+const { mockMaybeSingle, mockSelect } = vi.hoisted(() => {
+  const maybeSingle = vi.fn();
+  const select = vi.fn().mockReturnValue({
+    eq: vi.fn().mockReturnThis(),
+    or: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle,
+  });
+  return { mockMaybeSingle: maybeSingle, mockSelect: select };
+});
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn().mockReturnValue({
+    from: vi.fn().mockReturnValue({ select: mockSelect }),
+  }),
+}));
+
+import { get_template } from "@/lib/image/templates/index";
+import { TEMPLATE_SCHEMA_VERSION, LEGACY_SCHEMA_VERSION } from "@/lib/image/template-model";
+
+// ─── Row fixtures ─────────────────────────────────────────────────────────────
+
+const V1_ROW = {
+  id: "tmpl_v1",
+  company_id: null,
+  name: "default",
+  aspect_ratio: "16x9",
+  definition: {
+    compositionType: "split_layout",
+    overlayAlpha: 0.75,
+    logoPosition: "bottom-right",
+    logoSizePercent: 18,
+    logoPadding: 20,
+    maxHeadlineFontSize: 120,
+    fontFamily: "Inter",
+  },
+  version: 1,
+  schema_version: 1,
+  is_active: true,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const V2_ROW = {
+  id: "tmpl_v2",
+  company_id: null,
+  name: "podcast",
+  aspect_ratio: "16x9",
+  definition: {
+    // Minimal v2 Template shape
+    id: "tmpl_v2",
+    version: 2,
+    name: "Podcast Thumbnail",
+    width: 1280, height: 720,
+    orientation: "landscape",
+    background_color: "#2B0B5E",
+    layers: [],
+    groups: [],
+    fonts: [],
+    variants: [],
+    render_settings: { format: "png", quality: 100, scale: 1, dpi: 72 },
+    settings: { guides: false },
+  },
+  version: 3,
+  schema_version: 2,
+  is_active: true,
+  created_at: "2026-02-01T00:00:00Z",
+  updated_at: "2026-02-01T00:00:00Z",
+};
+
+const PRE_D1_ROW = {
+  ...V1_ROW,
+  schema_version: undefined, // column doesn't exist yet (pre-migration read)
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("get_template — schema_version dispatch (D3)", () => {
+  it("schema_version=1: schemaVersion matches LEGACY_SCHEMA_VERSION", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: V1_ROW, error: null });
+    const tmpl = await get_template("company_abc", "16x9");
+    expect(tmpl).not.toBeNull();
+    expect(tmpl!.schemaVersion).toBe(LEGACY_SCHEMA_VERSION);
+    expect(tmpl!.schemaVersion).toBe(1);
+  });
+
+  it("schema_version=1: resolvedTemplate is undefined", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: V1_ROW, error: null });
+    const tmpl = await get_template("company_abc", "16x9");
+    expect(tmpl!.resolvedTemplate).toBeUndefined();
+  });
+
+  it("schema_version=1: definition is the legacy TemplateDefinition", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: V1_ROW, error: null });
+    const tmpl = await get_template("company_abc", "16x9");
+    expect((tmpl!.definition as { compositionType: string }).compositionType).toBe("split_layout");
+  });
+
+  it("schema_version=2: schemaVersion matches TEMPLATE_SCHEMA_VERSION", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: V2_ROW, error: null });
+    const tmpl = await get_template("company_abc", "16x9", "podcast");
+    expect(tmpl!.schemaVersion).toBe(TEMPLATE_SCHEMA_VERSION);
+    expect(tmpl!.schemaVersion).toBe(2);
+  });
+
+  it("schema_version=2: resolvedTemplate is populated from definition JSONB", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: V2_ROW, error: null });
+    const tmpl = await get_template("company_abc", "16x9", "podcast");
+    expect(tmpl!.resolvedTemplate).toBeDefined();
+    expect(tmpl!.resolvedTemplate!.width).toBe(1280);
+    expect(tmpl!.resolvedTemplate!.height).toBe(720);
+    expect(tmpl!.resolvedTemplate!.background_color).toBe("#2B0B5E");
+  });
+
+  it("schema_version=2: resolvedTemplate.layers is an array", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: V2_ROW, error: null });
+    const tmpl = await get_template("company_abc", "16x9", "podcast");
+    expect(Array.isArray(tmpl!.resolvedTemplate!.layers)).toBe(true);
+  });
+
+  it("pre-D1 row (schema_version undefined): defaults to 1, no resolvedTemplate", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: PRE_D1_ROW, error: null });
+    const tmpl = await get_template("company_abc", "16x9");
+    expect(tmpl!.schemaVersion).toBe(1);
+    expect(tmpl!.resolvedTemplate).toBeUndefined();
+  });
+
+  it("returns null on DB error", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: { message: "DB error" } });
+    const tmpl = await get_template("company_abc", "16x9");
+    expect(tmpl).toBeNull();
+  });
+
+  it("returns null when no template found", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: null });
+    const tmpl = await get_template("company_abc", "16x9");
+    expect(tmpl).toBeNull();
+  });
+});
+
+describe("schema version constants", () => {
+  it("LEGACY_SCHEMA_VERSION = 1", () => expect(LEGACY_SCHEMA_VERSION).toBe(1));
+  it("TEMPLATE_SCHEMA_VERSION = 2", () => expect(TEMPLATE_SCHEMA_VERSION).toBe(2));
+});

--- a/lib/image/templates/index.ts
+++ b/lib/image/templates/index.ts
@@ -4,6 +4,8 @@ import { getServiceRoleClient } from "@/lib/supabase";
 import { logger } from "@/lib/logger";
 import type { AspectRatio, CompositionType } from "@/lib/image/types";
 import type { LogoConfig } from "@/lib/image/compositing";
+import type { Template } from "@/lib/image/template-model";
+import { TEMPLATE_SCHEMA_VERSION, LEGACY_SCHEMA_VERSION } from "@/lib/image/template-model";
 
 // ---------------------------------------------------------------------------
 // Template access layer — reads image_templates from the database.
@@ -36,6 +38,11 @@ export interface ImageTemplate {
   companyId: string | null;
   name: string;
   aspectRatio: AspectRatio;
+  /**
+   * Legacy fixed-zone definition (schema_version=1).
+   * Present for all templates; for schema_version=2 templates this is the
+   * raw JSONB cast as TemplateDefinition — use `resolvedTemplate` instead.
+   */
   definition: TemplateDefinition;
   version: number;
   /**
@@ -44,6 +51,12 @@ export interface ImageTemplate {
    * 2 = layer-based format (v2 editor, routes to compositeLayerBased).
    */
   schemaVersion: number;
+  /**
+   * Populated only when schemaVersion=2.
+   * The layer-based Template parsed from the definition JSONB.
+   * Use this when routing to compositeLayerBased() / renderTemplate().
+   */
+  resolvedTemplate?: Template;
   isActive: boolean;
   createdAt: string;
   updatedAt: string;
@@ -55,7 +68,7 @@ interface TemplateRow {
   company_id: string | null;
   name: string;
   aspect_ratio: string;
-  definition: TemplateDefinition;
+  definition: unknown; // JSONB: TemplateDefinition for v1, Template for v2
   version: number;
   schema_version: number;
   is_active: boolean;
@@ -64,18 +77,27 @@ interface TemplateRow {
 }
 
 function toTemplate(row: TemplateRow): ImageTemplate {
-  return {
+  const schemaVersion = row.schema_version ?? LEGACY_SCHEMA_VERSION;
+
+  const base: ImageTemplate = {
     id: row.id,
     companyId: row.company_id,
     name: row.name,
     aspectRatio: row.aspect_ratio as AspectRatio,
-    definition: row.definition,
+    definition: row.definition as TemplateDefinition,
     version: row.version,
-    schemaVersion: row.schema_version ?? 1,
+    schemaVersion,
     isActive: row.is_active,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+
+  if (schemaVersion === TEMPLATE_SCHEMA_VERSION) {
+    // schema_version=2: definition JSONB is a full layer-based Template object.
+    base.resolvedTemplate = row.definition as Template;
+  }
+
+  return base;
 }
 
 /**


### PR DESCRIPTION
## Summary

Updates `lib/image/templates/index.ts` so `get_template()` (and all other read functions) correctly handle both `schema_version=1` (fixed-zone) and `schema_version=2` (layer-based) templates.

**Changes to `ImageTemplate`:**
- `definition: TemplateDefinition` — unchanged for callers; correct for v1; for v2 it's the raw JSONB cast (callers should use `resolvedTemplate` instead).
- `resolvedTemplate?: Template` — **new**; populated only when `schemaVersion=2`; the layer-based `Template` parsed directly from the `definition` JSONB.
- `TemplateRow.definition: unknown` — JSONB holds either `TemplateDefinition` or `Template` depending on `schema_version`.

**`toTemplate()` logic:**
- `schemaVersion = row.schema_version ?? LEGACY_SCHEMA_VERSION` (1) — `?? 1` fallback handles pre-D1 reads.
- When `schemaVersion === TEMPLATE_SCHEMA_VERSION` (2): sets `resolvedTemplate = row.definition as Template`.

**Existing callers unaffected**: `ImageTemplate.definition` still typed as `TemplateDefinition`. Code using the fixed-zone path (`compositeSharp()`) continues unchanged.

## Working analog

Same `?? fallback` pattern used in E1's `toTemplate()` for the `schema_version` field added in D1.

## Pre-PR checklist
- [x] Typecheck clean
- [x] `test:unit` — 11/11 pass
- [x] No existing callers broken (definition field unchanged in type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)