### PR TITLE
fix(editor): escape NavShell content wrapper with fixed inset-0 on EditorShell

### DIFF
--- a/components/image/editor/EditorShell.tsx
+++ b/components/image/editor/EditorShell.tsx
@@ -27,7 +27,10 @@ interface EditorShellProps {
 export function EditorShell({ template, companyId, templateId }: EditorShellProps) {
   return (
     <EditorProvider template={template}>
-      <div className="h-screen flex flex-col overflow-hidden bg-background">
+      {/* fixed inset-0: escapes the platform NavShell's max-w-7xl / py-8 content
+          wrapper so the editor occupies the full viewport. z-50 keeps it above
+          the NavShell chrome (rail + section panel). */}
+      <div className="fixed inset-0 z-50 flex flex-col overflow-hidden bg-background">
         <EditorHeader companyId={companyId} templateId={templateId} />
 
         <div className="flex-1 flex overflow-hidden">


### PR DESCRIPTION
## Problem (U10 Audit Issue #1 — Major)

`EditorShell` rendered inside NavShellClient's `max-w-7xl mx-auto px-8 py-8` main content area. This caused: (1) `h-screen` overflowing the padded container → editor scrollable, (2) canvas constrained by `max-w-7xl` and px-8 padding → appeared small, (3) on wide viewports the dark canvas container was a wide rectangle with a small square canvas inside.

## Fix

Replace `h-screen` with `fixed inset-0 z-50` on the EditorShell root div. This overlays the full viewport, escaping all NavShell chrome. `z-50` keeps it above the section rail and panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)