### PR TITLE
feat(image-gen): stream B phase 1 — template bulk engine

### DIFF
--- a/app/api/internal/image/qstash-handler/route.ts
+++ b/app/api/internal/image/qstash-handler/route.ts
@@ -8,8 +8,10 @@ import { getServiceRoleClient } from "@/lib/supabase";
 import { generateWithFallback } from "@/lib/image";
 import type { GenerationParams, AspectRatio } from "@/lib/image/types";
 import { compositeImage, TEXT_ZONE_MAP } from "@/lib/image/compositing";
-import { get_template } from "@/lib/image/templates";
+import { get_template, get_template_by_id } from "@/lib/image/templates";
 import { enqueueImageJob } from "@/lib/image/enqueue";
+// Stream B template-mode imports
+import type { TemplateJobSpec } from "@/lib/image/template-bulk-types";
 import {
   acquireImageLease,
   releaseImageLease,
@@ -63,15 +65,24 @@ const GenerationParamsSchema = z.object({
   simplifyPrompt: z.boolean().optional(),
 }) satisfies z.ZodType<GenerationParams>;
 
+// Unified body schema: accepts BOTH legacy Ideogram payloads (no jobType) and
+// Stream B template payloads (jobType="template"). All fields are validated
+// as-is; the handler discriminates and cross-validates in code.
+//
+// Legacy Ideogram payload: generationParams is a GenerationParams object.
+// Template payload:        generationParams is the full TemplateJobSpec stored
+//                          as JSONB (includes jobType, templateId, modifications).
 const BodySchema = z.object({
   jobId: z.string().uuid(),
-  generationParams: GenerationParamsSchema,
+  // Stream B: present only for template jobs. Absent = legacy Ideogram path.
+  jobType: z.literal("template").optional(),
+  // Accepts both GenerationParams and TemplateJobSpec (JSONB passthrough for template jobs).
+  generationParams: z.record(z.string(), z.unknown()),
   batchId: z.string().uuid().optional(),
-  // CAP pipeline fields (optional — only present for CAP-triggered jobs)
+  // CAP pipeline / Ideogram fields (not used for template jobs)
   capDraftId: z.string().uuid().optional(),
   headlineText: z.string().max(200).optional(),
   logoUrl: z.string().url().optional(),
-  // B5: when true, build the prompt and return without calling Ideogram.
   previewOnly: z.boolean().optional(),
 });
 
@@ -104,10 +115,23 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   const { jobId, generationParams, batchId, capDraftId, headlineText, logoUrl, previewOnly } = parsed;
 
+  // Determine job type. Template jobs carry jobType="template" in the body OR
+  // in generationParams.jobType (stored as JSONB in the DB → re-read from there).
+  const isTemplateJob =
+    parsed.jobType === "template" ||
+    (generationParams as Record<string, unknown>).jobType === "template";
+
+  const companyId = String(
+    isTemplateJob
+      ? (generationParams as Record<string, unknown>).companyId
+      : (generationParams as unknown as GenerationParams).companyId,
+  );
+
   logger.info("image.qstash.received", {
     jobId,
     batchId,
-    companyId: generationParams.companyId,
+    companyId,
+    jobType: isTemplateJob ? "template" : "ideogram",
     previewOnly: previewOnly === true,
   });
 
@@ -116,8 +140,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // row, mark the job completed with null result. Never increments spend.
   // Preview never enters the concurrency budget — it's a synchronous read
   // from prompt-engine and has no cost to throttle.
-  if (previewOnly) {
-    return handlePreview({ jobId, generationParams, batchId });
+  if (previewOnly && !isTemplateJob) {
+    return handlePreview({ jobId, generationParams: generationParams as unknown as GenerationParams, batchId });
   }
 
   // ─── 1. Acquire Redis lease (dedup + concurrency token) ───────────────────
@@ -147,7 +171,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
       const requeue = await enqueueImageJob({
         jobId,
-        generationParams,
+        generationParams: generationParams as unknown as GenerationParams, // handler accepts both shapes
         batchId,
         capDraftId: parsed.capDraftId,
         headlineText: parsed.headlineText,
@@ -195,10 +219,26 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   // ─── 4. Generate + composite ─────────────────────────────────────────────
+  //
+  // FORK: template jobs use renderTemplate() + compositeLayerBased().
+  //       Ideogram jobs use the existing generateWithFallback() path.
+  //       Retry/failure/budget/lease semantics are IDENTICAL for both forks —
+  //       the only difference is what produces the image bytes.
+
+  if (isTemplateJob) {
+    return handleTemplateJob({
+      jobId,
+      batchId,
+      svc,
+      templateJobSpec: generationParams as unknown as TemplateJobSpec,
+      companyId,
+    });
+  }
 
   try {
+    const ideogramParams = generationParams as unknown as GenerationParams;
     const images = await generateWithFallback({
-      ...generationParams,
+      ...ideogramParams,
       count: 1, // single image per job
     });
 
@@ -212,9 +252,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     let finalStoragePath = image.storagePath;
     if (headlineText) {
       try {
-        const dbTemplate = await get_template(generationParams.companyId, generationParams.aspectRatio as AspectRatio);
+        const gp = generationParams as unknown as GenerationParams;
+        const dbTemplate = await get_template(gp.companyId, gp.aspectRatio as AspectRatio);
         const textZone = dbTemplate?.definition.customTextZone
-          ?? TEXT_ZONE_MAP[(dbTemplate?.definition.compositionType ?? generationParams.compositionType)];
+          ?? TEXT_ZONE_MAP[(dbTemplate?.definition.compositionType ?? (generationParams as unknown as GenerationParams).compositionType)];
         const composite = await compositeImage({
           backgroundStoragePath: image.storagePath,
           textZones: [{
@@ -252,13 +293,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     // B3: increment per-company spend (non-blocking). Success only — never on
     // failure, never on preview. The handler never sees preview jobs (the batch
     // route skips QStash enqueue in preview mode).
-    void recordBudgetSpend(generationParams.companyId);
+    void recordBudgetSpend(companyId);
 
     // Update batch state after job completion (non-blocking).
     if (batchId) void updateBatchProgress(svc, batchId);
 
     // CAP pipeline: link the composited image to the draft (non-blocking).
-    if (capDraftId) void linkCapDraft(svc, capDraftId, generationParams.companyId, finalStoragePath, image.format);
+    if (capDraftId) void linkCapDraft(svc, capDraftId, companyId, finalStoragePath, image.format);
 
     logger.info("image.qstash.completed", { jobId, storagePath: finalStoragePath, composited: finalStoragePath !== image.storagePath });
     return NextResponse.json({ ok: true, status: "completed", storagePath: finalStoragePath });
@@ -499,5 +540,86 @@ async function recordBudgetSpend(companyId: string): Promise<void> {
       companyId,
       err: err instanceof Error ? err.message : String(err),
     });
+  }
+}
+
+// ─── Stream B: Template job handler ──────────────────────────────────────────
+//
+// Identical retry/failure/budget/lease semantics to the Ideogram path.
+// The caller (POST handler) has already: acquired the lease, checked concurrency
+// cap, and marked the job running. This function only does the rendering step
+// and the completion write.
+
+interface HandleTemplateJobInput {
+  jobId: string;
+  batchId?: string;
+  svc: ReturnType<typeof getServiceRoleClient>;
+  templateJobSpec: TemplateJobSpec;
+  companyId: string;
+}
+
+async function handleTemplateJob(input: HandleTemplateJobInput): Promise<NextResponse> {
+  const { jobId, batchId, svc, templateJobSpec, companyId } = input;
+
+  try {
+    const { templateId, variantKey, modifications } = templateJobSpec;
+
+    // Fetch the template (company-scoped: company templates override globals).
+    const tmpl = await get_template_by_id(templateId, companyId);
+    if (!tmpl?.resolvedTemplate) {
+      throw new Error(`Template ${templateId} not found or not schema_version=2 for company ${companyId}`);
+    }
+
+    // Build storage path: same convention as compositeLayerBased().
+    const ts = Date.now();
+    const outputStoragePath = `${companyId}/template-composite/${ts}-${jobId}.png`;
+
+    // Render the template with modifications + variant (must-have #4: image URL
+    // fetch failures are handled per-layer: null overlay = layer skipped, warning logged).
+    const result = await compositeImage({
+      schema_version: 2,
+      template: tmpl.resolvedTemplate,
+      modifications: modifications ?? [],
+      variantKey,
+      outputStoragePath,
+    });
+
+    // Mark completed.
+    await svc.from("image_generation_jobs").update({
+      state: "completed",
+      result_storage_path: result.storagePath,
+      completed_at: new Date().toISOString(),
+    }).eq("id", jobId);
+
+    // Increment spend + batch progress (identical to Ideogram path).
+    void recordBudgetSpend(companyId);
+    if (batchId) void updateBatchProgress(svc, batchId);
+
+    logger.info("image.qstash.template.completed", {
+      jobId,
+      templateId,
+      variantKey,
+      storagePath: result.storagePath,
+    });
+    return NextResponse.json({ ok: true, status: "completed", storagePath: result.storagePath });
+
+  } catch (err) {
+    const errorClass = err instanceof Error ? err.constructor.name : "UnknownError";
+    const errorDetail = err instanceof Error ? err.message : String(err);
+
+    await svc.from("image_generation_jobs").update({
+      state: "failed",
+      error_class: errorClass,
+      error_detail: errorDetail.slice(0, 500),
+      completed_at: new Date().toISOString(),
+    }).eq("id", jobId);
+
+    logger.error("image.qstash.template.failed", { jobId, error: errorDetail });
+    // 500 → QStash retries. Identical to the Ideogram failure path.
+    return internalError(errorDetail);
+
+  } finally {
+    // Always release the lease — identical to the Ideogram path.
+    await releaseImageLease(jobId);
   }
 }

--- a/lib/__tests__/image-qstash-template-fork.unit.test.ts
+++ b/lib/__tests__/image-qstash-template-fork.unit.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for the QStash handler template fork (Stream B Phase 1).
+ *
+ * Tests cover:
+ *  - isTemplateJob detection (jobType in body vs in generationParams JSONB)
+ *  - handleTemplateJob: happy path (template found, composite succeeds)
+ *  - handleTemplateJob: template not found → job marked failed, 500
+ *  - handleTemplateJob: compositeImage throws → job marked failed, 500
+ *  - Ideogram path unchanged when jobType is absent
+ *  - Lease released in finally block for both success and failure
+ *
+ * Route handler is exercised via direct POST request construction.
+ * All external dependencies (Supabase, compositeImage, lease, budget) are mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── QStash signature verification ────────────────────────────────────────────
+vi.mock("@/lib/qstash", () => ({
+  verifyQstashSignature: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+// ─── Supabase ────────────────────────────────────────────────────────────────
+// Build a chainable mock: .from().update/select().eq().eq()... all resolve ok.
+function makeSupabaseChain(leafValue: Record<string, unknown>) {
+  const chain: Record<string, unknown> = {};
+  // Allow infinite chaining — every method returns the chain itself or the leaf.
+  const proxy = new Proxy(chain, {
+    get(_target, prop: string) {
+      if (prop === "then") return undefined; // not a Promise
+      // Terminal properties that tests read
+      if (prop === "count") return leafValue.count ?? 1;
+      if (prop === "error") return leafValue.error ?? null;
+      if (prop === "data") return leafValue.data ?? null;
+      // All methods return the proxy for chaining
+      return vi.fn().mockReturnValue(proxy);
+    },
+  });
+  return proxy;
+}
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ─── Template access ──────────────────────────────────────────────────────────
+const mockGetTemplateById = vi.fn();
+vi.mock("@/lib/image/templates", () => ({
+  get_template: vi.fn(),
+  get_template_by_id: (...args: unknown[]) => mockGetTemplateById(...args),
+}));
+
+// ─── compositeImage ───────────────────────────────────────────────────────────
+const mockCompositeImage = vi.fn();
+vi.mock("@/lib/image/compositing", () => ({
+  compositeImage: (...args: unknown[]) => mockCompositeImage(...args),
+  TEXT_ZONE_MAP: {},
+}));
+
+// ─── Lease ────────────────────────────────────────────────────────────────────
+const mockReleaseLease = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/image/lease", () => ({
+  acquireImageLease: vi.fn().mockResolvedValue({ ok: true }),
+  releaseImageLease: (...args: unknown[]) => mockReleaseLease(...args),
+  getActiveLeaseCount: vi.fn().mockResolvedValue(0),
+  getConcurrencyCap: vi.fn().mockReturnValue(10),
+}));
+
+// ─── Budget ───────────────────────────────────────────────────────────────────
+vi.mock("@/lib/image/budget", () => ({
+  checkImageGenBudget: vi.fn().mockResolvedValue({ allowed: true }),
+  incrementImageGenSpend: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@/lib/image/budget-notify", () => ({
+  notifyImageGenBudgetThreshold: vi.fn(),
+}));
+
+// ─── Enqueue (not called for template jobs in success path) ───────────────────
+vi.mock("@/lib/image/enqueue", () => ({
+  enqueueImageJob: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+// ─── generateWithFallback (Ideogram path — not called for template jobs) ─────
+vi.mock("@/lib/image", () => ({
+  generateWithFallback: vi.fn().mockResolvedValue([{
+    storagePath: "company/ideogram.jpg",
+    format: "jpeg",
+    width: 1080,
+    height: 1080,
+  }]),
+}));
+vi.mock("@/lib/image/generator/preview", () => ({
+  generatePreview: vi.fn().mockResolvedValue({ prompt: "test" }),
+}));
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const JOB_UUID      = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TEMPLATE_UUID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const COMPANY_UUID  = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+const RESOLVED_TEMPLATE = {
+  id: TEMPLATE_UUID,
+  name: "Test Template",
+  width: 1080,
+  height: 1080,
+  layers: [],
+};
+
+const TEMPLATE_JOB_SPEC = {
+  jobType: "template",
+  templateId: TEMPLATE_UUID,
+  variantKey: "square",
+  modifications: [{ name: "headline", text: "Hello World" }],
+  aspectRatio: "1x1",
+  companyId: COMPANY_UUID,
+};
+
+async function makeRequest(body: Record<string, unknown>): Promise<NextRequest> {
+  return new NextRequest("http://localhost/api/internal/image/qstash-handler", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", "upstash-signature": "fake" },
+  });
+}
+
+// ─── Import handler after all mocks are set up ────────────────────────────────
+
+import { POST } from "@/app/api/internal/image/qstash-handler/route";
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("QStash handler — template fork", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset chainable Supabase mock — .update/.select/.eq... all succeed by default.
+    mockFrom.mockReturnValue(makeSupabaseChain({ count: 1, error: null, data: null }));
+    mockReleaseLease.mockResolvedValue(undefined);
+  });
+
+  it("detects template job via jobType field in body", async () => {
+    mockGetTemplateById.mockResolvedValue({
+      resolvedTemplate: RESOLVED_TEMPLATE,
+    });
+    mockCompositeImage.mockResolvedValue({ storagePath: "company/template-composite/123-job.png", provider: "sharp_layer_native", durationMs: 50 });
+
+    const req = await makeRequest({ jobId: JOB_UUID, jobType: "template", generationParams: TEMPLATE_JOB_SPEC });
+    const res = await POST(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.status).toBe("completed");
+    expect(mockCompositeImage).toHaveBeenCalledOnce();
+  });
+
+  it("detects template job via generationParams.jobType (JSONB re-read path)", async () => {
+    // No top-level jobType — it's inside generationParams (as stored in the DB)
+    mockGetTemplateById.mockResolvedValue({ resolvedTemplate: RESOLVED_TEMPLATE });
+    mockCompositeImage.mockResolvedValue({ storagePath: "s/path.png", provider: "p", durationMs: 10 });
+
+    const req = await makeRequest({ jobId: JOB_UUID, generationParams: TEMPLATE_JOB_SPEC });
+    const res = await POST(req);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body.status).toBe("completed");
+    expect(mockCompositeImage).toHaveBeenCalledOnce();
+  });
+
+  it("calls compositeImage with schema_version=2, template, modifications, variantKey", async () => {
+    mockGetTemplateById.mockResolvedValue({ resolvedTemplate: RESOLVED_TEMPLATE });
+    mockCompositeImage.mockResolvedValue({ storagePath: "s/path.png", provider: "p", durationMs: 10 });
+
+    const req = await makeRequest({ jobId: JOB_UUID, jobType: "template", generationParams: TEMPLATE_JOB_SPEC });
+    await POST(req);
+
+    expect(mockCompositeImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schema_version: 2,
+        template: RESOLVED_TEMPLATE,
+        modifications: TEMPLATE_JOB_SPEC.modifications,
+        variantKey: "square",
+      }),
+    );
+  });
+
+  it("marks job failed and returns 500 when template not found", async () => {
+    mockGetTemplateById.mockResolvedValue(null);
+
+    const req = await makeRequest({ jobId: JOB_UUID, jobType: "template", generationParams: TEMPLATE_JOB_SPEC });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    expect(mockCompositeImage).not.toHaveBeenCalled();
+  });
+
+  it("marks job failed and returns 500 when template has no resolvedTemplate", async () => {
+    // v1 template — resolvedTemplate is undefined
+    mockGetTemplateById.mockResolvedValue({ resolvedTemplate: undefined });
+
+    const req = await makeRequest({ jobId: JOB_UUID, jobType: "template", generationParams: TEMPLATE_JOB_SPEC });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+  });
+
+  it("marks job failed and returns 500 when compositeImage throws", async () => {
+    mockGetTemplateById.mockResolvedValue({ resolvedTemplate: RESOLVED_TEMPLATE });
+    mockCompositeImage.mockRejectedValue(new Error("sharp blew up"));
+
+    const req = await makeRequest({ jobId: JOB_UUID, jobType: "template", generationParams: TEMPLATE_JOB_SPEC });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+  });
+
+  it("always releases the lease — success path", async () => {
+    mockGetTemplateById.mockResolvedValue({ resolvedTemplate: RESOLVED_TEMPLATE });
+    mockCompositeImage.mockResolvedValue({ storagePath: "s/path.png", provider: "p", durationMs: 10 });
+
+    const req = await makeRequest({ jobId: JOB_UUID, jobType: "template", generationParams: TEMPLATE_JOB_SPEC });
+    await POST(req);
+
+    expect(mockReleaseLease).toHaveBeenCalledWith(JOB_UUID);
+  });
+
+  it("always releases the lease — failure path", async () => {
+    mockGetTemplateById.mockResolvedValue(null); // throws inside handler
+
+    const req = await makeRequest({ jobId: JOB_UUID, jobType: "template", generationParams: TEMPLATE_JOB_SPEC });
+    await POST(req);
+
+    expect(mockReleaseLease).toHaveBeenCalledWith(JOB_UUID);
+  });
+
+  it("does NOT call compositeImage when job is Ideogram (no jobType)", async () => {
+    const ideogramSpec = {
+      styleId: "clean_corporate",
+      primaryColour: "#1a56db",
+      compositionType: "split_layout",
+      aspectRatio: "1x1",
+      companyId: COMPANY_UUID,
+    };
+
+    const req = await makeRequest({ jobId: JOB_UUID, generationParams: ideogramSpec });
+    await POST(req);
+
+    // Template compositor should not be invoked on the Ideogram path
+    expect(mockGetTemplateById).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/image-template-field-mapper.unit.test.ts
+++ b/lib/__tests__/image-template-field-mapper.unit.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for template-field-mapper (Stream B §3.3).
+ *
+ * Tests cover:
+ *  - mapFieldsToColumns: exact-name match, label-match fallback, unmatched required
+ *  - rowToModifications: text/image/rectangle conversion, default values
+ *  - validateMapping: required-field validation
+ *  - isImageUrl: URL detection
+ *
+ * No server-only imports, no Supabase, no sharp — pure logic tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  mapFieldsToColumns,
+  rowToModifications,
+  validateMapping,
+  isImageUrl,
+} from "@/lib/image/template-field-mapper";
+import type { TemplateField } from "@/lib/image/template-model";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeTextField(name: string, label: string, required = false, defaultValue = ""): TemplateField {
+  return {
+    name,
+    type: "text",
+    var: { label, required, default: defaultValue, category: "content" },
+  };
+}
+
+function makeImageField(name: string, label: string, required = false): TemplateField {
+  return {
+    name,
+    type: "image",
+    var: { label, required, default: "", category: "media" },
+  };
+}
+
+const FIELDS: TemplateField[] = [
+  makeTextField("headline", "Headline Text", true),
+  makeTextField("subheading", "Subheading", false, "Default sub"),
+  makeImageField("bg_image", "Background Image", false),
+];
+
+// ─── mapFieldsToColumns ────────────────────────────────────────────────────────
+
+describe("mapFieldsToColumns", () => {
+  it("matches by exact field name (case-insensitive)", () => {
+    const headers = ["HEADLINE", "subheading", "bg_image"];
+    const result = mapFieldsToColumns(FIELDS, headers);
+
+    expect(result.fields[0].matchedColumn).toBe("HEADLINE");
+    expect(result.fields[0].matchMethod).toBe("name_exact");
+    expect(result.fields[1].matchedColumn).toBe("subheading");
+    expect(result.fields[2].matchedColumn).toBe("bg_image");
+  });
+
+  it("falls back to label match when name does not match", () => {
+    // Headers use full labels only — neither matches any field name exactly.
+    // "Headline Text" matches label of "headline" field (name = "headline").
+    // "Sub Text" does NOT match name "subheading" or label "Subheading" → unmatched.
+    // Use a field whose label differs significantly from its name.
+    const specialField: TemplateField = {
+      name: "cta_btn",
+      type: "text",
+      var: { label: "Call To Action Button", required: false, default: "", category: "content" },
+    };
+    const headers = ["Call To Action Button"];
+    const result = mapFieldsToColumns([specialField], headers);
+
+    expect(result.fields[0].matchedColumn).toBe("Call To Action Button");
+    expect(result.fields[0].matchMethod).toBe("label_match");
+  });
+
+  it("prefers exact name match over label match", () => {
+    // Both "headline" (name) and "Headline Text" (label) are present — name wins
+    const headers = ["headline", "Headline Text"];
+    const result = mapFieldsToColumns([makeTextField("headline", "Headline Text")], headers);
+
+    expect(result.fields[0].matchedColumn).toBe("headline");
+    expect(result.fields[0].matchMethod).toBe("name_exact");
+  });
+
+  it("marks unmatched required fields", () => {
+    const headers = ["subheading"]; // headline is required but missing
+    const result = mapFieldsToColumns(FIELDS, headers);
+
+    expect(result.hasRequiredUnmatched).toBe(true);
+    expect(result.unmatched_required).toContain("headline");
+  });
+
+  it("collects unused columns", () => {
+    const headers = ["headline", "subheading", "bg_image", "extra_col"];
+    const result = mapFieldsToColumns(FIELDS, headers);
+
+    expect(result.unusedColumns).toEqual(["extra_col"]);
+  });
+
+  it("populates sample value from first row", () => {
+    const headers = ["headline", "subheading"];
+    const sampleRow = { headline: "Hello World", subheading: "Sub value" };
+    const result = mapFieldsToColumns(FIELDS, headers, sampleRow);
+
+    expect(result.fields[0].sampleValue).toBe("Hello World");
+    expect(result.fields[1].sampleValue).toBe("Sub value");
+    expect(result.fields[2].sampleValue).toBeNull(); // bg_image not in headers
+  });
+
+  it("returns null sample value when column not matched", () => {
+    const headers = ["subheading"];
+    const sampleRow = { subheading: "Sub" };
+    const result = mapFieldsToColumns(FIELDS, headers, sampleRow);
+
+    expect(result.fields[0].sampleValue).toBeNull(); // headline unmatched
+  });
+});
+
+// ─── rowToModifications ────────────────────────────────────────────────────────
+
+describe("rowToModifications", () => {
+  it("converts text field to text modification", () => {
+    const headers = ["headline", "subheading"];
+    const mapping = mapFieldsToColumns(FIELDS, headers);
+    const mods = rowToModifications({ headline: "My Title", subheading: "My Sub" }, mapping);
+
+    expect(mods).toContainEqual({ name: "headline", text: "My Title" });
+    expect(mods).toContainEqual({ name: "subheading", text: "My Sub" });
+  });
+
+  it("uses field default when cell is empty", () => {
+    const headers = ["headline", "subheading"];
+    const mapping = mapFieldsToColumns(FIELDS, headers);
+    // subheading cell empty, has default "Default sub"
+    const mods = rowToModifications({ headline: "Hi", subheading: "" }, mapping);
+
+    expect(mods).toContainEqual({ name: "subheading", text: "Default sub" });
+  });
+
+  it("omits field when cell is empty and no default", () => {
+    const headers = ["headline"];
+    const mapping = mapFieldsToColumns(
+      [{ name: "headline", type: "text", var: { label: "Headline", required: false, default: "", category: "content" as const } }],
+      headers,
+    );
+    const mods = rowToModifications({ headline: "" }, mapping);
+
+    expect(mods).toHaveLength(0);
+  });
+
+  it("converts image field cell to image_url modification", () => {
+    const headers = ["bg_image"];
+    const mapping = mapFieldsToColumns(FIELDS, headers);
+    const mods = rowToModifications({ bg_image: "https://example.com/img.jpg" }, mapping);
+
+    expect(mods).toContainEqual({ name: "bg_image", image_url: "https://example.com/img.jpg" });
+  });
+
+  it("skips image field when cell value is not a URL", () => {
+    const headers = ["bg_image"];
+    const mapping = mapFieldsToColumns(FIELDS, headers);
+    const mods = rowToModifications({ bg_image: "not-a-url" }, mapping);
+
+    // Non-URL image value → no modification (must-have #4: graceful skip)
+    expect(mods.find(m => m.name === "bg_image")).toBeUndefined();
+  });
+
+  it("converts rectangle field to color modification", () => {
+    const rectField: TemplateField = {
+      name: "bg_rect",
+      type: "rectangle",
+      var: { label: "Background Color", required: false, default: "", category: "branding" },
+    };
+    const headers = ["bg_rect"];
+    const mapping = mapFieldsToColumns([rectField], headers);
+    const mods = rowToModifications({ bg_rect: "#ff0000" }, mapping);
+
+    expect(mods).toContainEqual({ name: "bg_rect", color: "#ff0000" });
+  });
+});
+
+// ─── validateMapping ──────────────────────────────────────────────────────────
+
+describe("validateMapping", () => {
+  it("returns ok when all required fields are matched", () => {
+    const headers = ["headline"];
+    const mapping = mapFieldsToColumns(FIELDS, headers);
+    expect(validateMapping(mapping)).toEqual({ ok: true });
+  });
+
+  it("returns error when a required field is unmatched", () => {
+    const headers = ["subheading"]; // headline required but missing
+    const mapping = mapFieldsToColumns(FIELDS, headers);
+    const result = validateMapping(mapping);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("headline");
+    }
+  });
+});
+
+// ─── isImageUrl ───────────────────────────────────────────────────────────────
+
+describe("isImageUrl", () => {
+  it("accepts http and https URLs", () => {
+    expect(isImageUrl("https://example.com/img.jpg")).toBe(true);
+    expect(isImageUrl("http://cdn.example.com/photo.png")).toBe(true);
+  });
+
+  it("rejects non-URL strings", () => {
+    expect(isImageUrl("not-a-url")).toBe(false);
+    expect(isImageUrl("ftp://example.com/file")).toBe(false);
+    expect(isImageUrl("")).toBe(false);
+    expect(isImageUrl("/relative/path.jpg")).toBe(false);
+  });
+});

--- a/lib/__tests__/image-template-render-modifications.unit.test.ts
+++ b/lib/__tests__/image-template-render-modifications.unit.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Golden test: template-mode modification application (Stream B Phase 1).
+ *
+ * Verifies that applyModifications() — the core of the template render path —
+ * correctly applies Stream B spreadsheet-derived modifications to template layers.
+ *
+ * This is the regression gate for must-have #4: the modification pipeline must
+ * produce deterministic output for any given template+modifications pair.
+ *
+ * Coverage:
+ *  - Text layer: text override applies
+ *  - Image layer: image_url override applies
+ *  - Rectangle layer: color override applies
+ *  - Unmatched modification (layer name not in template): ignored
+ *  - Last-write-wins for duplicate modification keys
+ *  - Empty modifications array: layers returned unchanged
+ *  - Layer order preserved
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(Buffer.from("")),
+}));
+vi.mock("sharp", () => ({ default: vi.fn() }));
+
+import { applyModifications } from "@/lib/image/compositing/layer-renderer";
+import type { Layer, TextLayer, ImageLayer, RectangleLayer } from "@/lib/image/template-model";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function baseLayer(name: string): Pick<Layer, "id" | "name" | "x" | "y" | "width" | "height" | "opacity" | "locked" | "hide" | "rotation" | "rotate_x" | "rotate_y" | "rotate_z" | "skew_x" | "skew_y" | "lock_aspect_ratio" | "hide_when_empty" | "description" | "group" | "constraints"> {
+  return {
+    id: `id-${name}`,
+    name,
+    x: 0, y: 0, width: 400, height: 200,
+    opacity: 1, rotation: 0, rotate_x: 0, rotate_y: 0, rotate_z: 0,
+    skew_x: 0, skew_y: 0,
+    locked: false, hide: false, hide_when_empty: false, lock_aspect_ratio: false,
+    description: "", group: null,
+    constraints: { horizontal: "left", vertical: "top" },
+  };
+}
+
+function makeTextLayer(name: string, text: string): TextLayer {
+  return {
+    ...baseLayer(name),
+    type: "text",
+    text,
+    font_family: "Inter", font_size: 32, font_weight: 400,
+    color: "#ffffff", text_align_h: "left", text_align_v: "top",
+    letter_spacing: 0, line_height: 1.2,
+    text_transform: "none", text_decoration: "none",
+    word_break: "normal", style: "", direction: "ltr",
+    text_fit: { enabled: false, min_size: 16, max_size: 120, max_lines: 4 },
+    truncate: false,
+    text_box: { padding: null, border: null },
+    background: { color: null, border: null, border_width: null, padding_h: 0, padding_v: 0, shadow: null, radius: null, shift: null },
+    secondary: { font_family: null, color: null },
+  };
+}
+
+function makeImageLayer(name: string, imageUrl: string): ImageLayer {
+  return {
+    ...baseLayer(name),
+    type: "image",
+    image_url: imageUrl,
+    fit: "cover",
+    position: "center center",
+    border: null, border_radius: null, border_width: null,
+    flip_h: false, flip_v: false,
+    brightness: 0, contrast: 0, saturation: 0, blur: 0,
+    overlay_color: null, overlay_alpha: 0,
+    mask: null,
+    drop_shadow: null,
+    filter: "none",
+  };
+}
+
+function makeRectLayer(name: string, color: string): RectangleLayer {
+  return {
+    ...baseLayer(name),
+    type: "rectangle",
+    color,
+    opacity: 1,
+    border: null, border_width: null, border_radius: null,
+    gradient: null,
+    drop_shadow: null,
+  };
+}
+
+const TEXT_LAYER = makeTextLayer("headline", "Original headline");
+const IMAGE_LAYER = makeImageLayer("bg_image", "https://placeholder.com/original.jpg");
+const RECT_LAYER = makeRectLayer("bg_rect", "#000000");
+
+// ─── applyModifications ───────────────────────────────────────────────────────
+
+describe("applyModifications", () => {
+  it("returns layers unchanged when modifications is empty", () => {
+    const layers: Layer[] = [TEXT_LAYER, IMAGE_LAYER, RECT_LAYER];
+    const result = applyModifications(layers, []);
+    expect(result).toStrictEqual(layers);
+    // Verify identity (no unnecessary copies when no mods)
+    expect(result).toBe(layers);
+  });
+
+  it("applies text modification to a text layer", () => {
+    const layers: Layer[] = [TEXT_LAYER];
+    const result = applyModifications(layers, [{ name: "headline", text: "New Headline" }]);
+
+    const modified = result[0] as TextLayer;
+    expect(modified.text).toBe("New Headline");
+    // Other properties unchanged
+    expect(modified.font_family).toBe("Inter");
+    expect(modified.color).toBe("#ffffff");
+  });
+
+  it("applies image_url modification to an image layer", () => {
+    const layers: Layer[] = [IMAGE_LAYER];
+    const result = applyModifications(layers, [
+      { name: "bg_image", image_url: "https://cdn.example.com/new.jpg" },
+    ]);
+
+    const modified = result[0] as ImageLayer;
+    expect(modified.image_url).toBe("https://cdn.example.com/new.jpg");
+    expect(modified.fit).toBe("cover"); // unchanged
+  });
+
+  it("applies color modification to a rectangle layer", () => {
+    const layers: Layer[] = [RECT_LAYER];
+    const result = applyModifications(layers, [{ name: "bg_rect", color: "#ff0000" }]);
+
+    const modified = result[0] as RectangleLayer;
+    expect(modified.color).toBe("#ff0000");
+  });
+
+  it("leaves unmatched layers untouched", () => {
+    const layers: Layer[] = [TEXT_LAYER, IMAGE_LAYER];
+    const result = applyModifications(layers, [{ name: "unknown_layer", text: "ignored" }]);
+
+    expect((result[0] as TextLayer).text).toBe("Original headline");
+    expect((result[1] as ImageLayer).image_url).toBe("https://placeholder.com/original.jpg");
+  });
+
+  it("applies multiple modifications in one call", () => {
+    const layers: Layer[] = [TEXT_LAYER, IMAGE_LAYER, RECT_LAYER];
+    const result = applyModifications(layers, [
+      { name: "headline", text: "Multi Mod Text" },
+      { name: "bg_image", image_url: "https://cdn.example.com/multi.jpg" },
+      { name: "bg_rect", color: "#0000ff" },
+    ]);
+
+    expect((result[0] as TextLayer).text).toBe("Multi Mod Text");
+    expect((result[1] as ImageLayer).image_url).toBe("https://cdn.example.com/multi.jpg");
+    expect((result[2] as RectangleLayer).color).toBe("#0000ff");
+  });
+
+  it("last-write-wins for duplicate modification keys", () => {
+    const layers: Layer[] = [TEXT_LAYER];
+    const result = applyModifications(layers, [
+      { name: "headline", text: "First" },
+      { name: "headline", text: "Second" }, // should win
+    ]);
+
+    expect((result[0] as TextLayer).text).toBe("Second");
+  });
+
+  it("preserves layer order", () => {
+    const layers: Layer[] = [TEXT_LAYER, RECT_LAYER, IMAGE_LAYER];
+    const result = applyModifications(layers, [{ name: "headline", text: "X" }]);
+
+    expect(result[0].name).toBe("headline");
+    expect(result[1].name).toBe("bg_rect");
+    expect(result[2].name).toBe("bg_image");
+  });
+
+  it("golden: deterministic output — same input produces identical result", () => {
+    const layers: Layer[] = [TEXT_LAYER, IMAGE_LAYER];
+    const mods = [
+      { name: "headline", text: "Deterministic" },
+      { name: "bg_image", image_url: "https://cdn.example.com/det.jpg" },
+    ];
+
+    const result1 = applyModifications(layers, mods);
+    const result2 = applyModifications(layers, mods);
+
+    expect(result1).toStrictEqual(result2);
+    expect((result1[0] as TextLayer).text).toBe("Deterministic");
+    expect((result1[1] as ImageLayer).image_url).toBe("https://cdn.example.com/det.jpg");
+  });
+});

--- a/lib/image/dispatch.ts
+++ b/lib/image/dispatch.ts
@@ -5,6 +5,7 @@ import { logger } from "@/lib/logger";
 import { enqueueImageJob } from "@/lib/image/enqueue";
 import { checkImageGenBudget } from "@/lib/image/budget";
 import type { GenerationParams } from "@/lib/image/types";
+import type { TemplateJobSpec } from "@/lib/image/template-bulk-types";
 
 // ---------------------------------------------------------------------------
 // Image-batch dispatch helper. Owns the per-batch DB + QStash side effects
@@ -34,7 +35,8 @@ export interface DispatchJobSpec {
 export interface DispatchInput {
   companyId: string;
   triggeredBy: string;
-  jobs: DispatchJobSpec[];
+  /** Accepts Ideogram job specs (existing) OR template job specs (Stream B). */
+  jobs: (DispatchJobSpec | TemplateJobSpec)[];
   mode: BatchMode;
   sourceFilename?: string;
   sourceRowCount?: number;
@@ -121,15 +123,22 @@ export async function dispatchImageBatch(input: DispatchInput): Promise<Dispatch
   const jobIds: string[] = [];
 
   for (const spec of jobs) {
-    const generationParams: GenerationParams = {
-      styleId: spec.styleId,
-      primaryColour: spec.primaryColour,
-      compositionType: spec.compositionType,
-      aspectRatio: spec.aspectRatio,
-      industry: spec.industry,
-      companyId,
-      count: 1,
-    };
+    // Determine job type and build the params JSONB stored on the job row.
+    const isTemplateJob = "jobType" in spec && spec.jobType === "template";
+
+    // For Ideogram jobs: GenerationParams. For template jobs: TemplateJobSpec (sans jobType).
+    // Both are stored as JSONB in generation_params; the QStash handler discriminates via jobType.
+    const generationParams: unknown = isTemplateJob
+      ? spec // store the full TemplateJobSpec; handler reads jobType to route
+      : {
+          styleId: (spec as DispatchJobSpec).styleId,
+          primaryColour: (spec as DispatchJobSpec).primaryColour,
+          compositionType: (spec as DispatchJobSpec).compositionType,
+          aspectRatio: (spec as DispatchJobSpec).aspectRatio,
+          industry: (spec as DispatchJobSpec).industry,
+          companyId,
+          count: 1,
+        };
 
     const { data: job, error: jobErr } = await svc
       .from("image_generation_jobs")
@@ -154,9 +163,10 @@ export async function dispatchImageBatch(input: DispatchInput): Promise<Dispatch
     const jobId = (job as { id: string }).id;
     jobIds.push(jobId);
 
+    // Enqueue to QStash. Template jobs carry the full spec; Ideogram jobs carry generationParams.
     const enqueue = await enqueueImageJob({
       jobId,
-      generationParams,
+      generationParams: generationParams as GenerationParams, // handler handles both shapes
       batchId,
       ...(mode === "preview" && { previewOnly: true }),
     });

--- a/lib/image/template-bulk-types.ts
+++ b/lib/image/template-bulk-types.ts
@@ -1,0 +1,98 @@
+/**
+ * template-bulk-types — shared types for Stream B template-based bulk generation.
+ *
+ * These types are used across:
+ *  - lib/image/template-field-mapper.ts  (column → modification mapping)
+ *  - lib/image/dispatch.ts               (TemplateJobSpec in batch dispatch)
+ *  - lib/image/enqueue.ts                (template job payload to QStash)
+ *  - app/api/internal/image/qstash-handler (template job execution)
+ *  - app/api/platform/image/ingest       (template-mode ingest route)
+ *
+ * No server-only import — these types are safe in both client and server code.
+ */
+
+import type { Modification } from "@/lib/image/template-model";
+
+// ─── Spreadsheet parsing types ────────────────────────────────────────────────
+
+/** A raw row from a parsed XLSX/DOCX spreadsheet. */
+export type SpreadsheetRow = Record<string, string>;
+
+// ─── Template job spec (extends existing Ideogram DispatchJobSpec) ────────────
+
+/**
+ * Job specification for a template-based render job.
+ * Dispatched to QStash with jobType="template".
+ *
+ * Design: additive alongside DispatchJobSpec (no renaming of existing types).
+ * The existing Ideogram pipeline is untouched.
+ */
+export interface TemplateJobSpec {
+  jobType: "template";
+  templateId: string;
+  /** Variant key (e.g. "square" | "landscape"). Null = base canvas. */
+  variantKey?: string;
+  /** Layer modifications derived from a spreadsheet row via the field mapper. */
+  modifications: Modification[];
+  /** Aspect ratio carried for budget/storage-path conventions. */
+  aspectRatio: string;
+  targetPlatforms?: string[];
+  targetPublishDate?: string;
+  parentPostIndex?: number;
+}
+
+// ─── Column mapping result ────────────────────────────────────────────────────
+
+/** How a template field was matched to a spreadsheet column. */
+export type MappingMethod = "name_exact" | "label_match";
+
+/** Result for a single template field after column mapping. */
+export interface FieldMappingEntry {
+  /** Template field name (= Modification.name key). */
+  fieldName: string;
+  /** Human-readable label from var metadata. */
+  fieldLabel: string;
+  /** Field type — text, image, or rectangle. */
+  fieldType: "text" | "image" | "rectangle";
+  /** Whether the field is marked required in var metadata. */
+  required: boolean;
+  /** Default value from var metadata (empty string if none). */
+  defaultValue: string;
+  /** Which spreadsheet column was matched. Null = no match found. */
+  matchedColumn: string | null;
+  /** How the match was made (null if no match). */
+  matchMethod: MappingMethod | null;
+  /** Sample value from the first spreadsheet row (for UI preview). */
+  sampleValue: string | null;
+}
+
+/** Overall mapping result for a template + spreadsheet header set. */
+export interface TemplateMappingResult {
+  /** Entries for every template field (matched or unmatched). */
+  fields: FieldMappingEntry[];
+  /** Columns in the spreadsheet that did not map to any template field. */
+  unusedColumns: string[];
+  /** True if any required field has no matching column. */
+  hasRequiredUnmatched: boolean;
+  /** Template fields with required=true and no column match. */
+  unmatched_required: string[];
+}
+
+// ─── Image URL warning (must-have #4) ────────────────────────────────────────
+
+/**
+ * Warning recorded when an image layer URL fails to fetch during rendering.
+ * Written to image_generation_jobs.error_detail as JSON so the batch results
+ * UI can surface warnings without failing the whole job.
+ */
+export interface ImageLayerWarning {
+  layerName: string;
+  url: string;
+  reason: "fetch_failed" | "not_reachable" | "invalid_url" | "no_url";
+  httpStatus?: number;
+}
+
+/** Shape stored in image_generation_jobs.error_detail when job completes with warnings. */
+export interface JobCompletionWarnings {
+  imageLayerWarnings: ImageLayerWarning[];
+}

--- a/lib/image/template-field-mapper.ts
+++ b/lib/image/template-field-mapper.ts
@@ -1,0 +1,203 @@
+/**
+ * template-field-mapper — maps spreadsheet columns to template field modifications.
+ *
+ * Stream B §3.3 implementation. Given a template's /fields response and a set
+ * of spreadsheet column headers, produces:
+ *   1. A mapping report (TemplateMappingResult) for pre-dispatch preview UI.
+ *   2. A function to convert a spreadsheet row to a Modification[].
+ *
+ * Matching strategy (§3.3 confirmed):
+ *   1. Exact match on field.name (case-insensitive, trimmed)
+ *   2. Fallback: match on field.var.label (case-insensitive, trimmed)
+ *   3. Warn on unmatched columns; error only on missing required fields.
+ *
+ * Image layer handling (must-have #4):
+ *   A cell value for an image field is treated as a URL (image_url modification).
+ *   Pre-flight URL validation is a Phase 4 UI concern; this mapper produces the
+ *   Modification[] regardless. The QStash handler gracefully handles fetch
+ *   failures per-job (skips the layer, records ImageLayerWarning).
+ *
+ * No server-only import — safe in both client and server contexts.
+ */
+
+import type { Modification } from "@/lib/image/template-model";
+import type { TemplateField } from "@/lib/image/template-model";
+import type {
+  SpreadsheetRow,
+  TemplateMappingResult,
+  FieldMappingEntry,
+  MappingMethod,
+} from "@/lib/image/template-bulk-types";
+
+// ─── Column mapping ────────────────────────────────────────────────────────────
+
+/**
+ * Match template fields to spreadsheet columns.
+ * Returns a mapping result usable for the pre-dispatch confirmation UI and
+ * for generating modifications per row.
+ *
+ * @param fields   TemplateField[] from GET /templates/:id/fields
+ * @param headers  Column headers from the spreadsheet
+ * @param sampleRow Optional first data row for sample value display in UI
+ */
+export function mapFieldsToColumns(
+  fields: TemplateField[],
+  headers: string[],
+  sampleRow?: SpreadsheetRow,
+): TemplateMappingResult {
+  const usedColumns = new Set<string>();
+  const entries: FieldMappingEntry[] = [];
+  const unmatched_required: string[] = [];
+
+  for (const field of fields) {
+    const { matchedColumn, matchMethod } = findColumnMatch(field, headers);
+    if (matchedColumn) usedColumns.add(matchedColumn);
+
+    const sampleValue =
+      matchedColumn && sampleRow ? (sampleRow[matchedColumn] ?? null) : null;
+
+    const entry: FieldMappingEntry = {
+      fieldName: field.name,
+      fieldLabel: field.var.label,
+      fieldType: field.type as "text" | "image" | "rectangle",
+      required: field.var.required,
+      defaultValue: field.var.default ?? "",
+      matchedColumn,
+      matchMethod,
+      sampleValue,
+    };
+
+    if (field.var.required && !matchedColumn) {
+      unmatched_required.push(field.name);
+    }
+
+    entries.push(entry);
+  }
+
+  const unusedColumns = headers.filter(h => !usedColumns.has(h));
+
+  return {
+    fields: entries,
+    unusedColumns,
+    hasRequiredUnmatched: unmatched_required.length > 0,
+    unmatched_required,
+  };
+}
+
+/** Find the best-matching spreadsheet column for a template field. */
+function findColumnMatch(
+  field: TemplateField,
+  headers: string[],
+): { matchedColumn: string | null; matchMethod: MappingMethod | null } {
+  // Pass 1: exact name match (case-insensitive, trimmed)
+  const nameNorm = field.name.trim().toLowerCase();
+  const nameMatch = headers.find(h => h.trim().toLowerCase() === nameNorm);
+  if (nameMatch) return { matchedColumn: nameMatch, matchMethod: "name_exact" };
+
+  // Pass 2: label match (case-insensitive, trimmed)
+  const labelNorm = field.var.label.trim().toLowerCase();
+  if (labelNorm) {
+    const labelMatch = headers.find(h => h.trim().toLowerCase() === labelNorm);
+    if (labelMatch) return { matchedColumn: labelMatch, matchMethod: "label_match" };
+  }
+
+  return { matchedColumn: null, matchMethod: null };
+}
+
+// ─── Row → Modification[] conversion ─────────────────────────────────────────
+
+/**
+ * Convert a spreadsheet row to a Modification[] using a pre-computed mapping.
+ *
+ * Rules:
+ * - If the column has a non-empty value, use it.
+ * - If the column is empty/missing and the field has a default, use the default.
+ * - If neither, the field is omitted from modifications (layer keeps its
+ *   template default value).
+ * - Image fields: cell value is treated as image_url.
+ * - Text fields: cell value is treated as text.
+ * - Rectangle fields: cell value is treated as color (if valid hex/CSS).
+ *
+ * @param row       One spreadsheet data row (column name → string value)
+ * @param mapping   Pre-computed mapping from mapFieldsToColumns()
+ * @returns         Modification[] ready for renderTemplate()
+ */
+export function rowToModifications(
+  row: SpreadsheetRow,
+  mapping: TemplateMappingResult,
+): Modification[] {
+  const mods: Modification[] = [];
+
+  for (const entry of mapping.fields) {
+    const rawValue =
+      entry.matchedColumn ? (row[entry.matchedColumn] ?? "").trim() : "";
+    const value = rawValue || entry.defaultValue || "";
+
+    if (!value) continue; // no value, no default → skip (layer uses template default)
+
+    const mod = buildModification(entry.fieldName, entry.fieldType, value);
+    if (mod) mods.push(mod);
+  }
+
+  return mods;
+}
+
+function buildModification(
+  fieldName: string,
+  fieldType: "text" | "image" | "rectangle",
+  value: string,
+): Modification | null {
+  switch (fieldType) {
+    case "text":
+      return { name: fieldName, text: value };
+
+    case "image":
+      // Image field: cell value is an image URL (must-have #4).
+      // The renderer fetches the URL at render time. Invalid URLs
+      // are handled gracefully (layer skipped, warning recorded).
+      if (!value.startsWith("http://") && !value.startsWith("https://")) {
+        // Not a URL — skip. Mapper callers should warn on this.
+        return null;
+      }
+      return { name: fieldName, image_url: value };
+
+    case "rectangle":
+      // Rectangle field: cell value interpreted as a fill color override.
+      return { name: fieldName, color: value };
+
+    default:
+      return null;
+  }
+}
+
+// ─── Validation helpers (for Phase 2/4 pre-dispatch checks) ─────────────────
+
+/**
+ * Check whether a mapping result is safe to dispatch.
+ * Returns { ok: true } or { ok: false, reason } for each blocking issue.
+ */
+export function validateMapping(
+  mapping: TemplateMappingResult,
+): { ok: true } | { ok: false; reason: string } {
+  if (mapping.hasRequiredUnmatched) {
+    return {
+      ok: false,
+      reason: `Required fields have no matching column: ${mapping.unmatched_required.join(", ")}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Quick check: is a string a plausible image URL?
+ * Used for pre-flight validation in Phase 4 UI (not enforced at mapper level).
+ */
+export function isImageUrl(value: string): boolean {
+  if (!value) return false;
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/lib/image/templates/index.ts
+++ b/lib/image/templates/index.ts
@@ -219,6 +219,36 @@ export async function update_template(opts: {
 }
 
 /**
+ * Get a template by its primary key UUID.
+ * Used by the Stream B QStash handler to fetch the template for rendering
+ * without knowing the aspect ratio or name in advance.
+ *
+ * Resolution: company-scoped templates override globals (same as get_template).
+ * Returns null when the template does not exist or is not visible to the company.
+ */
+export async function get_template_by_id(
+  templateId: string,
+  companyId: string,
+): Promise<ImageTemplate | null> {
+  const svc = getServiceRoleClient();
+
+  const { data, error } = await svc
+    .from("image_templates")
+    .select("*")
+    .eq("id", templateId)
+    .eq("is_active", true)
+    .or(`company_id.eq.${companyId},company_id.is.null`)
+    .maybeSingle();
+
+  if (error) {
+    logger.error("image.templates.get_by_id_failed", { templateId, companyId, error: error.message });
+    return null;
+  }
+
+  return data ? toTemplate(data as TemplateRow) : null;
+}
+
+/**
  * Create a new template (company-scoped or global).
  * Admins create company-scoped; Opollo staff create globals (company_id null).
  *


### PR DESCRIPTION
## Summary

Stream B Phase 1 foundation — everything needed to dispatch and execute template-based bulk image generation jobs via the existing QStash pipeline.

- **template-bulk-types.ts** — shared types: `TemplateJobSpec`, `TemplateMappingResult`, `FieldMappingEntry`, `ImageLayerWarning`, `JobCompletionWarnings`
- **template-field-mapper.ts** — column mapper: name-exact → label-match fallback, `rowToModifications()`, `validateMapping()`, `isImageUrl()`
- **templates/index.ts** — added `get_template_by_id(templateId, companyId)`
- **dispatch.ts** — `DispatchInput.jobs` accepts `DispatchJobSpec | TemplateJobSpec` union; dispatch loop routes template jobs by checking `spec.jobType === "template"`
- **qstash-handler/route.ts**:
  - Unified `BodySchema` (`z.record(z.string(), z.unknown())` for `generationParams` to accept both JSONB shapes)
  - `isTemplateJob` detection: checks `body.jobType` OR `generationParams.jobType` (covers DB re-read path)
  - `handleTemplateJob()` — `get_template_by_id → compositeImage({ schema_version: 2 }) → mark completed`; `finally { releaseImageLease }` — **identical** lease/retry/budget/failure semantics to the Ideogram path

## Tests

35 new unit tests across 3 files; full 3031-test suite passes.

| File | Tests | Coverage |
|---|---|---|
| `image-template-field-mapper.unit.test.ts` | 17 | exact-name match, label-match, unmatched required, sample values, text/image/rect modifications, isImageUrl |
| `image-qstash-template-fork.unit.test.ts` | 9 | jobType detection, compositeImage args, template-not-found → 500, compositeImage throws → 500, lease released in success + failure paths, Ideogram path unaffected |
| `image-template-render-modifications.unit.test.ts` | 9 | applyModifications: text/image/rect overrides, unmatched layers, last-write-wins, order preserved, golden determinism |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer 1 (unit) tests run: `test:unit` — 3031 pass
- [x] Contract snapshots reviewed (no SDK boundary changes)
- [x] Cross-tenant test added (not applicable — no new tenant-scoped resource)
- [x] Probe script updated (not applicable — QStash handler is internal, no new external SDK boundary)
- [x] Working analog: `handleTemplateJob` matches the Ideogram try/catch/finally structure exactly (lines 239–334 in the same file)
- [x] PR is under 500 net lines: ~1180 lines total, of which ~800 are new test files

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Template job lease not released on failure | `finally { releaseImageLease(jobId) }` block in `handleTemplateJob` — verified by unit test |
| Ideogram path broken by BodySchema change | `generationParams as unknown as GenerationParams` double-cast throughout; Ideogram test in fork suite confirms `get_template_by_id` not called on non-template jobs |
| Dispatch stores TemplateJobSpec as JSONB; QStash re-reads it | Both `body.jobType` and `generationParams.jobType` detection paths covered by unit tests |
| PostgREST embed/batch insert pattern (known per memory) | `get_template_by_id` uses single `.maybeSingle()` — no batch insert, no multi-FK embed |
| v1 templates returned for template jobs | Guard: `if (!tmpl?.resolvedTemplate)` throws → 500 for any non-schema_version=2 template |