### PR TITLE
fix(editor): add variable metadata UI to all layer panels (§3.7)

### DIFF
--- a/components/image/editor/panels/ImageLayerPanel.tsx
+++ b/components/image/editor/panels/ImageLayerPanel.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useEditor } from "../EditorContext";
 import type { ImageLayer } from "@/lib/image/template-model";
+import { VarMetadataPanel } from "./VarMetadataPanel";
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -171,6 +172,8 @@ export function ImageLayerPanel({ layer }: { layer: ImageLayer }) {
           </div>
         </Field>
       </Section>
+
+      <VarMetadataPanel layer={layer} />
     </div>
   );
 }

--- a/components/image/editor/panels/RectangleLayerPanel.tsx
+++ b/components/image/editor/panels/RectangleLayerPanel.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useEditor } from "../EditorContext";
 import type { RectangleLayer, Gradient, GradientStop } from "@/lib/image/template-model";
+import { VarMetadataPanel } from "./VarMetadataPanel";
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -192,6 +193,8 @@ export function RectangleLayerPanel({ layer }: { layer: RectangleLayer }) {
           </button>
         )}
       </Section>
+
+      <VarMetadataPanel layer={layer} />
     </div>
   );
 }

--- a/components/image/editor/panels/TextLayerPanel.tsx
+++ b/components/image/editor/panels/TextLayerPanel.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useEditor } from "../EditorContext";
 import type { TextLayer } from "@/lib/image/template-model";
+import { VarMetadataPanel } from "./VarMetadataPanel";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -339,6 +340,11 @@ export function TextLayerPanel({ layer }: { layer: TextLayer }) {
         />
         <p className="text-xs text-muted-foreground mt-1">Wrap text in *asterisks* for secondary style.</p>
       </Section>
+
+      {/* Variable metadata — §3.7, drives N-Series auto-form */}
+      <div className="px-0">
+        <VarMetadataPanel layer={layer} />
+      </div>
     </div>
   );
 }

--- a/components/image/editor/panels/VarMetadataPanel.tsx
+++ b/components/image/editor/panels/VarMetadataPanel.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+/**
+ * VarMetadataPanel — Variable metadata editor for any layer (§3.7, §9, U11 scope).
+ *
+ * Drives the N-Series auto-form (Stream B): when a layer has `var` metadata,
+ * GET /templates/:id/fields returns it so the social composer can auto-build
+ * typed inputs without per-template code.
+ *
+ * Shared across TextLayerPanel, ImageLayerPanel, and RectangleLayerPanel.
+ * The `var` field is optional on LayerBase — this panel creates it on first
+ * edit and clears it when the label is emptied.
+ */
+
+import { useCallback } from "react";
+import { Input } from "@/components/ui/input";
+import { useEditor } from "../EditorContext";
+import type { Layer, VarMetadata, VarCategory } from "@/lib/image/template-model";
+
+const CATEGORIES: { value: VarCategory; label: string }[] = [
+  { value: "content",  label: "Content"  },
+  { value: "branding", label: "Branding" },
+  { value: "media",    label: "Media"    },
+  { value: "meta",     label: "Meta"     },
+];
+
+interface VarMetadataPanelProps {
+  layer: Layer;
+}
+
+export function VarMetadataPanel({ layer }: VarMetadataPanelProps) {
+  const { dispatch } = useEditor();
+
+  const meta = layer.var;
+
+  const update = useCallback(
+    (patch: Partial<VarMetadata>) => {
+      const current = layer.var ?? {
+        label: "", required: false, default: "", category: "content" as VarCategory, help: "",
+      };
+      const next = { ...current, ...patch };
+      // Clear var entirely if label is empty (makes the field non-modifiable in the API).
+      dispatch({
+        type: "update_layer",
+        layerId: layer.id,
+        patch: { var: next.label.trim() ? next : undefined },
+      });
+    },
+    [layer.id, layer.var, dispatch],
+  );
+
+  const isEnabled = !!meta?.label.trim();
+
+  return (
+    <div className="mb-3">
+      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider pb-1 border-b border-border mb-2">
+        Variable (API field)
+      </div>
+      <p className="text-xs text-muted-foreground mb-2">
+        Set a label to expose this layer as a named field in{" "}
+        <code className="text-xs font-mono">GET /templates/:id/fields</code>.
+        Empty label = not modifiable via the API.
+      </p>
+
+      {/* Label */}
+      <div className="flex items-center gap-2 py-0.5 mb-1">
+        <span className="text-xs text-muted-foreground w-16 shrink-0">Label</span>
+        <Input
+          value={meta?.label ?? ""}
+          placeholder="e.g. Episode Title"
+          className="h-7 text-xs flex-1"
+          onChange={(e) => update({ label: e.target.value })}
+        />
+      </div>
+
+      {isEnabled && (
+        <>
+          {/* Required */}
+          <div className="flex items-center gap-2 py-0.5 mb-1">
+            <span className="text-xs text-muted-foreground w-16 shrink-0">Required</span>
+            <input
+              type="checkbox"
+              checked={meta?.required ?? false}
+              onChange={(e) => update({ required: e.target.checked })}
+              className="cursor-pointer"
+            />
+            <span className="text-xs">Required before generating</span>
+          </div>
+
+          {/* Default */}
+          <div className="flex items-center gap-2 py-0.5 mb-1">
+            <span className="text-xs text-muted-foreground w-16 shrink-0">Default</span>
+            <Input
+              value={meta?.default ?? ""}
+              placeholder="Pre-filled value"
+              className="h-7 text-xs flex-1"
+              onChange={(e) => update({ default: e.target.value })}
+            />
+          </div>
+
+          {/* Category */}
+          <div className="flex items-center gap-2 py-0.5 mb-1">
+            <span className="text-xs text-muted-foreground w-16 shrink-0">Category</span>
+            <select
+              value={meta?.category ?? "content"}
+              className="h-7 text-xs flex-1 border border-input rounded px-2 bg-background"
+              onChange={(e) => update({ category: e.target.value as VarCategory })}
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>{c.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Help */}
+          <div className="flex items-center gap-2 py-0.5">
+            <span className="text-xs text-muted-foreground w-16 shrink-0">Help</span>
+            <Input
+              value={meta?.help ?? ""}
+              placeholder='e.g. "Wrap emphasis in *asterisks*"'
+              className="h-7 text-xs flex-1"
+              onChange={(e) => update({ help: e.target.value })}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem (U10 Audit Issue #11 — Major)

`layer.var` (VarMetadata: label, required, default, category, help) drove the N-Series auto-form (Stream B) but was completely inaccessible from the editor UI. No panel exposed it.

## Fix

New shared `VarMetadataPanel` component, added to `TextLayerPanel`, `ImageLayerPanel`, and `RectangleLayerPanel`. Setting a non-empty label exposes the layer in `GET /templates/:id/fields`. Clearing it removes `var` entirely. Panel is compact (shows only label input when label is empty; expands to show all fields when a label is set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)