### PR TITLE
feat(editor): tier 3 polish — icons, layout, scrollbars, font preview

### DIFF
--- a/components/image/editor/EditorLeftPanel.tsx
+++ b/components/image/editor/EditorLeftPanel.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useRef, useState } from "react";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useEditor } from "./EditorContext";
 import { LayerRow } from "./LayerRow";
 import { AddLayerMenu } from "./AddLayerMenu";
@@ -38,8 +39,8 @@ export function EditorLeftPanel() {
       </div>
 
       {/* Layer list (top-first, drag-to-reorder) */}
-      <div
-        className="flex-1 overflow-y-auto"
+      <ScrollArea
+        className="flex-1"
         onDragOver={(e) => { e.preventDefault(); }}
         onDrop={(e) => {
           e.preventDefault();
@@ -56,7 +57,7 @@ export function EditorLeftPanel() {
           <div
             key={layer.id}
             onDragOver={(e) => { e.preventDefault(); setDragOverIndex(idx); }}
-            className={dragOverIndex === idx ? "bg-blue-500/10 border-t-2 border-blue-500" : ""}
+            className={dragOverIndex === idx ? "bg-accent/10 border-t-2 border-accent" : ""}
           >
             <LayerRow
               layer={layer}
@@ -76,7 +77,7 @@ export function EditorLeftPanel() {
             No layers yet.<br />Click + to add one.
           </p>
         )}
-      </div>
+      </ScrollArea>
 
       {/* Footer: guides toggle + layer count + add-layer menu */}
       <div className="px-3 py-2 border-t border-border space-y-1">

--- a/components/image/editor/EditorRightPanel.tsx
+++ b/components/image/editor/EditorRightPanel.tsx
@@ -11,6 +11,7 @@
  * U8, U9, U10 panels are stubs — wired fully in their respective slices.
  */
 
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useEditor } from "./EditorContext";
 import { TextLayerPanel } from "./panels/TextLayerPanel";
 import { ImageLayerPanel } from "./panels/ImageLayerPanel";
@@ -31,8 +32,8 @@ export function EditorRightPanel() {
             <span className="capitalize text-muted-foreground">{selectedLayer.type}</span>
           </div>
 
-          {/* Scrollable properties */}
-          <div className="flex-1 overflow-y-auto">
+          {/* Scrollable properties — ScrollArea gives a styled thin scrollbar */}
+          <ScrollArea className="flex-1">
             {/* Geometry block — shown for all layer types (U10) */}
             <GeometryPanel layer={selectedLayer} />
 
@@ -50,7 +51,7 @@ export function EditorRightPanel() {
                 Reserved layer type — not editable in V1
               </div>
             )}
-          </div>
+          </ScrollArea>
         </>
       ) : (
         <div className="flex-1 flex items-center justify-center">

--- a/components/image/editor/LayerRow.tsx
+++ b/components/image/editor/LayerRow.tsx
@@ -1,18 +1,28 @@
 "use client";
 
 /**
- * LayerRow — single row in the layers list panel (U4).
+ * LayerRow — single row in the layers list panel (U4, Tier 3 polish).
  *
- * Features: type icon, editable name (double-click), lock/hide indicators,
- * drag handle for reorder, ⋯ context menu (Radix Popover) with:
- *   Toggle Lock · Toggle Hide · Rename · Duplicate · Delete
+ * Tier 3 changes:
+ *  - Lucide icons for type (Type/Image/Square), drag handle (GripVertical),
+ *    ⋯ menu (MoreVertical), visibility (Eye/EyeOff), lock (Lock/Unlock)
+ *  - Eye + Lock are now ONE-CLICK buttons directly in the row (Figma-style),
+ *    always visible when non-default state, visible on hover otherwise.
+ *    They remain in the ⋯ menu too for discoverability.
+ *  - Selected row uses bg-accent/15 + left border for a clear highlight.
+ *  - Layer name has a 4px gap from the type icon (was flush).
  *
  * Naming validation per §1.10: unique, slug-safe (a-z0-9_), warns on rename.
  */
 
 import { useCallback, useRef, useState } from "react";
+import {
+  GripVertical, Type, Image, Square,
+  Eye, EyeOff, Lock, Unlock, MoreVertical,
+} from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useEditor } from "./EditorContext";
 import type { Layer } from "@/lib/image/template-model";
 
@@ -35,10 +45,10 @@ export function LayerRow({ layer, index, isSelected, dragHandleProps }: LayerRow
   const [menuOpen, setMenuOpen] = useState(false);
   const nameRef = useRef<HTMLInputElement>(null);
 
-  const typeIcon =
-    layer.type === "text" ? "T"
-    : layer.type === "image" ? "⬜"
-    : "▭";
+  const TypeIcon =
+    layer.type === "text" ? Type
+    : layer.type === "image" ? Image
+    : Square;
 
   const commitName = useCallback(() => {
     setEditingName(false);
@@ -81,87 +91,128 @@ export function LayerRow({ layer, index, isSelected, dragHandleProps }: LayerRow
     </button>
   );
 
+  const toggleHide = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    dispatch({ type: "update_layer", layerId: layer.id, patch: { hide: !layer.hide } });
+  };
+  const toggleLock = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    dispatch({ type: "update_layer", layerId: layer.id, patch: { locked: !layer.locked } });
+  };
+
   return (
-    <div
-      className={[
-        "flex items-center gap-1 px-2 py-1.5 group cursor-pointer select-none",
-        isSelected ? "bg-muted" : "hover:bg-muted/50",
-        layer.locked ? "opacity-60" : "",
-      ].join(" ")}
-      onClick={() => dispatch({ type: "select", layerId: isSelected ? null : layer.id })}
-    >
-      {/* Drag handle */}
-      <span
-        className="text-muted-foreground cursor-grab active:cursor-grabbing shrink-0 opacity-0 group-hover:opacity-100 text-sm"
-        {...dragHandleProps}
-        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+    <TooltipProvider delayDuration={400}>
+      <div
+        className={[
+          // Selected: accent background + left border for a Figma-style clear indicator.
+          "relative flex items-center gap-1.5 px-2 py-1.5 group cursor-pointer select-none transition-colors",
+          isSelected
+            ? "bg-accent/15 border-l-2 border-primary pl-[6px]"
+            : "hover:bg-muted/50 border-l-2 border-transparent pl-[6px]",
+        ].join(" ")}
+        onClick={() => dispatch({ type: "select", layerId: isSelected ? null : layer.id })}
       >
-        ⠿
-      </span>
-
-      {/* Type icon */}
-      <span className="text-muted-foreground w-4 text-center text-xs shrink-0">{typeIcon}</span>
-
-      {/* Name */}
-      {editingName ? (
-        <Input
-          ref={nameRef}
-          defaultValue={layer.name}
-          className="h-6 text-xs flex-1 py-0"
-          autoFocus
-          onClick={(e: React.MouseEvent) => e.stopPropagation()}
-          onBlur={commitName}
-          onKeyDown={(e: React.KeyboardEvent) => {
-            e.stopPropagation();
-            if (e.key === "Enter") commitName();
-            if (e.key === "Escape") setEditingName(false);
-          }}
-        />
-      ) : (
+        {/* Drag handle — GripVertical icon, revealed on hover */}
         <span
-          className="flex-1 truncate text-xs"
-          onDoubleClick={(e: React.MouseEvent) => { e.stopPropagation(); setEditingName(true); }}
+          className="text-muted-foreground/50 hover:text-muted-foreground cursor-grab active:cursor-grabbing shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+          {...dragHandleProps}
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
         >
-          {layer.name}
+          <GripVertical size={14} />
         </span>
-      )}
 
-      {layer.hide && <span className="text-muted-foreground text-xs shrink-0">○</span>}
-      {layer.locked && <span className="text-muted-foreground text-xs shrink-0">🔒</span>}
+        {/* Type icon — Lucide icons for clarity */}
+        <span className="text-muted-foreground shrink-0">
+          <TypeIcon size={13} />
+        </span>
 
-      {/* Context menu */}
-      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-        <PopoverTrigger asChild>
-          <button
-            className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground px-1 text-xs shrink-0"
-            onClick={(e: React.MouseEvent) => { e.stopPropagation(); setMenuOpen(!menuOpen); }}
+        {/* Name — 4px gap from icon via gap-1.5 on parent */}
+        {editingName ? (
+          <Input
+            ref={nameRef}
+            defaultValue={layer.name}
+            className="h-6 text-xs flex-1"
+            autoFocus
+            onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            onBlur={commitName}
+            onKeyDown={(e: React.KeyboardEvent) => {
+              e.stopPropagation();
+              if (e.key === "Enter") commitName();
+              if (e.key === "Escape") setEditingName(false);
+            }}
+          />
+        ) : (
+          <span
+            className="flex-1 truncate text-xs min-w-0"
+            onDoubleClick={(e: React.MouseEvent) => { e.stopPropagation(); setEditingName(true); }}
           >
-            ⋯
-          </button>
-        </PopoverTrigger>
-        <PopoverContent className="w-40 p-1" align="end" sideOffset={4}>
-          {menuItem(
-            layer.locked ? "Unlock" : "Lock",
-            () => dispatch({ type: "update_layer", layerId: layer.id, patch: { locked: !layer.locked } }),
-          )}
-          {menuItem(
-            layer.hide ? "Show" : "Hide",
-            () => dispatch({ type: "update_layer", layerId: layer.id, patch: { hide: !layer.hide } }),
-          )}
-          {menuItem("Rename", () => { setEditingName(true); })}
-          {menuItem("Duplicate", duplicate)}
-          <div className="border-t border-border my-1" />
-          {menuItem(
-            "Delete",
-            () => {
+            {layer.name}
+          </span>
+        )}
+
+        {/* One-click Visibility toggle — always shown when hidden, hover-only when visible */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className={[
+                "shrink-0 transition-opacity",
+                layer.hide
+                  ? "text-muted-foreground opacity-100"
+                  : "text-muted-foreground/30 opacity-0 group-hover:opacity-100",
+              ].join(" ")}
+              onClick={toggleHide}
+              aria-label={layer.hide ? "Show layer" : "Hide layer"}
+            >
+              {layer.hide ? <EyeOff size={13} /> : <Eye size={13} />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">{layer.hide ? "Show" : "Hide"}</TooltipContent>
+        </Tooltip>
+
+        {/* One-click Lock toggle — always shown when locked, hover-only when unlocked */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className={[
+                "shrink-0 transition-opacity",
+                layer.locked
+                  ? "text-muted-foreground opacity-100"
+                  : "text-muted-foreground/30 opacity-0 group-hover:opacity-100",
+              ].join(" ")}
+              onClick={toggleLock}
+              aria-label={layer.locked ? "Unlock layer" : "Lock layer"}
+            >
+              {layer.locked ? <Lock size={13} /> : <Unlock size={13} />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">{layer.locked ? "Unlock" : "Lock"}</TooltipContent>
+        </Tooltip>
+
+        {/* ⋯ context menu — Rename, Duplicate, Delete (lock/hide also here for discoverability) */}
+        <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+          <PopoverTrigger asChild>
+            <button
+              className="shrink-0 text-muted-foreground/30 hover:text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+              onClick={(e: React.MouseEvent) => { e.stopPropagation(); setMenuOpen(!menuOpen); }}
+              aria-label="Layer options"
+            >
+              <MoreVertical size={13} />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-40 p-1" align="end" sideOffset={4}>
+            {menuItem(layer.locked ? "Unlock" : "Lock", () => dispatch({ type: "update_layer", layerId: layer.id, patch: { locked: !layer.locked } }))}
+            {menuItem(layer.hide ? "Show" : "Hide", () => dispatch({ type: "update_layer", layerId: layer.id, patch: { hide: !layer.hide } }))}
+            {menuItem("Rename", () => { setEditingName(true); })}
+            {menuItem("Duplicate", duplicate)}
+            <div className="border-t border-border my-1" />
+            {menuItem("Delete", () => {
               if (window.confirm(`Delete layer "${layer.name}"?`)) {
                 dispatch({ type: "remove_layer", layerId: layer.id });
               }
-            },
-            true,
-          )}
-        </PopoverContent>
-      </Popover>
-    </div>
+            }, true)}
+          </PopoverContent>
+        </Popover>
+      </div>
+    </TooltipProvider>
   );
 }

--- a/components/image/editor/panels/GeometryPanel.tsx
+++ b/components/image/editor/panels/GeometryPanel.tsx
@@ -3,25 +3,48 @@
 /**
  * GeometryPanel — geometry block shared by all layer types (U10, §9).
  *
- * Controls (all layers): W, H, X, Y, Angle, Opacity.
+ * Controls (all layers): W, H, X, Y, Angle, Opacity, Skew X/Y.
  * Constraints: horizontal + vertical pin selectors (§8.1 Figma-style).
  * Lock Aspect Ratio: toggle (for image + shape layers).
  *
  * Constraint pins (§8.1):
  *   horizontal: left | right | center | left_right | scale
  *   vertical:   top  | bottom | center | top_bottom  | scale
+ *
+ * Tier 3 polish: Lucide icons for constraint pins, stacked PairField layout
+ * so W/H/X/Y values are fully visible in the narrow two-column grid.
  */
 
 import { useCallback } from "react";
+import {
+  ChevronLeft, ChevronRight, ArrowLeftRight, Maximize2,
+  ChevronUp, ChevronDown, ArrowUpDown,
+} from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useEditor } from "../EditorContext";
 import type { Layer, ConstraintHorizontal, ConstraintVertical } from "@/lib/image/template-model";
 
+/** Full-width field with side label — used for single-column controls. */
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex items-center gap-2 py-0.5">
       <span className="text-xs text-muted-foreground w-16 shrink-0">{label}</span>
       <div className="flex-1">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * Stacked field — label above input — used in the two-column W/H/X/Y grid.
+ * Gives the full column width (~124px) to the number input instead of sharing
+ * it with a 64px side label that left only ~52px for values like "1080".
+ */
+function PairField({ label, children, title }: { label: string; children: React.ReactNode; title?: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs text-muted-foreground leading-none opacity-70" title={title}>{label}</span>
+      {children}
     </div>
   );
 }
@@ -46,7 +69,7 @@ function NumInput({
       min={min}
       max={max}
       step={step}
-      className="h-7 text-xs"
+      className="h-7 text-xs w-full"
       onChange={(e) => {
         const v = parseFloat(e.target.value);
         if (!isNaN(v)) onChange(v);
@@ -55,20 +78,20 @@ function NumInput({
   );
 }
 
-const H_PIN_OPTIONS: { value: ConstraintHorizontal; label: string; title: string }[] = [
-  { value: "left",       label: "←",   title: "Pin left edge" },
-  { value: "right",      label: "→",   title: "Pin right edge" },
-  { value: "center",     label: "↔",   title: "Center horizontally" },
-  { value: "left_right", label: "⇔",   title: "Stretch (pin both edges)" },
-  { value: "scale",      label: "⟺",  title: "Scale with canvas" },
+const H_PIN_OPTIONS: { value: ConstraintHorizontal; icon: React.ElementType; title: string }[] = [
+  { value: "left",       icon: ChevronLeft,   title: "Pin left edge" },
+  { value: "right",      icon: ChevronRight,  title: "Pin right edge" },
+  { value: "center",     icon: ArrowLeftRight, title: "Centre horizontally" },
+  { value: "left_right", icon: Maximize2,      title: "Stretch — pin both edges" },
+  { value: "scale",      icon: Maximize2,      title: "Scale proportionally with canvas" },
 ];
 
-const V_PIN_OPTIONS: { value: ConstraintVertical; label: string; title: string }[] = [
-  { value: "top",        label: "↑",   title: "Pin top edge" },
-  { value: "bottom",     label: "↓",   title: "Pin bottom edge" },
-  { value: "center",     label: "↕",   title: "Center vertically" },
-  { value: "top_bottom", label: "⇕",   title: "Stretch (pin both edges)" },
-  { value: "scale",      label: "⟺",  title: "Scale with canvas" },
+const V_PIN_OPTIONS: { value: ConstraintVertical; icon: React.ElementType; title: string }[] = [
+  { value: "top",        icon: ChevronUp,     title: "Pin top edge" },
+  { value: "bottom",     icon: ChevronDown,   title: "Pin bottom edge" },
+  { value: "center",     icon: ArrowUpDown,   title: "Centre vertically" },
+  { value: "top_bottom", icon: Maximize2,     title: "Stretch — pin both edges" },
+  { value: "scale",      icon: Maximize2,     title: "Scale proportionally with canvas" },
 ];
 
 export function GeometryPanel({ layer }: { layer: Layer }) {
@@ -86,60 +109,37 @@ export function GeometryPanel({ layer }: { layer: Layer }) {
         Geometry
       </div>
 
-      {/* W, H */}
-      <div className="flex gap-1 mb-1">
-        <div className="flex-1">
-          <Field label="W">
-            <NumInput value={layer.width} onChange={(v) => up({ width: Math.max(1, Math.round(v)) })} min={1} />
-          </Field>
-        </div>
-        <div className="flex-1">
-          <Field label="H">
-            <NumInput value={layer.height} onChange={(v) => up({ height: Math.max(1, Math.round(v)) })} min={1} />
-          </Field>
-        </div>
-      </div>
+      {/* W, H / X, Y / Angle, Opacity / Skew — stacked PairField so the full
+          column width is available to the number input (fixes values like "1080"
+          being clipped in the old side-label layout). */}
+      <div className="grid grid-cols-2 gap-x-2 gap-y-1 mb-2">
+        <PairField label="W" title="Width (px)">
+          <NumInput value={layer.width} onChange={(v) => up({ width: Math.max(1, Math.round(v)) })} min={1} />
+        </PairField>
+        <PairField label="H" title="Height (px)">
+          <NumInput value={layer.height} onChange={(v) => up({ height: Math.max(1, Math.round(v)) })} min={1} />
+        </PairField>
 
-      {/* X, Y */}
-      <div className="flex gap-1 mb-1">
-        <div className="flex-1">
-          <Field label="X">
-            <NumInput value={layer.x} onChange={(v) => up({ x: Math.round(v) })} />
-          </Field>
-        </div>
-        <div className="flex-1">
-          <Field label="Y">
-            <NumInput value={layer.y} onChange={(v) => up({ y: Math.round(v) })} />
-          </Field>
-        </div>
-      </div>
+        <PairField label="X" title="Left position (px)">
+          <NumInput value={layer.x} onChange={(v) => up({ x: Math.round(v) })} />
+        </PairField>
+        <PairField label="Y" title="Top position (px)">
+          <NumInput value={layer.y} onChange={(v) => up({ y: Math.round(v) })} />
+        </PairField>
 
-      {/* Angle, Opacity */}
-      <div className="flex gap-1 mb-1">
-        <div className="flex-1">
-          <Field label="Angle">
-            <NumInput value={layer.rotation} onChange={(v) => up({ rotation: v })} min={-360} max={360} step={0.1} />
-          </Field>
-        </div>
-        <div className="flex-1">
-          <Field label="Opacity">
-            <NumInput value={layer.opacity} onChange={(v) => up({ opacity: Math.max(0, Math.min(1, v)) })} min={0} max={1} step={0.01} />
-          </Field>
-        </div>
-      </div>
+        <PairField label="°" title="Rotation (degrees)">
+          <NumInput value={layer.rotation} onChange={(v) => up({ rotation: v })} min={-360} max={360} step={0.1} />
+        </PairField>
+        <PairField label="%" title="Opacity (0–1)">
+          <NumInput value={layer.opacity} onChange={(v) => up({ opacity: Math.max(0, Math.min(1, v)) })} min={0} max={1} step={0.01} />
+        </PairField>
 
-      {/* Skew X, Skew Y (§6.1, §1.3 — all layer types) */}
-      <div className="flex gap-1 mb-2">
-        <div className="flex-1">
-          <Field label="Skew X">
-            <NumInput value={layer.skew_x} onChange={(v) => up({ skew_x: v })} min={-89} max={89} step={0.5} />
-          </Field>
-        </div>
-        <div className="flex-1">
-          <Field label="Skew Y">
-            <NumInput value={layer.skew_y} onChange={(v) => up({ skew_y: v })} min={-89} max={89} step={0.5} />
-          </Field>
-        </div>
+        <PairField label="Skew X" title="Horizontal skew (degrees)">
+          <NumInput value={layer.skew_x} onChange={(v) => up({ skew_x: v })} min={-89} max={89} step={0.5} />
+        </PairField>
+        <PairField label="Skew Y" title="Vertical skew (degrees)">
+          <NumInput value={layer.skew_y} onChange={(v) => up({ skew_y: v })} min={-89} max={89} step={0.5} />
+        </PairField>
       </div>
 
       {/* Lock aspect ratio (image + rect) */}
@@ -156,49 +156,62 @@ export function GeometryPanel({ layer }: { layer: Layer }) {
         </div>
       )}
 
-      {/* Constraints */}
+      {/* Constraints — Figma-style pins controlling variant reflow (§8.1) */}
       <div className="mt-1">
-        <p className="text-xs text-muted-foreground mb-1">Constraints (Figma-style pins for variant reflow)</p>
-        <div className="mb-1">
-          <p className="text-xs text-muted-foreground mb-0.5">Horizontal</p>
-          <div className="flex gap-1">
-            {H_PIN_OPTIONS.map((opt) => (
-              <button
-                key={opt.value}
-                title={opt.title}
-                className={[
-                  "flex-1 h-7 text-xs rounded border transition-colors",
-                  layer.constraints.horizontal === opt.value
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border hover:bg-muted",
-                ].join(" ")}
-                onClick={() => up({ constraints: { ...layer.constraints, horizontal: opt.value } })}
-              >
-                {opt.label}
-              </button>
-            ))}
+        <p className="text-xs text-muted-foreground mb-1">
+          Constraints
+          <span className="ml-1 text-muted-foreground/60">— how layers reflow when the canvas resizes</span>
+        </p>
+        <TooltipProvider delayDuration={400}>
+          <div className="mb-1">
+            <p className="text-xs text-muted-foreground/70 mb-0.5">Horizontal</p>
+            <div className="flex gap-1">
+              {H_PIN_OPTIONS.map(({ value, icon: Icon, title }) => (
+                <Tooltip key={value}>
+                  <TooltipTrigger asChild>
+                    <button
+                      className={[
+                        "flex-1 h-7 flex items-center justify-center rounded border transition-colors",
+                        layer.constraints.horizontal === value
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border hover:bg-muted",
+                      ].join(" ")}
+                      onClick={() => up({ constraints: { ...layer.constraints, horizontal: value } })}
+                      aria-label={title}
+                    >
+                      <Icon size={13} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="text-xs">{title}</TooltipContent>
+                </Tooltip>
+              ))}
+            </div>
           </div>
-        </div>
-        <div>
-          <p className="text-xs text-muted-foreground mb-0.5">Vertical</p>
-          <div className="flex gap-1">
-            {V_PIN_OPTIONS.map((opt) => (
-              <button
-                key={opt.value}
-                title={opt.title}
-                className={[
-                  "flex-1 h-7 text-xs rounded border transition-colors",
-                  layer.constraints.vertical === opt.value
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border hover:bg-muted",
-                ].join(" ")}
-                onClick={() => up({ constraints: { ...layer.constraints, vertical: opt.value } })}
-              >
-                {opt.label}
-              </button>
-            ))}
+          <div>
+            <p className="text-xs text-muted-foreground/70 mb-0.5">Vertical</p>
+            <div className="flex gap-1">
+              {V_PIN_OPTIONS.map(({ value, icon: Icon, title }) => (
+                <Tooltip key={value}>
+                  <TooltipTrigger asChild>
+                    <button
+                      className={[
+                        "flex-1 h-7 flex items-center justify-center rounded border transition-colors",
+                        layer.constraints.vertical === value
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border hover:bg-muted",
+                      ].join(" ")}
+                      onClick={() => up({ constraints: { ...layer.constraints, vertical: value } })}
+                      aria-label={title}
+                    >
+                      <Icon size={13} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="text-xs">{title}</TooltipContent>
+                </Tooltip>
+              ))}
+            </div>
           </div>
-        </div>
+        </TooltipProvider>
       </div>
     </div>
   );

--- a/components/image/editor/panels/TextLayerPanel.tsx
+++ b/components/image/editor/panels/TextLayerPanel.tsx
@@ -10,8 +10,13 @@
  */
 
 import { useCallback } from "react";
+import {
+  AlignLeft, AlignCenter, AlignRight, AlignJustify,
+  AlignVerticalJustifyStart, AlignVerticalJustifyCenter, AlignVerticalJustifyEnd,
+} from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useEditor } from "../EditorContext";
 import type { TextLayer } from "@/lib/image/template-model";
 import { VarMetadataPanel } from "./VarMetadataPanel";
@@ -114,6 +119,19 @@ function SelectInput<T extends string>({
 }
 
 const FONT_FAMILIES = ["Inter", "Roboto", "Montserrat", "Open Sans", "Poppins"];
+
+const H_ALIGN_ICONS = {
+  left:    { icon: AlignLeft,    label: "Align left" },
+  center:  { icon: AlignCenter,  label: "Align centre" },
+  right:   { icon: AlignRight,   label: "Align right" },
+  justify: { icon: AlignJustify, label: "Justify" },
+} as const;
+
+const V_ALIGN_ICONS = {
+  top:    { icon: AlignVerticalJustifyStart,  label: "Align top" },
+  center: { icon: AlignVerticalJustifyCenter, label: "Align middle" },
+  bottom: { icon: AlignVerticalJustifyEnd,    label: "Align bottom" },
+} as const;
 const FONT_WEIGHTS = [100, 200, 300, 400, 500, 600, 700, 800, 900];
 
 // ─── Panel ────────────────────────────────────────────────────────────────────
@@ -132,11 +150,16 @@ export function TextLayerPanel({ layer }: { layer: TextLayer }) {
       {/* ── U5: TYPOGRAPHY ─────────────────────────────────────────── */}
       <Section title="Typography">
         <Field label="Font">
-          <SelectInput
+          {/* Each option renders in its own typeface so the user can visually compare */}
+          <select
             value={layer.font_family}
-            options={FONT_FAMILIES.map((f) => ({ value: f, label: f }))}
-            onChange={(v) => up({ font_family: v })}
-          />
+            className="h-7 text-xs w-full border border-input rounded px-2 bg-background"
+            onChange={(e) => up({ font_family: e.target.value })}
+          >
+            {FONT_FAMILIES.map((f) => (
+              <option key={f} value={f} style={{ fontFamily: f }}>{f}</option>
+            ))}
+          </select>
         </Field>
         <Field label="Size">
           <NumInput value={layer.font_size} onChange={(v) => up({ font_size: v })} min={4} max={400} />
@@ -165,34 +188,54 @@ export function TextLayerPanel({ layer }: { layer: TextLayer }) {
         </div>
 
         <Field label="H-Align">
-          <div className="flex gap-1">
-            {(["left", "center", "right", "justify"] as const).map((a) => (
-              <Button
-                key={a}
-                variant={layer.text_align_h === a ? "default" : "outline"}
-                size="sm"
-                className="flex-1 h-7 text-xs px-1"
-                onClick={() => up({ text_align_h: a })}
-              >
-                {a[0].toUpperCase()}
-              </Button>
-            ))}
-          </div>
+          <TooltipProvider delayDuration={400}>
+            <div className="flex gap-1">
+              {(["left", "center", "right", "justify"] as const).map((a) => {
+                const { icon: Icon, label } = H_ALIGN_ICONS[a];
+                return (
+                  <Tooltip key={a}>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant={layer.text_align_h === a ? "default" : "outline"}
+                        size="sm"
+                        className="flex-1 h-7 px-1"
+                        onClick={() => up({ text_align_h: a })}
+                        aria-label={label}
+                      >
+                        <Icon size={14} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="text-xs">{label}</TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </TooltipProvider>
         </Field>
         <Field label="V-Align">
-          <div className="flex gap-1">
-            {(["top", "center", "bottom"] as const).map((a) => (
-              <Button
-                key={a}
-                variant={layer.text_align_v === a ? "default" : "outline"}
-                size="sm"
-                className="flex-1 h-7 text-xs px-1"
-                onClick={() => up({ text_align_v: a })}
-              >
-                {a[0].toUpperCase()}
-              </Button>
-            ))}
-          </div>
+          <TooltipProvider delayDuration={400}>
+            <div className="flex gap-1">
+              {(["top", "center", "bottom"] as const).map((a) => {
+                const { icon: Icon, label } = V_ALIGN_ICONS[a];
+                return (
+                  <Tooltip key={a}>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant={layer.text_align_v === a ? "default" : "outline"}
+                        size="sm"
+                        className="flex-1 h-7 px-1"
+                        onClick={() => up({ text_align_v: a })}
+                        aria-label={label}
+                      >
+                        <Icon size={14} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="text-xs">{label}</TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </TooltipProvider>
         </Field>
         <Field label="Transform">
           <SelectInput

--- a/docs/briefs/image-generator/v2-editor/U10_AUDIT.md
+++ b/docs/briefs/image-generator/v2-editor/U10_AUDIT.md
@@ -419,3 +419,45 @@ This ensures the editor preview matches the server-rendered image for text-fit l
 | Add guides toggle to EditorLeftPanel | Minor | `EditorLeftPanel.tsx`, `EditorContext.tsx` |
 | Text-fit in DOM renderer | Major | New `lib/image/text-fit-utils.ts`, `CanvasContent.tsx` |
 
+
+---
+
+## Tier 2 Re-Investigation — 2026-05-31 (second UAT pass)
+
+### Items 1, 2, 4, 5 — Status from previous session
+
+These were investigated, fixed, and deployed in the previous Tier 2 pass:
+
+| Item | Status | PR | Evidence |
+|------|--------|----|---------|
+| 1. Per-layer ⋯ actions | ✅ Working + persists | — | Code trace confirmed Lock/Hide/Rename/Duplicate/Delete all dispatch to EditorContext and survive save/reload via the full template JSON write path |
+| 2. + Layer menu | ✅ Implemented | #1206 | AddLayerMenu component: Text/Image/Rectangle, unique names, inserted at index 0 |
+| 4. Snap guides | ✅ Fixed + toggle | #1206/#1207 | splice(-1) bug fixed; toggle_guides action + UI toggle in left panel footer |
+| 5. Text Fit auto-size | ✅ Fixed | #1208 | fitFontSize() now runs in CanvasContent via lib/image/text-fit-utils.ts; editor preview matches generated image |
+
+---
+
+### Item 3: Multiple image layers coexist
+
+**Code trace — CanvasContent (DOM renderer):**
+
+`renderOrder = [...template.layers].reverse()`. Each layer is wrapped in a `div style={{ position:"absolute", inset:0 }}` click-capture div containing an `ImageLayerEl` with explicit `left/top/width/height`. Multiple ImageLayerEl components render independently at their own canvas coordinates — no collision, no shared state. ✓
+
+**Code trace — sharp renderer (renderTemplate):**
+
+```typescript
+for (const layer of [...layers].reverse()) {
+  if (layer.type === "image") {
+    overlay = await renderImageLayer(layer); // null on fetch failure
+  }
+  if (overlay) overlays.push(overlay);
+}
+const png = await canvas.composite(overlays).png().toBuffer();
+```
+
+Each image layer produces a separate `sharp.OverlayOptions` entry in the `overlays` array. `sharp.composite()` accepts multiple overlays and renders them in order (later entries appear on top). Multiple image layers composite independently with their own `left`/`top` positions. ✓
+
+**Potential performance note (not a bug):** If two image layers share the same `image_url`, the renderer fetches the URL twice (no deduplication at the fetch level). Acceptable for V1 — optimisable later.
+
+**Verdict: Multiple image layers coexist correctly in both the editor DOM renderer and the sharp renderer.** A template with a photo layer + decorative image layer + logo layer produces correct layered output with independent fill/anchor/tint per layer. No fix needed.
+


### PR DESCRIPTION
## Tier 3 — 7 items

**6. Icons + tooltips** (`TextLayerPanel`, `GeometryPanel`)  
H-Align `L/C/R/J` → Lucide `AlignLeft/Center/Right/Justify`. V-Align `T/C/B` → `AlignVerticalJustifyStart/Center/End`. Constraint pins: Unicode arrows → Lucide `Chevron*`, `ArrowLeftRight`, `ArrowUpDown`, `Maximize2`. All with `Radix Tooltip` on hover.

**7. Lock + visibility one-click icons** (`LayerRow`)  
`Eye`/`EyeOff` and `Lock`/`Unlock` are now direct buttons on each layer row — always visible when non-default (hidden/locked), hover-only otherwise (Figma/Illustrator style). Also retained in ⋯ menu for discoverability.

**8. Selected-layer highlight** (`LayerRow`)  
`bg-muted` → `bg-accent/15` + 2px `border-l` in `border-primary`. Clear visual selection indicator. Unselected rows keep `border-transparent` for alignment.

**9. Geometry field widths** (`GeometryPanel`)  
Old side-label layout (`w-16` label + `~52px` input in paired rows) → stacked `PairField` in a CSS grid. Full column width available to number inputs — values like `1080` and `-100` now fully readable.

**10. Panel scrollbars** (`EditorLeftPanel`, `EditorRightPanel`)  
Both panels wrap scrollable content in `<ScrollArea>` (Radix), replacing native browser scrollbars.

**11. Font preview** (`TextLayerPanel`)  
Font `<select>` options carry `style={{ fontFamily }}` so each option renders in its own typeface.

**12. Layer label spacing + icon upgrades** (`LayerRow`)  
Parent gap `1 → 1.5`. Type icons (`T`/`⬜`/`▭`) → Lucide `Type`/`Image`/`Square`. Drag handle `⠿` → `GripVertical`. ⋯ → `MoreVertical`.

**Tests:** 1567 design-token + 273 unit — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)