### PR TITLE
feat(image-gen): slice U3 — snap guides during drag

### DIFF
--- a/components/image/editor/GuideLines.tsx
+++ b/components/image/editor/GuideLines.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * GuideLines — snap guides rendered on the Konva layer during drag (§6.4).
+ *
+ * Shows dashed vertical/horizontal guides when dragging a layer near:
+ *   - Canvas centre, left edge, right edge, top edge, bottom edge
+ *   - Other layer edges (left, center, right, top, middle, bottom)
+ *
+ * Guides auto-hide when the dragged layer is released.
+ * "Disable Guides" in the template settings.guides field turns snapping off.
+ *
+ * Snap threshold: SNAP_PX pixels (5px). Guide lines rendered as Konva Lines.
+ */
+
+import { Line } from "react-konva";
+
+export interface Guide {
+  orientation: "H" | "V";
+  lineGuide: number;
+  snap: "start" | "center" | "end";
+  diff: number;
+}
+
+interface GuideLinesProps {
+  guides: Guide[];
+  width: number;
+  height: number;
+}
+
+export function GuideLines({ guides, width, height }: GuideLinesProps) {
+  return (
+    <>
+      {guides.map((g, i) =>
+        g.orientation === "H" ? (
+          <Line
+            key={i}
+            points={[0, g.lineGuide, width, g.lineGuide]}
+            stroke="#3b82f6"
+            strokeWidth={1}
+            dash={[6, 3]}
+            listening={false}
+          />
+        ) : (
+          <Line
+            key={i}
+            points={[g.lineGuide, 0, g.lineGuide, height]}
+            stroke="#3b82f6"
+            strokeWidth={1}
+            dash={[6, 3]}
+            listening={false}
+          />
+        ),
+      )}
+    </>
+  );
+}
+
+// ─── Snap computation ─────────────────────────────────────────────────────────
+
+const SNAP_PX = 6;
+
+interface LayerBounds {
+  id: string;
+  left: number;
+  centerH: number;
+  right: number;
+  top: number;
+  centerV: number;
+  bottom: number;
+}
+
+function boundsOf(
+  x: number, y: number, w: number, h: number, id: string,
+): LayerBounds {
+  return {
+    id,
+    left: x, centerH: x + w / 2, right: x + w,
+    top: y,  centerV: y + h / 2, bottom: y + h,
+  };
+}
+
+export function computeSnap(
+  dragging: { x: number; y: number; width: number; height: number; id: string },
+  allLayers: Array<{ id: string; x: number; y: number; width: number; height: number }>,
+  canvasW: number,
+  canvasH: number,
+): { x: number; y: number; guides: Guide[] } {
+  const db = boundsOf(dragging.x, dragging.y, dragging.width, dragging.height, dragging.id);
+
+  // Reference lines: canvas edges + centre + other layers.
+  const hRefs: number[] = [0, canvasH / 2, canvasH];
+  const vRefs: number[] = [0, canvasW / 2, canvasW];
+
+  for (const l of allLayers) {
+    if (l.id === dragging.id) continue;
+    const b = boundsOf(l.x, l.y, l.width, l.height, l.id);
+    hRefs.push(b.top, b.centerV, b.bottom);
+    vRefs.push(b.left, b.centerH, b.right);
+  }
+
+  const guides: Guide[] = [];
+  let snapX = dragging.x;
+  let snapY = dragging.y;
+
+  // Vertical snapping (affects x)
+  const dEdgesV = [
+    { snap: "start" as const, val: db.left },
+    { snap: "center" as const, val: db.centerH },
+    { snap: "end" as const, val: db.right },
+  ];
+  let bestV = SNAP_PX + 1;
+  for (const ref of vRefs) {
+    for (const { snap, val } of dEdgesV) {
+      const diff = Math.abs(val - ref);
+      if (diff < SNAP_PX && diff < bestV) {
+        bestV = diff;
+        const dx = ref - val;
+        snapX = dragging.x + dx;
+        guides.splice(guides.findIndex((g) => g.orientation === "V"), 1);
+        guides.push({ orientation: "V", lineGuide: ref, snap, diff });
+      }
+    }
+  }
+
+  // Horizontal snapping (affects y)
+  const dEdgesH = [
+    { snap: "start" as const, val: db.top },
+    { snap: "center" as const, val: db.centerV },
+    { snap: "end" as const, val: db.bottom },
+  ];
+  let bestH = SNAP_PX + 1;
+  for (const ref of hRefs) {
+    for (const { snap, val } of dEdgesH) {
+      const diff = Math.abs(val - ref);
+      if (diff < SNAP_PX && diff < bestH) {
+        bestH = diff;
+        const dy = ref - val;
+        snapY = dragging.y + dy;
+        guides.splice(guides.findIndex((g) => g.orientation === "H"), 1);
+        guides.push({ orientation: "H", lineGuide: ref, snap, diff });
+      }
+    }
+  }
+
+  return { x: Math.round(snapX), y: Math.round(snapY), guides };
+}

--- a/components/image/editor/KonvaInteractionLayer.tsx
+++ b/components/image/editor/KonvaInteractionLayer.tsx
@@ -1,25 +1,23 @@
 "use client";
 
 /**
- * KonvaInteractionLayer — react-konva overlay for canvas interaction (U2).
+ * KonvaInteractionLayer — react-konva overlay for canvas interaction (U2+U3).
  *
  * Rendered on top of CanvasContent (DOM renderer). Provides:
  *   - Layer selection (click a transparent Rect that mirrors each layer)
- *   - Drag to move (updates x,y in EditorContext on dragEnd)
- *   - Transformer: resize handles + rotation handle (updates w/h/rotation on transformEnd)
+ *   - Drag to move with snap guides (§6.4, U3)
+ *   - Transformer: resize handles + rotation handle per §6.3
  *
- * The DOM renderer (CanvasContent) remains the source of visual truth;
- * this layer handles ONLY interaction. All shapes are fill="transparent".
- *
- * Design spec §6.3: Selected object shows outline + resize handles + rotate handle.
- * Fade heavy content during resize: handled via opacity in CanvasContent (U5+).
+ * The DOM renderer (CanvasContent) remains the visual source of truth.
+ * All Rects are fill="transparent" — interaction only.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Layer, Rect, Stage, Transformer } from "react-konva";
 import type Konva from "konva";
 
 import { useEditor } from "./EditorContext";
+import { GuideLines, computeSnap, type Guide } from "./GuideLines";
 
 interface KonvaInteractionLayerProps {
   width: number;
@@ -32,6 +30,7 @@ export function KonvaInteractionLayer({ width, height }: KonvaInteractionLayerPr
 
   const transformerRef = useRef<Konva.Transformer>(null);
   const shapeRefs = useRef<Map<string, Konva.Rect>>(new Map());
+  const [guides, setGuides] = useState<Guide[]>([]);
 
   // Attach / detach Transformer when selection changes.
   useEffect(() => {
@@ -56,6 +55,12 @@ export function KonvaInteractionLayer({ width, height }: KonvaInteractionLayerPr
     }
   }, [template.layers]);
 
+  const guidesEnabled = template.settings?.guides !== false;
+
+  const snapLayers = template.layers.map((l) => ({
+    id: l.id, x: l.x, y: l.y, width: l.width, height: l.height,
+  }));
+
   return (
     <Stage
       width={width}
@@ -68,70 +73,73 @@ export function KonvaInteractionLayer({ width, height }: KonvaInteractionLayerPr
       }}
     >
       <Layer>
-        {template.layers.map((layer) => {
-          const locked = layer.locked;
-          return (
-            <Rect
-              key={layer.id}
-              ref={(node) => {
-                if (node) shapeRefs.current.set(layer.id, node);
-                else shapeRefs.current.delete(layer.id);
-              }}
-              x={layer.x}
-              y={layer.y}
-              width={layer.width}
-              height={layer.height}
-              rotation={layer.rotation}
-              draggable={!locked}
-              fill="transparent"
-              listening={!layer.hide}
-              onMouseDown={() => dispatch({ type: "select", layerId: layer.id })}
-              onDragEnd={(e) => {
-                dispatch({
-                  type: "update_layer",
-                  layerId: layer.id,
-                  patch: {
-                    x: Math.round(e.target.x()),
-                    y: Math.round(e.target.y()),
-                  },
-                });
-              }}
-              onTransformEnd={(e) => {
-                const node = e.target as Konva.Rect;
-                const scaleX = node.scaleX();
-                const scaleY = node.scaleY();
-                // Absorb scale into width/height; reset scale to 1.
-                node.scaleX(1);
-                node.scaleY(1);
-                dispatch({
-                  type: "update_layer",
-                  layerId: layer.id,
-                  patch: {
-                    x: Math.round(node.x()),
-                    y: Math.round(node.y()),
-                    width: Math.max(4, Math.round(node.width() * scaleX)),
-                    height: Math.max(4, Math.round(node.height() * scaleY)),
-                    rotation: Math.round(node.rotation() * 100) / 100,
-                  },
-                });
-              }}
-            />
-          );
-        })}
+        {/* Snap guide lines (§6.4) */}
+        {guidesEnabled && <GuideLines guides={guides} width={width} height={height} />}
+
+        {template.layers.map((layer) => (
+          <Rect
+            key={layer.id}
+            ref={(node) => {
+              if (node) shapeRefs.current.set(layer.id, node);
+              else shapeRefs.current.delete(layer.id);
+            }}
+            x={layer.x}
+            y={layer.y}
+            width={layer.width}
+            height={layer.height}
+            rotation={layer.rotation}
+            draggable={!layer.locked}
+            fill="transparent"
+            listening={!layer.hide}
+            onMouseDown={() => dispatch({ type: "select", layerId: layer.id })}
+            onDragMove={(e) => {
+              if (!guidesEnabled) return;
+              const node = e.target as Konva.Rect;
+              const { x, y, guides: newGuides } = computeSnap(
+                { x: node.x(), y: node.y(), width: layer.width, height: layer.height, id: layer.id },
+                snapLayers, width, height,
+              );
+              node.x(x);
+              node.y(y);
+              setGuides(newGuides);
+            }}
+            onDragEnd={(e) => {
+              setGuides([]);
+              dispatch({
+                type: "update_layer",
+                layerId: layer.id,
+                patch: { x: Math.round(e.target.x()), y: Math.round(e.target.y()) },
+              });
+            }}
+            onTransformEnd={(e) => {
+              const node = e.target as Konva.Rect;
+              const scaleX = node.scaleX();
+              const scaleY = node.scaleY();
+              node.scaleX(1);
+              node.scaleY(1);
+              dispatch({
+                type: "update_layer",
+                layerId: layer.id,
+                patch: {
+                  x: Math.round(node.x()),
+                  y: Math.round(node.y()),
+                  width: Math.max(4, Math.round(node.width() * scaleX)),
+                  height: Math.max(4, Math.round(node.height() * scaleY)),
+                  rotation: Math.round(node.rotation() * 100) / 100,
+                },
+              });
+            }}
+          />
+        ))}
 
         <Transformer
           ref={transformerRef}
           rotateEnabled
           keepRatio={false}
           enabledAnchors={[
-            "top-left",
-            "top-center",
-            "top-right",
-            "middle-right",
-            "bottom-right",
-            "bottom-center",
-            "bottom-left",
-            "middle-left",
+            "top-left", "top-center", "top-right",
+            "middle-right", "bottom-right", "bottom-center",
+            "bottom-left", "middle-left",
           ]}
           boundBoxFunc={(oldBox, newBox) => {
             if (Math.abs(newBox.width) < 4 || Math.abs(newBox.height) < 4) return oldBox;


### PR DESCRIPTION
## Summary

Adds `GuideLines` component and `computeSnap()` algorithm implementing §6.4 (dashed snap guides, snap to canvas centre, edges, other layer edges).

- **`computeSnap()`**: within `SNAP_PX=6px`, snaps to canvas edges (0, W/2, W, 0, H/2, H) and all other layers' `left/center/right/top/middle/bottom`. Returns adjusted `x,y` + `Guide[]` for rendering.
- **`GuideLines`**: dashed `#3b82f6` Konva Lines for each active guide.
- `KonvaInteractionLayer`: calls `computeSnap` in `onDragMove`, snaps node, clears guides on `dragEnd`. Respects `settings.guides === false` to disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)