### PR TITLE
feat(image-gen): shape layer UI — picker submenu, property panel, layer row icon

### DIFF
--- a/components/image/editor/AddLayerMenu.tsx
+++ b/components/image/editor/AddLayerMenu.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useState } from "react";
+import { Circle, Triangle, Minus, Diamond } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { useEditor } from "./EditorContext";
@@ -16,6 +17,8 @@ import type {
   TextLayer,
   ImageLayer,
   RectangleLayer,
+  ShapeLayer,
+  ShapeKind,
   Layer,
 } from "@/lib/image/template-model";
 
@@ -116,6 +119,39 @@ function makeRectLayer(canvasW: number, canvasH: number, existingNames: string[]
   };
 }
 
+function makeShapeLayer(
+  kind: ShapeKind,
+  canvasW: number,
+  canvasH: number,
+  existingNames: string[],
+): ShapeLayer {
+  const name = uniqueName(kind, existingNames);
+  const isLine = kind === "line";
+  const w = Math.round(canvasW * (isLine ? 0.6 : 0.35));
+  const h = Math.round(isLine ? canvasH * 0.03 : canvasH * 0.35);
+  return {
+    ...BASE,
+    id: uid(kind),
+    name,
+    type: "shape",
+    shapeKind: kind,
+    x: Math.round((canvasW - w) / 2),
+    y: Math.round((canvasH - h) / 2),
+    width: w,
+    height: h,
+    color: "#7c3aed",
+    gradient: null,
+    border: null,
+  };
+}
+
+const SHAPE_OPTIONS: { kind: ShapeKind; label: string; icon: React.ElementType }[] = [
+  { kind: "ellipse",  label: "Ellipse",  icon: Circle },
+  { kind: "triangle", label: "Triangle", icon: Triangle },
+  { kind: "line",     label: "Line",     icon: Minus },
+  { kind: "diamond",  label: "Diamond",  icon: Diamond },
+];
+
 /** Generate a slug-safe unique name not already in the template. */
 function uniqueName(prefix: string, existing: string[]): string {
   for (let i = 1; i <= 99; i++) {
@@ -127,44 +163,75 @@ function uniqueName(prefix: string, existing: string[]): string {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
+const menuItemCls = "w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors rounded flex items-center gap-2";
+
 export function AddLayerMenu() {
   const { state, dispatch } = useEditor();
   const [open, setOpen] = useState(false);
+  const [shapesOpen, setShapesOpen] = useState(false);
 
   const { width, height, layers } = state.template;
   const existingNames = layers.map((l) => l.name);
 
   function addLayer(layer: Layer) {
     setOpen(false);
-    dispatch({ type: "add_layer", layer, index: 0 }); // insert at top of visual stack
+    setShapesOpen(false);
+    dispatch({ type: "add_layer", layer, index: 0 });
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={(v) => { setOpen(v); if (!v) setShapesOpen(false); }}>
       <PopoverTrigger asChild>
         <Button variant="ghost" size="sm" className="h-6 text-xs px-2">
           + Layer
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-44 p-1" align="end" sideOffset={4}>
-        <button
-          className="w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors rounded"
-          onClick={() => addLayer(makeTextLayer(width, height, existingNames))}
-        >
-          T  Text
+        {/* Text */}
+        <button className={menuItemCls}
+          onClick={() => addLayer(makeTextLayer(width, height, existingNames))}>
+          <span className="w-4 text-center text-muted-foreground font-bold text-sm">T</span>
+          Text
         </button>
-        <button
-          className="w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors rounded"
-          onClick={() => addLayer(makeImageLayer(width, height, existingNames))}
-        >
-          ⬜  Image
+        {/* Image */}
+        <button className={menuItemCls}
+          onClick={() => addLayer(makeImageLayer(width, height, existingNames))}>
+          <span className="w-4 text-center text-muted-foreground text-sm">⬜</span>
+          Image
         </button>
-        <button
-          className="w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors rounded"
-          onClick={() => addLayer(makeRectLayer(width, height, existingNames))}
-        >
-          ▭  Rectangle
+        {/* Rectangle */}
+        <button className={menuItemCls}
+          onClick={() => addLayer(makeRectLayer(width, height, existingNames))}>
+          <span className="w-4 text-center text-muted-foreground text-sm">▭</span>
+          Rectangle
         </button>
+        {/* Shape submenu */}
+        <div className="relative">
+          <button
+            className={[menuItemCls, "justify-between"].join(" ")}
+            onClick={() => setShapesOpen((v) => !v)}
+          >
+            <span className="flex items-center gap-2">
+              <Circle size={13} className="text-muted-foreground" />
+              Shape
+            </span>
+            <span className="text-muted-foreground text-xs">▶</span>
+          </button>
+          {shapesOpen && (
+            <div className="absolute right-full top-0 mr-1 w-36 bg-popover border border-border rounded-md shadow-md p-1 z-50">
+              {SHAPE_OPTIONS.map(({ kind, label, icon: Icon }) => (
+                <button
+                  key={kind}
+                  className={menuItemCls}
+                  onClick={() => addLayer(makeShapeLayer(kind, width, height, existingNames))}
+                >
+                  <Icon size={13} className="text-muted-foreground shrink-0" />
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/components/image/editor/EditorRightPanel.tsx
+++ b/components/image/editor/EditorRightPanel.tsx
@@ -16,8 +16,9 @@ import { useEditor } from "./EditorContext";
 import { TextLayerPanel } from "./panels/TextLayerPanel";
 import { ImageLayerPanel } from "./panels/ImageLayerPanel";
 import { RectangleLayerPanel } from "./panels/RectangleLayerPanel";
+import { ShapeLayerPanel } from "./panels/ShapeLayerPanel";
 import { GeometryPanel } from "./panels/GeometryPanel";
-import type { TextLayer, ImageLayer, RectangleLayer } from "@/lib/image/template-model";
+import type { TextLayer, ImageLayer, RectangleLayer, ShapeLayer } from "@/lib/image/template-model";
 
 export function EditorRightPanel() {
   const { selectedLayer } = useEditor();
@@ -45,6 +46,9 @@ export function EditorRightPanel() {
             )}
             {selectedLayer.type === "rectangle" && (
               <RectangleLayerPanel layer={selectedLayer as RectangleLayer} />
+            )}
+            {selectedLayer.type === "shape" && (
+              <ShapeLayerPanel layer={selectedLayer as ShapeLayer} />
             )}
             {selectedLayer.type !== "text" && selectedLayer.type !== "image" && selectedLayer.type !== "rectangle" && (
               <div className="px-3 py-6 text-xs text-muted-foreground text-center">

--- a/components/image/editor/LayerRow.tsx
+++ b/components/image/editor/LayerRow.tsx
@@ -17,7 +17,7 @@
 
 import { useCallback, useRef, useState } from "react";
 import {
-  GripVertical, Type, Image, Square,
+  GripVertical, Type, Image, Square, Circle,
   Eye, EyeOff, Lock, Unlock, MoreVertical,
 } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -48,6 +48,7 @@ export function LayerRow({ layer, index, isSelected, dragHandleProps }: LayerRow
   const TypeIcon =
     layer.type === "text" ? Type
     : layer.type === "image" ? Image
+    : layer.type === "shape" ? Circle  // generic shape icon; shapeKind could refine later
     : Square;
 
   const commitName = useCallback(() => {

--- a/components/image/editor/panels/ShapeLayerPanel.tsx
+++ b/components/image/editor/panels/ShapeLayerPanel.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+/**
+ * ShapeLayerPanel — properties panel for a selected ShapeLayer (S-ui).
+ *
+ * Controls: fill (solid / gradient), border, variable metadata.
+ * Geometry, constraints, opacity, skew are handled by GeometryPanel (shared).
+ *
+ * Line layers: only show color (= stroke colour); gradient + border hidden
+ * because a line IS a stroke — adding a border around a line makes no sense.
+ */
+
+import { useCallback } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useEditor } from "../EditorContext";
+import type { ShapeLayer, Gradient, GradientStop } from "@/lib/image/template-model";
+import { VarMetadataPanel } from "./VarMetadataPanel";
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-3">
+      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider pb-1 border-b border-border mb-2">
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 py-0.5">
+      <span className="text-xs text-muted-foreground w-20 shrink-0">{label}</span>
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}
+
+function ColorInput({ value, onChange }: { value: string | null; onChange: (v: string | null) => void }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <input
+        type="color"
+        value={value ?? "#000000"}
+        className="w-7 h-7 rounded border border-border cursor-pointer p-0.5 bg-transparent"
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <Input value={value ?? ""} placeholder="None" className="h-7 text-xs flex-1"
+        onChange={(e) => onChange(e.target.value || null)} />
+      {value && <button className="text-xs text-muted-foreground" onClick={() => onChange(null)}>✕</button>}
+    </div>
+  );
+}
+
+const DEFAULT_GRADIENT: Gradient = {
+  type: "linear", angle: 135,
+  stops: [{ color: "#7C3AED", position: 0 }, { color: "#DB2777", position: 1 }],
+};
+
+export function ShapeLayerPanel({ layer }: { layer: ShapeLayer }) {
+  const { dispatch } = useEditor();
+  const up = useCallback(
+    (patch: Partial<ShapeLayer>) => dispatch({ type: "update_layer", layerId: layer.id, patch }),
+    [dispatch, layer.id],
+  );
+
+  const isLine = layer.shapeKind === "line";
+  const isGradient = !!layer.gradient;
+
+  return (
+    <div className="px-3 py-2 space-y-1 text-sm">
+      <Section title="Fill">
+        {!isLine && (
+          <div className="flex gap-1 mb-2">
+            <Button size="sm" variant={!isGradient ? "default" : "outline"} className="flex-1 h-7 text-xs"
+              onClick={() => up({ color: layer.color ?? "#7c3aed", gradient: null })}>
+              Solid
+            </Button>
+            <Button size="sm" variant={isGradient ? "default" : "outline"} className="flex-1 h-7 text-xs"
+              onClick={() => up({ color: null, gradient: layer.gradient ?? DEFAULT_GRADIENT })}>
+              Gradient
+            </Button>
+          </div>
+        )}
+
+        {(!isGradient || isLine) ? (
+          <Field label={isLine ? "Stroke" : "Color"}>
+            <ColorInput value={layer.color} onChange={(v) => up({ color: v })} />
+          </Field>
+        ) : (
+          <>
+            <Field label="Type">
+              <div className="flex gap-1">
+                {(["linear", "radial"] as const).map((t) => (
+                  <Button key={t} size="sm" variant={layer.gradient?.type === t ? "default" : "outline"}
+                    className="flex-1 h-7 text-xs"
+                    onClick={() => up({ gradient: { ...layer.gradient!, type: t } })}>
+                    {t}
+                  </Button>
+                ))}
+              </div>
+            </Field>
+            {layer.gradient?.type === "linear" && (
+              <Field label="Angle">
+                <Input type="number" value={layer.gradient.angle ?? 0} min={0} max={360}
+                  className="h-7 text-xs"
+                  onChange={(e) => { const v = parseInt(e.target.value, 10); if (!isNaN(v)) up({ gradient: { ...layer.gradient!, angle: v } }); }} />
+              </Field>
+            )}
+            <div className="text-xs text-muted-foreground mb-1 mt-1">Stops</div>
+            {layer.gradient?.stops.map((stop, i) => (
+              <div key={i} className="flex items-center gap-1 mb-1">
+                <input type="color" value={stop.color}
+                  className="w-6 h-6 rounded border border-border cursor-pointer p-0.5 bg-transparent"
+                  onChange={(e) => {
+                    const stops = [...(layer.gradient?.stops ?? [])];
+                    stops[i] = { ...stop, color: e.target.value };
+                    up({ gradient: { ...layer.gradient!, stops } });
+                  }} />
+                <Input type="number" value={Math.round(stop.position * 100)} min={0} max={100}
+                  className="h-6 text-xs w-14"
+                  onChange={(e) => {
+                    const v = parseInt(e.target.value, 10);
+                    if (isNaN(v)) return;
+                    const stops = [...(layer.gradient?.stops ?? [])];
+                    stops[i] = { ...stop, position: v / 100 };
+                    up({ gradient: { ...layer.gradient!, stops } });
+                  }} />
+                <span className="text-xs text-muted-foreground">%</span>
+                {(layer.gradient?.stops.length ?? 0) > 2 && (
+                  <button className="text-xs text-muted-foreground"
+                    onClick={() => {
+                      const stops = (layer.gradient?.stops ?? []).filter((_, j) => j !== i);
+                      up({ gradient: { ...layer.gradient!, stops } });
+                    }}>✕</button>
+                )}
+              </div>
+            ))}
+            <button className="text-xs text-muted-foreground hover:text-foreground mt-1"
+              onClick={() => {
+                const stops: GradientStop[] = [...(layer.gradient?.stops ?? []), { color: "#ffffff", position: 1 }];
+                up({ gradient: { ...layer.gradient!, stops } });
+              }}>
+              + Add stop
+            </button>
+          </>
+        )}
+      </Section>
+
+      {!isLine && (
+        <Section title="Border">
+          {layer.border ? (
+            <>
+              <Field label="Color">
+                <ColorInput value={layer.border.color}
+                  onChange={(v) => up({ border: v ? { ...layer.border!, color: v } : null })} />
+              </Field>
+              <Field label="Width">
+                <Input type="number" value={layer.border.width} min={0} max={40} className="h-7 text-xs"
+                  onChange={(e) => { const v = parseInt(e.target.value, 10); if (!isNaN(v)) up({ border: { ...layer.border!, width: v } }); }} />
+              </Field>
+              <Field label="Style">
+                <select value={layer.border.style} className="h-7 text-xs w-full border border-input rounded px-2 bg-background"
+                  onChange={(e) => up({ border: { ...layer.border!, style: e.target.value as "solid" | "dashed" | "dotted" } })}>
+                  <option value="solid">Solid</option>
+                  <option value="dashed">Dashed</option>
+                  <option value="dotted">Dotted</option>
+                </select>
+              </Field>
+              <button className="text-xs text-muted-foreground mt-1" onClick={() => up({ border: null })}>Remove border</button>
+            </>
+          ) : (
+            <button className="text-xs text-muted-foreground hover:text-foreground py-1"
+              onClick={() => up({ border: { color: "#000000", width: 1, style: "solid" } })}>
+              + Add border
+            </button>
+          )}
+        </Section>
+      )}
+
+      <VarMetadataPanel layer={layer} />
+    </div>
+  );
+}


### PR DESCRIPTION
## What ships

**Picker** — `AddLayerMenu` gains "Shape ▶" entry (inline submenu): Ellipse, Triangle, Line, Diamond. Each creates a `ShapeLayer` at index 0, centred in canvas, auto-named.

**Property panel** — `ShapeLayerPanel`: fill (solid/gradient with stop editor), border (add/remove, color/width/style), variable metadata. Line layers show stroke colour only (gradient/border hidden — a line IS a stroke).

**Layer row** — `type === "shape"` maps to Lucide `Circle` icon. All layer row behaviours (lock/visibility one-click, ⋯ menu, drag, rename) work identically.

**Tests** — 282 unit + 13 golden, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)