### PR TITLE
fix(editor): reverse Konva Rect z-order so canvas click selects correct layer

### DIFF
--- a/components/image/editor/KonvaInteractionLayer.tsx
+++ b/components/image/editor/KonvaInteractionLayer.tsx
@@ -76,7 +76,12 @@ export function KonvaInteractionLayer({ width, height }: KonvaInteractionLayerPr
         {/* Snap guide lines (§6.4) */}
         {guidesEnabled && <GuideLines guides={guides} width={width} height={height} />}
 
-        {template.layers.map((layer) => (
+        {/* Render Rects in REVERSE layer order so that the visually-topmost layer
+            (layers[0]) is the LAST Rect drawn, making it the top of the Konva
+            z-order and the first to receive pointer events. Without this reversal
+            the background Rect (layers[N-1], rendered last) sits on top in Konva
+            and intercepts every canvas click, preventing selection of any other layer. */}
+        {[...template.layers].reverse().map((layer) => (
           <Rect
             key={layer.id}
             ref={(node) => {


### PR DESCRIPTION
## Problem (U10 Audit Issue #2 — Blocker)

Every canvas click selects the background layer regardless of where the user clicks. Root cause from audit: `KonvaInteractionLayer` rendered transparent `Rect` elements in `template.layers` order (index 0 = visual top = Konva **bottom** z-order; background = last = Konva **top**). Konva paints later shapes on top, so the background `Rect` intercepted every pointer event.

## Fix

Render the `Rect` elements in `[...template.layers].reverse()` order so the visually-topmost layer (index 0) is drawn last in Konva (= Konva top z-order) and captures clicks before layers beneath it. The `shapeRefs` map and `Transformer` attachment are unaffected — they key by `layer.id`, not render order.

## Verification
- Selecting background via left panel: still works ✓
- Clicking a non-background layer on canvas: now selects correct layer ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)