### PR TITLE
fix(editor): snap guides lose each other when both axes snap simultaneously

### DIFF
--- a/components/image/editor/GuideLines.tsx
+++ b/components/image/editor/GuideLines.tsx
@@ -117,7 +117,10 @@ export function computeSnap(
         bestV = diff;
         const dx = ref - val;
         snapX = dragging.x + dx;
-        guides.splice(guides.findIndex((g) => g.orientation === "V"), 1);
+        // Guard: findIndex returns -1 when no V guide exists yet. splice(-1,1)
+        // would incorrectly remove the last element (possibly an H guide).
+        const vIdx = guides.findIndex((g) => g.orientation === "V");
+        if (vIdx !== -1) guides.splice(vIdx, 1);
         guides.push({ orientation: "V", lineGuide: ref, snap, diff });
       }
     }
@@ -137,7 +140,8 @@ export function computeSnap(
         bestH = diff;
         const dy = ref - val;
         snapY = dragging.y + dy;
-        guides.splice(guides.findIndex((g) => g.orientation === "H"), 1);
+        const hIdx = guides.findIndex((g) => g.orientation === "H");
+        if (hIdx !== -1) guides.splice(hIdx, 1);
         guides.push({ orientation: "H", lineGuide: ref, snap, diff });
       }
     }


### PR DESCRIPTION
## Root cause (Tier 2 UAT item 3)

`computeSnap()` called `guides.splice(guides.findIndex(...), 1)` to replace the best guide for each axis. When `findIndex` returns -1 (no guide for that axis yet), `splice(-1, 1)` removes the **last element** — destroying the other axis's guide if one already existed.

**Scenario**: V snap fires first, pushes a V guide. H snap fires next; no H guide yet → `findIndex('H')` = -1 → `splice(-1, 1)` removes the V guide → only H guide shows.

**Fix**: Guard each `splice` with `!== -1`. Both H and V guides now survive independently when both axes snap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)