### PR TITLE
fix(image-gen): extract parseSecondaryRuns to client-safe module (build fix)

### DIFF
--- a/components/image/editor/CanvasContent.tsx
+++ b/components/image/editor/CanvasContent.tsx
@@ -20,7 +20,7 @@ import type {
   Gradient,
 } from "@/lib/image/template-model";
 import { isV1Layer } from "@/lib/image/template-model";
-import { parseSecondaryRuns } from "@/lib/image/compositing/layer-renderer";
+import { parseSecondaryRuns } from "@/lib/image/secondary-style-parser";
 
 // ─── Transform builder (§6.1) ─────────────────────────────────────────────────
 

--- a/lib/image/compositing/layer-renderer.ts
+++ b/lib/image/compositing/layer-renderer.ts
@@ -255,33 +255,13 @@ export function fitFontSize(
 }
 
 // ─── Secondary style parser (§6.6, §1.7) ──────────────────────────────────────
+// Lives in a client-safe module (no server-only) so the DOM renderer
+// (CanvasContent) can import it without pulling server-only into the bundle.
+// Re-exported here for backward compat with existing test imports.
 
-export interface TextRun {
-  text: string;
-  secondary: boolean;
-}
-
-/**
- * Split a text string into normal and secondary runs.
- * Text wrapped in *asterisks* is marked secondary: true.
- * Parser must be identical across all renderers — do not diverge.
- *
- * "Mindset Shifts That *Matter*" →
- *   [{text:"Mindset Shifts That ",secondary:false},{text:"Matter",secondary:true}]
- */
-export function parseSecondaryRuns(text: string): TextRun[] {
-  const runs: TextRun[] = [];
-  // Match: (normal text)(* secondary text *) pairs, plus trailing normal text.
-  const re = /([^*]*)(?:\*([^*]*)\*)?/g;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(text)) !== null) {
-    // Guard against infinite loop at end-of-string
-    if (match[0].length === 0) break;
-    if (match[1]) runs.push({ text: match[1], secondary: false });
-    if (match[2]) runs.push({ text: match[2], secondary: true });
-  }
-  return runs.filter((r) => r.text.length > 0);
-}
+import { parseSecondaryRuns, type TextRun } from "@/lib/image/secondary-style-parser";
+export type { TextRun };
+export { parseSecondaryRuns };
 
 // ─── XML helpers ─────────────────────────────────────────────────────────────
 

--- a/lib/image/secondary-style-parser.ts
+++ b/lib/image/secondary-style-parser.ts
@@ -1,0 +1,35 @@
+/**
+ * parseSecondaryRuns — secondary style parser for the v2 template engine.
+ *
+ * Design spec §6.6, §1.7: text wrapped in *asterisks* renders with the
+ * layer's `secondary` style. This parser must be identical across ALL
+ * renderers (DOM editor canvas and sharp server renderer).
+ *
+ * This file is deliberately free of `server-only` and any server-side
+ * imports so it can be used in client components (CanvasContent.tsx)
+ * as well as the server-side sharp renderer (layer-renderer.ts).
+ */
+
+export interface TextRun {
+  text: string;
+  secondary: boolean;
+}
+
+/**
+ * Split a text string into normal and secondary runs.
+ * Text wrapped in *asterisks* is marked secondary: true.
+ *
+ * "Mindset Shifts That *Matter*" →
+ *   [{text:"Mindset Shifts That ",secondary:false},{text:"Matter",secondary:true}]
+ */
+export function parseSecondaryRuns(text: string): TextRun[] {
+  const runs: TextRun[] = [];
+  const re = /([^*]*)(?:\*([^*]*)\*)?/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    if (match[0].length === 0) break;
+    if (match[1]) runs.push({ text: match[1], secondary: false });
+    if (match[2]) runs.push({ text: match[2], secondary: true });
+  }
+  return runs.filter((r) => r.text.length > 0);
+}


### PR DESCRIPTION
## Problem

Build fails with:

```
You're importing a component that needs server-only.
./lib/image/compositing/layer-renderer.ts
./components/image/editor/CanvasContent.tsx
```

`CanvasContent.tsx` (client component) imported `parseSecondaryRuns` from `layer-renderer.ts`, which has `import "server-only"` at the top. This is the documented server-only barrel leak pattern.

## Fix

Moves `parseSecondaryRuns` + `TextRun` to `lib/image/secondary-style-parser.ts` — no `server-only`, pure string parsing, safe for both client and server contexts.

- **`layer-renderer.ts`**: imports + re-exports from `secondary-style-parser.ts` (backward-compat for existing test imports — no test changes needed)
- **`CanvasContent.tsx`**: imports directly from `secondary-style-parser.ts`

Design spec §6.6/§1.7: *"the parser must be identical in every renderer."* Sharing the module ensures both the DOM renderer (client) and the sharp renderer (server) use exact same logic.

## Verification

- `npm run build` ✓ compiles with no errors
- All 273 image unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)