### PR TITLE
feat(image-gen): slice U2 — canvas interaction (select, drag, resize, rotate)

### DIFF
--- a/components/image/editor/EditorCanvas.tsx
+++ b/components/image/editor/EditorCanvas.tsx
@@ -3,14 +3,30 @@
 /**
  * EditorCanvas — center pane wrapper for the v2 template editor.
  *
- * Handles scale-to-fit (§4): geometry stored in true canvas px; this
- * wrapper applies CSS transform: scale() so the canvas fits the viewport.
- * The scale is recalculated on container resize via ResizeObserver.
+ * Renders two overlapping layers at true canvas pixel dimensions,
+ * then applies CSS scale-to-fit to the whole container:
+ *
+ *   ┌──────────────────────────────────┐
+ *   │  CanvasContent (DOM renderer)    │  ← §6 visual truth
+ *   │  KonvaInteractionLayer           │  ← §6.3 handles, transparent
+ *   └──────────────────────────────────┘
+ *     ↑ transformed: scale(s) where s = min(cw/W, ch/H)
+ *
+ * Scale recalculated on container resize via ResizeObserver.
+ * Konva stage is dynamically imported (browser Canvas API, no SSR).
  */
 
+import dynamic from "next/dynamic";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { CanvasContent } from "./CanvasContent";
+
 import { useEditor } from "./EditorContext";
+import { CanvasContent } from "./CanvasContent";
+
+// Dynamic import keeps Konva out of the SSR bundle (Canvas API not available server-side).
+const KonvaInteractionLayer = dynamic(
+  () => import("./KonvaInteractionLayer").then((m) => m.KonvaInteractionLayer),
+  { ssr: false },
+);
 
 export function EditorCanvas() {
   const { state, dispatch } = useEditor();
@@ -23,11 +39,8 @@ export function EditorCanvas() {
     const el = containerRef.current;
     if (!el) return;
     const { clientWidth: cw, clientHeight: ch } = el;
-    const padding = 48; // px breathing room on each axis
-    const s = Math.min(
-      (cw - padding) / template.width,
-      (ch - padding) / template.height,
-    );
+    const padding = 48;
+    const s = Math.min((cw - padding) / template.width, (ch - padding) / template.height);
     setScale(Math.max(0.05, Math.min(s, 4)));
   }, [template.width, template.height]);
 
@@ -50,25 +63,32 @@ export function EditorCanvas() {
       style={{ position: "relative" }}
     >
       {/* Scale indicator */}
-      <div className="absolute top-2 right-2 text-xs text-white/40 select-none z-10">
+      <div className="absolute top-2 right-2 text-xs text-white/40 select-none z-10 pointer-events-none">
         {Math.round(scale * 100)}%
       </div>
 
-      {/* Canvas at true pixel size, scaled to fit */}
+      {/* Canvas at true pixel dimensions, scaled to fit viewport */}
       <div
         style={{
           transform: `scale(${scale})`,
           transformOrigin: "center center",
           boxShadow: "0 4px 32px rgba(0,0,0,0.5)",
           flexShrink: 0,
+          position: "relative",
+          width: template.width,
+          height: template.height,
         }}
       >
+        {/* DOM renderer — visual source of truth */}
         <CanvasContent
           template={template}
           selectedLayerId={selectedLayerId}
           onSelectLayer={handleSelect}
           scale={scale}
         />
+
+        {/* react-konva interaction layer — transparent, handles only */}
+        <KonvaInteractionLayer width={template.width} height={template.height} />
       </div>
     </div>
   );

--- a/components/image/editor/KonvaInteractionLayer.tsx
+++ b/components/image/editor/KonvaInteractionLayer.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+/**
+ * KonvaInteractionLayer — react-konva overlay for canvas interaction (U2).
+ *
+ * Rendered on top of CanvasContent (DOM renderer). Provides:
+ *   - Layer selection (click a transparent Rect that mirrors each layer)
+ *   - Drag to move (updates x,y in EditorContext on dragEnd)
+ *   - Transformer: resize handles + rotation handle (updates w/h/rotation on transformEnd)
+ *
+ * The DOM renderer (CanvasContent) remains the source of visual truth;
+ * this layer handles ONLY interaction. All shapes are fill="transparent".
+ *
+ * Design spec §6.3: Selected object shows outline + resize handles + rotate handle.
+ * Fade heavy content during resize: handled via opacity in CanvasContent (U5+).
+ */
+
+import { useEffect, useRef } from "react";
+import { Layer, Rect, Stage, Transformer } from "react-konva";
+import type Konva from "konva";
+
+import { useEditor } from "./EditorContext";
+
+interface KonvaInteractionLayerProps {
+  width: number;
+  height: number;
+}
+
+export function KonvaInteractionLayer({ width, height }: KonvaInteractionLayerProps) {
+  const { state, dispatch } = useEditor();
+  const { template, selectedLayerId } = state;
+
+  const transformerRef = useRef<Konva.Transformer>(null);
+  const shapeRefs = useRef<Map<string, Konva.Rect>>(new Map());
+
+  // Attach / detach Transformer when selection changes.
+  useEffect(() => {
+    const tr = transformerRef.current;
+    if (!tr) return;
+    const node = selectedLayerId ? shapeRefs.current.get(selectedLayerId) : null;
+    tr.nodes(node ? [node] : []);
+    tr.getLayer()?.batchDraw();
+  }, [selectedLayerId]);
+
+  // Sync Konva shape positions when EditorContext changes externally (undo/redo).
+  useEffect(() => {
+    for (const layer of template.layers) {
+      const node = shapeRefs.current.get(layer.id);
+      if (node && !node.isDragging()) {
+        node.x(layer.x);
+        node.y(layer.y);
+        node.width(layer.width);
+        node.height(layer.height);
+        node.rotation(layer.rotation);
+      }
+    }
+  }, [template.layers]);
+
+  return (
+    <Stage
+      width={width}
+      height={height}
+      style={{ position: "absolute", top: 0, left: 0 }}
+      onMouseDown={(e) => {
+        if (e.target === e.target.getStage()) {
+          dispatch({ type: "select", layerId: null });
+        }
+      }}
+    >
+      <Layer>
+        {template.layers.map((layer) => {
+          const locked = layer.locked;
+          return (
+            <Rect
+              key={layer.id}
+              ref={(node) => {
+                if (node) shapeRefs.current.set(layer.id, node);
+                else shapeRefs.current.delete(layer.id);
+              }}
+              x={layer.x}
+              y={layer.y}
+              width={layer.width}
+              height={layer.height}
+              rotation={layer.rotation}
+              draggable={!locked}
+              fill="transparent"
+              listening={!layer.hide}
+              onMouseDown={() => dispatch({ type: "select", layerId: layer.id })}
+              onDragEnd={(e) => {
+                dispatch({
+                  type: "update_layer",
+                  layerId: layer.id,
+                  patch: {
+                    x: Math.round(e.target.x()),
+                    y: Math.round(e.target.y()),
+                  },
+                });
+              }}
+              onTransformEnd={(e) => {
+                const node = e.target as Konva.Rect;
+                const scaleX = node.scaleX();
+                const scaleY = node.scaleY();
+                // Absorb scale into width/height; reset scale to 1.
+                node.scaleX(1);
+                node.scaleY(1);
+                dispatch({
+                  type: "update_layer",
+                  layerId: layer.id,
+                  patch: {
+                    x: Math.round(node.x()),
+                    y: Math.round(node.y()),
+                    width: Math.max(4, Math.round(node.width() * scaleX)),
+                    height: Math.max(4, Math.round(node.height() * scaleY)),
+                    rotation: Math.round(node.rotation() * 100) / 100,
+                  },
+                });
+              }}
+            />
+          );
+        })}
+
+        <Transformer
+          ref={transformerRef}
+          rotateEnabled
+          keepRatio={false}
+          enabledAnchors={[
+            "top-left",
+            "top-center",
+            "top-right",
+            "middle-right",
+            "bottom-right",
+            "bottom-center",
+            "bottom-left",
+            "middle-left",
+          ]}
+          boundBoxFunc={(oldBox, newBox) => {
+            if (Math.abs(newBox.width) < 4 || Math.abs(newBox.height) < 4) return oldBox;
+            return newBox;
+          }}
+          anchorStroke="#3b82f6"
+          anchorFill="#ffffff"
+          anchorSize={8}
+          borderStroke="#3b82f6"
+          borderDash={[]}
+          rotateAnchorOffset={24}
+        />
+      </Layer>
+    </Stage>
+  );
+}


### PR DESCRIPTION
## Summary

Adds `KonvaInteractionLayer` — a react-konva `Stage` overlaid on the DOM renderer (`CanvasContent`). Transparent `Rect` shapes mirror each template layer for hit detection; `Transformer` provides 8 resize anchors + rotation handle per §6.3.

**Interaction model:**
- Click → `select` dispatch
- Drag → `onDragEnd` dispatches `update_layer` with rounded `x,y`
- Transform → `onTransformEnd` absorbs `scaleX/scaleY` into `width/height`, dispatches `update_layer`
- Click canvas background → deselect
- Locked layers: `draggable=false`. Hidden: `listening=false`.

**EditorCanvas**: `CanvasContent` + `KonvaInteractionLayer` are siblings in a `position: relative` container at true canvas px; CSS `scale(s)` applies to both together. Konva is `dynamic` imported (`ssr: false`) — browser Canvas API only.

**Undo/redo**: each `update_layer` pushes an `Op[]` to `state.past`; the `undo` action applies inverses and a `useEffect` syncs Konva shape positions.

## Pre-PR checklist
- [x] Typecheck clean
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)