### PR TITLE
feat(editor): + Layer menu (text/image/rectangle) + snap guides toggle

### DIFF
--- a/components/image/editor/AddLayerMenu.tsx
+++ b/components/image/editor/AddLayerMenu.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+/**
+ * AddLayerMenu — the "+ Layer" popover for adding new layers to the template.
+ *
+ * Offers Text, Image, and Rectangle layer types. Each creates a sensibly-sized
+ * default layer centred in the canvas, immediately selectable and editable.
+ * Dispatches add_layer at index 0 (inserts at the visual top of the stack).
+ */
+
+import { useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { useEditor } from "./EditorContext";
+import type {
+  TextLayer,
+  ImageLayer,
+  RectangleLayer,
+  Layer,
+} from "@/lib/image/template-model";
+
+// ─── Default layer factories ───────────────────────────────────────────────────
+
+function uid(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}`;
+}
+
+const BASE = {
+  rotation: 0, rotate_x: 0, rotate_y: 0, rotate_z: 0,
+  skew_x: 0, skew_y: 0, opacity: 1,
+  locked: false, hide: false, hide_when_empty: false,
+  lock_aspect_ratio: false, description: "", group: null,
+  constraints: { horizontal: "left" as const, vertical: "top" as const },
+};
+
+function makeTextLayer(canvasW: number, canvasH: number, existingNames: string[]): TextLayer {
+  const name = uniqueName("text", existingNames);
+  const w = Math.round(canvasW * 0.7);
+  const h = Math.round(canvasH * 0.15);
+  return {
+    ...BASE,
+    id: uid("text"),
+    name,
+    type: "text",
+    x: Math.round((canvasW - w) / 2),
+    y: Math.round((canvasH - h) / 2),
+    width: w,
+    height: h,
+    text: "New text layer",
+    font_family: "Inter",
+    font_size: 48,
+    font_weight: 700,
+    color: "#ffffff",
+    text_align_h: "center",
+    text_align_v: "center",
+    letter_spacing: 0,
+    line_height: 1.2,
+    text_transform: "none",
+    text_decoration: "none",
+    word_break: "normal",
+    style: "",
+    direction: "ltr",
+    text_fit: { enabled: false, min_size: 16, max_size: 120, max_lines: 4 },
+    truncate: false,
+    text_box: { padding: null, border: null },
+    background: {
+      color: null, border: null, border_width: null,
+      padding_h: 0, padding_v: 0, shadow: null, radius: null, shift: null,
+    },
+    secondary: { font_family: null, color: null },
+  };
+}
+
+function makeImageLayer(canvasW: number, canvasH: number, existingNames: string[]): ImageLayer {
+  const name = uniqueName("image", existingNames);
+  const size = Math.round(Math.min(canvasW, canvasH) * 0.5);
+  return {
+    ...BASE,
+    id: uid("image"),
+    name,
+    type: "image",
+    x: Math.round((canvasW - size) / 2),
+    y: Math.round((canvasH - size) / 2),
+    width: size,
+    height: size,
+    asset_id: null,
+    image_url: null,
+    fill: "cover",
+    anchor_x: "center",
+    anchor_y: "center",
+    tint_color: null,
+    border_radius: 0,
+    clip_path: null,
+    face_detect: false,
+    hide_when_empty: true,
+  };
+}
+
+function makeRectLayer(canvasW: number, canvasH: number, existingNames: string[]): RectangleLayer {
+  const name = uniqueName("rectangle", existingNames);
+  const w = Math.round(canvasW * 0.4);
+  const h = Math.round(canvasH * 0.25);
+  return {
+    ...BASE,
+    id: uid("rect"),
+    name,
+    type: "rectangle",
+    x: Math.round((canvasW - w) / 2),
+    y: Math.round((canvasH - h) / 2),
+    width: w,
+    height: h,
+    color: "#7c3aed",
+    gradient: null,
+    border_radius: 8,
+    border: null,
+  };
+}
+
+/** Generate a slug-safe unique name not already in the template. */
+function uniqueName(prefix: string, existing: string[]): string {
+  for (let i = 1; i <= 99; i++) {
+    const candidate = `${prefix}_${String(i).padStart(2, "0")}`;
+    if (!existing.includes(candidate)) return candidate;
+  }
+  return `${prefix}_${Date.now().toString(36)}`;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function AddLayerMenu() {
+  const { state, dispatch } = useEditor();
+  const [open, setOpen] = useState(false);
+
+  const { width, height, layers } = state.template;
+  const existingNames = layers.map((l) => l.name);
+
+  function addLayer(layer: Layer) {
+    setOpen(false);
+    dispatch({ type: "add_layer", layer, index: 0 }); // insert at top of visual stack
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="sm" className="h-6 text-xs px-2">
+          + Layer
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-44 p-1" align="end" sideOffset={4}>
+        <button
+          className="w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors rounded"
+          onClick={() => addLayer(makeTextLayer(width, height, existingNames))}
+        >
+          T  Text
+        </button>
+        <button
+          className="w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors rounded"
+          onClick={() => addLayer(makeImageLayer(width, height, existingNames))}
+        >
+          ⬜  Image
+        </button>
+        <button
+          className="w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors rounded"
+          onClick={() => addLayer(makeRectLayer(width, height, existingNames))}
+        >
+          ▭  Rectangle
+        </button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/image/editor/EditorContext.tsx
+++ b/components/image/editor/EditorContext.tsx
@@ -52,7 +52,9 @@ export type EditorAction =
   | { type: "undo" }
   | { type: "redo" }
   | { type: "set_saving"; isSaving: boolean }
-  | { type: "mark_clean" };
+  | { type: "mark_clean" }
+  /** Toggle template.settings.guides (snap guides on/off). */
+  | { type: "toggle_guides" };
 
 // ─── Reducer ──────────────────────────────────────────────────────────────────
 
@@ -204,6 +206,18 @@ function editorReducer(state: EditorState, action: EditorAction): EditorState {
 
     case "mark_clean":
       return { ...state, isDirty: false, past: [], future: [] };
+
+    case "toggle_guides": {
+      const current = state.template.settings?.guides !== false;
+      return {
+        ...state,
+        template: {
+          ...state.template,
+          settings: { ...state.template.settings, guides: !current },
+        },
+        isDirty: true,
+      };
+    }
 
     default:
       return state;

--- a/components/image/editor/EditorLeftPanel.tsx
+++ b/components/image/editor/EditorLeftPanel.tsx
@@ -1,18 +1,19 @@
 "use client";
 
 /**
- * EditorLeftPanel — left panel of the v2 template editor (U4).
+ * EditorLeftPanel — left panel of the v2 template editor (U4 + Tier 2 UAT).
  *
  * Layer list: top-first (index 0 = visual top). Drag-to-reorder via HTML5
  * drag-and-drop (dispatches reorder_layers on drop). Each row: LayerRow
  * with type icon, editable name, lock/hide indicators, context menu.
- * New Layer (+) button at the bottom (opens AddLayerMenu from U14 — placeholder for now).
+ * AddLayerMenu: + Layer button opens type picker (text/image/rectangle).
+ * Guides toggle: snaps on/off, persists in template.settings.guides.
  */
 
 import { useRef, useState } from "react";
-import { Button } from "@/components/ui/button";
 import { useEditor } from "./EditorContext";
 import { LayerRow } from "./LayerRow";
+import { AddLayerMenu } from "./AddLayerMenu";
 
 export function EditorLeftPanel() {
   const { state, dispatch } = useEditor();
@@ -20,6 +21,8 @@ export function EditorLeftPanel() {
 
   const dragFromIndex = useRef<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+  const guidesEnabled = template.settings?.guides !== false;
 
   return (
     <aside className="w-[280px] border-r border-border flex flex-col overflow-hidden bg-background shrink-0">
@@ -75,15 +78,25 @@ export function EditorLeftPanel() {
         )}
       </div>
 
-      {/* Footer: layer count + new layer button */}
-      <div className="px-3 py-2 border-t border-border flex items-center justify-between">
-        <span className="text-xs text-muted-foreground">
-          {template.layers.length} layer{template.layers.length !== 1 ? "s" : ""}
-        </span>
-        {/* New Layer menu — wired in U14 */}
-        <Button variant="ghost" size="sm" className="h-6 text-xs px-2" title="Add layer (U14)">
-          + Layer
-        </Button>
+      {/* Footer: guides toggle + layer count + add-layer menu */}
+      <div className="px-3 py-2 border-t border-border space-y-1">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            {template.layers.length} layer{template.layers.length !== 1 ? "s" : ""}
+          </span>
+          <AddLayerMenu />
+        </div>
+        <button
+          className={[
+            "flex items-center gap-1.5 text-xs w-full transition-colors",
+            guidesEnabled ? "text-muted-foreground hover:text-foreground" : "text-muted-foreground/50 hover:text-muted-foreground",
+          ].join(" ")}
+          onClick={() => dispatch({ type: "toggle_guides" })}
+          title={guidesEnabled ? "Snap guides on — click to disable" : "Snap guides off — click to enable"}
+        >
+          <span>{guidesEnabled ? "⊞" : "⊡"}</span>
+          <span>Snap guides {guidesEnabled ? "on" : "off"}</span>
+        </button>
       </div>
     </aside>
   );

--- a/docs/briefs/image-generator/v2-editor/U10_AUDIT.md
+++ b/docs/briefs/image-generator/v2-editor/U10_AUDIT.md
@@ -349,3 +349,73 @@ After fixing Item 1 (live drag via `update_layer_live`), undo must still work: `
 - `components/image/editor/EditorContext.tsx` — add `update_layer_live` action (no undo push)
 - `components/image/editor/KonvaInteractionLayer.tsx` — dispatch `update_layer_live` from `onDragMove` and new `onTransform`; guard sync useEffect from fighting live Transformer
 
+
+---
+
+## Tier 2 UAT Investigation — 2026-05-31
+
+### Item 1: Per-layer actions (⋯ menu)
+
+**Code traced:** All five actions in `LayerRow.tsx` dispatch to `EditorContext` and are correctly wired:
+
+| Action | Dispatch | Persists |
+|--------|---------|---------|
+| Lock/Unlock | `update_layer({ locked: !layer.locked })` | ✓ via save |
+| Hide/Show | `update_layer({ hide: !layer.hide })` | ✓ |
+| Rename | `update_layer({ name: newName })` with slug validation | ✓ |
+| Duplicate | `add_layer(copy, index)` — inserts above original in top-first order | ✓ |
+| Delete | `remove_layer(layerId)` | ✓ |
+
+**Verdict: All actions work correctly. No fix needed.**
+
+Note: locked layers show `draggable={false}` on Konva Rects; the visual lock icon (🔒) appears in the layer row. CanvasContent does not reduce opacity for locked layers (cosmetic gap, Tier 3).
+
+---
+
+### Item 2: + Layer button
+
+**Root cause:** `EditorLeftPanel.tsx` line 85: the `+ Layer` `<Button>` has NO `onClick` handler — it's a complete placeholder from U1. Clicking it does nothing.
+
+**Fix:** Implement `AddLayerMenu` component — a Radix Popover with three options (Text, Image, Rectangle). Each creates a default Layer object and dispatches `add_layer` at index 0 (top of stack). Layer IDs use `${type}_${Date.now().toString(36)}`.
+
+---
+
+### Item 3: Snap/alignment guides
+
+**Root cause A (bug): `guides.splice(findIndex(-1), 1)`.** In `GuideLines.ts` `computeSnap()`:
+
+```typescript
+guides.splice(guides.findIndex((g) => g.orientation === "V"), 1);
+```
+
+When no V-orientation guide exists yet, `findIndex` returns -1. `Array.splice(-1, 1)` removes the LAST element — potentially destroying an already-added H-orientation guide. This causes guides to disappear unpredictably when both axes snap near-simultaneously.
+
+**Fix:** Guard with `!== -1` before splicing.
+
+**Root cause B (missing UI): No guides toggle.** `KonvaInteractionLayer` reads `template.settings?.guides !== false` to enable snap, but `EditorLeftPanel` has no control to set `template.settings.guides`. The user can't disable guides from the editor.
+
+**Fix:** Add a guides toggle button to the `EditorLeftPanel` footer (dispatch `update_template_settings`... actually use a simpler approach: add a `toggle_guides` action or dispatch `update_layer` equivalent for settings).
+
+Actually the cleanest fix: add `update_settings` action to EditorContext that patches `template.settings`, and wire a toggle button in `EditorLeftPanel`.
+
+---
+
+### Item 4: Text Fit
+
+**Root cause:** `CanvasContent.TextLayerEl` uses `layer.font_size` unconditionally (line 148). There is no text-fit computation in the DOM renderer. The `fitFontSize` binary-search algorithm lives only in `lib/image/compositing/layer-renderer.ts` (has `import "server-only"`) and runs at sharp-render time. The editor shows a static font size regardless of `text_fit.enabled`.
+
+**Fix:** Extract `fitFontSize`, `wrapLayerText`, `measureTextWidth`, and `CHAR_RATIO` from `layer-renderer.ts` into a client-safe module (like `lib/image/secondary-style-parser.ts` was extracted). Then in `TextLayerEl`, when `layer.text_fit.enabled`, call the extracted `fitFontSize` to compute the display font size.
+
+This ensures the editor preview matches the server-rendered image for text-fit layers.
+
+---
+
+### Tier 2 Fix Plan
+
+| Fix | Severity | Files |
+|-----|----------|-------|
+| Add `+ Layer` menu (AddLayerMenu component) | Major | `EditorLeftPanel.tsx`, new `AddLayerMenu.tsx` |
+| Fix `splice(-1)` bug in `computeSnap` | Major | `GuideLines.tsx` |
+| Add guides toggle to EditorLeftPanel | Minor | `EditorLeftPanel.tsx`, `EditorContext.tsx` |
+| Text-fit in DOM renderer | Major | New `lib/image/text-fit-utils.ts`, `CanvasContent.tsx` |
+


### PR DESCRIPTION
## Tier 2 UAT — Items 2 & 3

### + Layer (item 2)

The `+ Layer` button had no `onClick` — complete placeholder from U1. 

**`AddLayerMenu`**: Radix Popover with three type options. Each creates a sensible default layer centred in the canvas (position/size relative to template dimensions), inserts at index 0 (top of visual stack), and generates a unique slug-safe name (`text_01`, `image_01`, etc.).

### Snap guides toggle (item 3 — partial)

No UI existed to disable snap guides. New `toggle_guides` action flips `template.settings.guides`. `EditorLeftPanel` footer now shows a **"Snap guides on/off"** toggle that persists via the normal save chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)