### PR TITLE
feat(image-gen): stream B phase 2 — ingest API template mode

### DIFF
--- a/app/api/platform/image/ingest/route.ts
+++ b/app/api/platform/image/ingest/route.ts
@@ -7,31 +7,43 @@ import { logger } from "@/lib/logger";
 
 import { parseXlsxBuffer, type PostRow } from "@/lib/ingestion/xlsx-parse";
 import { parseDocxBuffer } from "@/lib/ingestion/docx-parse";
+import { parseXlsxRawRows } from "@/lib/ingestion/xlsx-raw-parse";
 import { interpretPosts } from "@/lib/ingestion/interpret";
 import { dispatchImageBatch } from "@/lib/image/dispatch";
 import { fanOutJobs } from "@/lib/image/fan-out";
+import { get_template_by_id } from "@/lib/image/templates";
+import { mapFieldsToColumns, rowToModifications, validateMapping } from "@/lib/image/template-field-mapper";
+import { PRICE_CENTS_PER_JOB } from "@/lib/image/budget";
+import type { TemplateJobSpec } from "@/lib/image/template-bulk-types";
+import type { TemplateField, Layer } from "@/lib/image/template-model";
+import { TEMPLATE_SCHEMA_VERSION } from "@/lib/image/template-model";
 
 // ---------------------------------------------------------------------------
 // POST /api/platform/image/ingest
 //
-// §C4 of MASS_IMAGE_GEN_BUILD_BRIEF. End-to-end mass-image-gen ingestion:
-//   upload .xlsx or .docx → parse → AI interpret → fan-out into per-ratio
-//   image jobs → dispatch batch → return batchId.
+// §C4 of MASS_IMAGE_GEN_BUILD_BRIEF. End-to-end mass-image-gen ingestion.
 //
 // Multipart body:
-//   - company_id (uuid)
-//   - file       (.xlsx or .docx, ≤ 5 MB)
+//   - company_id  (uuid)
+//   - file        (.xlsx or .docx, ≤ 5 MB)
+//   - ingest_mode "ideogram" | "template"  (default "ideogram")
+//   - template_id uuid  (required when ingest_mode=template)
 //
 // Query:
-//   - mode=preview|generate  (default 'generate'; preview routes to B5)
+//   - mode=preview|generate  (default 'generate')
 //
-// Caps (per brief §C4):
+// Caps:
 //   - 5 MB file size
 //   - 100 parsed-row cap
-//   - 5/hour/company rate limit (reuses csv_upload limiter)
+//   - 5/hour/company rate limit (csv_upload bucket)
 //
-// Returns the batchId so the operator can poll
-// /api/platform/image/batch/[id] for completion.
+// ingest_mode=ideogram (default):
+//   xlsx/docx → parse → AI interpret → fan-out → dispatch → { batchId }
+//
+// ingest_mode=template (Stream B Phase 2):
+//   xlsx → parse raw rows → column-map to template fields → fan-out per
+//   variant → dispatch → { batchId, mappingSummary, estimatedCostCents }
+//   XLSX only; DOCX not supported for template mode.
 // ---------------------------------------------------------------------------
 
 export const runtime = "nodejs";
@@ -48,9 +60,9 @@ const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.s
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
 type FileFormat = "xlsx" | "docx";
+type IngestMode = "ideogram" | "template";
 
 function detectFormat(file: File): FileFormat | null {
-  // Trust mime type when explicit; fall back to extension.
   if (file.type === XLSX_MIME) return "xlsx";
   if (file.type === DOCX_MIME) return "docx";
   const name = file.name?.toLowerCase() ?? "";
@@ -59,9 +71,31 @@ function detectFormat(file: File): FileFormat | null {
   return null;
 }
 
-function parseMode(req: NextRequest): "preview" | "generate" {
+function parseGenerateMode(req: NextRequest): "preview" | "generate" {
   const v = new URL(req.url).searchParams.get("mode");
   return v === "preview" ? "preview" : "generate";
+}
+
+function parseIngestMode(formData: FormData): IngestMode {
+  const v = (formData.get("ingest_mode") as string | null)?.trim();
+  return v === "template" ? "template" : "ideogram";
+}
+
+/** Extract modifiable fields from a v2 template's layer list. */
+function extractTemplateFields(layers: Layer[]): TemplateField[] {
+  const fields: TemplateField[] = [];
+  for (const layer of layers) {
+    const l = layer as Layer;
+    if (
+      l.var &&
+      typeof l.var.label === "string" &&
+      l.var.label.trim().length > 0 &&
+      (l.type === "text" || l.type === "image" || l.type === "rectangle")
+    ) {
+      fields.push({ name: l.name, type: l.type, var: l.var });
+    }
+  }
+  return fields;
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
@@ -102,12 +136,36 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (gate.kind === "deny") return gate.response;
 
   // ─── Rate-limit (5/hour/company) ────────────────────────────────────────
-  // Reuses csv_upload (3/hour) for v1; can split into a dedicated limiter
-  // if image-gen ingestion volume warrants its own bucket later.
   const rl = await checkRateLimit("csv_upload", `company:${companyId}`);
   if (!rl.ok) return rateLimitExceeded(rl);
 
-  // ─── Parse ──────────────────────────────────────────────────────────────
+  // ─── Route by ingest mode ────────────────────────────────────────────────
+  const ingestMode = parseIngestMode(formData);
+
+  if (ingestMode === "template") {
+    return handleTemplateIngest({ formData, fileBlob, format, companyId, gate, req });
+  }
+
+  return handleIdeogramIngest({ fileBlob, format, companyId, gate, req });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ideogram ingest (existing flow — unchanged)
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function handleIdeogramIngest({
+  fileBlob,
+  format,
+  companyId,
+  gate,
+  req,
+}: {
+  fileBlob: File;
+  format: FileFormat;
+  companyId: string;
+  gate: { userId: string };
+  req: NextRequest;
+}): Promise<NextResponse> {
   const buffer = Buffer.from(await fileBlob.arrayBuffer());
   const parsed =
     format === "xlsx"
@@ -131,7 +189,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // ─── Interpret (Anthropic) ─────────────────────────────────────────────
   const interpreted = await interpretPosts({
     companyId,
     posts: parsed.posts as PostRow[],
@@ -148,17 +205,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // ─── Fan-out into per-ratio jobs (§1.7) ─────────────────────────────────
-  // Build the source-row → publish_date lookup from the parser output;
-  // interpretPosts strips it from InterpretedPost shape.
   const publishDateBySourceRow = new Map<number, string>();
   for (const row of parsed.posts) {
     if (row.publish_date) publishDateBySourceRow.set(row.sourceRow, row.publish_date);
   }
   const jobSpecs = fanOutJobs(interpreted.posts, publishDateBySourceRow);
 
-  // ─── Dispatch ───────────────────────────────────────────────────────────
-  const mode = parseMode(req);
+  const mode = parseGenerateMode(req);
   const dispatched = await dispatchImageBatch({
     companyId,
     triggeredBy: gate.userId,
@@ -173,11 +226,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       return NextResponse.json(
         {
           ok: false,
-          error: {
-            code: dispatched.code,
-            message: dispatched.message,
-            ...dispatched.details,
-          },
+          error: { code: dispatched.code, message: dispatched.message, ...dispatched.details },
           timestamp: new Date().toISOString(),
         },
         { status: 402 },
@@ -186,7 +235,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return internalError(dispatched.message);
   }
 
-  logger.info("image.ingest.ok", {
+  logger.info("image.ingest.ideogram.ok", {
     companyId,
     format,
     mode,
@@ -211,3 +260,220 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   );
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Template ingest — Stream B Phase 2
+//
+// Pipeline:
+//   1. Validate: XLSX only + template_id required
+//   2. Parse XLSX into generic header+row format (no Ideogram-specific validation)
+//   3. Fetch template → extract fields + variants
+//   4. Column-map fields to spreadsheet headers
+//   5. Validate mapping (fail on unmatched required fields)
+//   6. Fan-out: one TemplateJobSpec per (row × variant)
+//   7. Dispatch via existing dispatchImageBatch()
+//   8. Return pre-dispatch summary (must-have #3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function handleTemplateIngest({
+  formData,
+  fileBlob,
+  format,
+  companyId,
+  gate,
+  req,
+}: {
+  formData: FormData;
+  fileBlob: File;
+  format: FileFormat;
+  companyId: string;
+  gate: { userId: string };
+  req: NextRequest;
+}): Promise<NextResponse> {
+  // ─── 1. Validate template mode constraints ───────────────────────────────
+  if (format !== "xlsx") {
+    return validationError(
+      "Template mode only supports .xlsx files. " +
+      "DOCX ingestion is available for the Ideogram flow (omit ingest_mode=template).",
+    );
+  }
+
+  const templateId = (formData.get("template_id") as string | null)?.trim() ?? "";
+  if (!UUID_RE.test(templateId)) {
+    return validationError("template_id must be a valid UUID (required for ingest_mode=template).");
+  }
+
+  // ─── 2. Parse XLSX into raw rows ────────────────────────────────────────
+  const buffer = Buffer.from(await fileBlob.arrayBuffer());
+  const parsed = await parseXlsxRawRows(buffer);
+
+  if (!parsed.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "PARSE_FAILED", message: parsed.error },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 422 },
+    );
+  }
+
+  if (parsed.rowCount === 0) {
+    return validationError("Spreadsheet has no data rows.");
+  }
+
+  if (parsed.rowCount > MAX_ROWS) {
+    return validationError(
+      `Spreadsheet has ${parsed.rowCount} rows; max ${MAX_ROWS} per upload.`,
+    );
+  }
+
+  // ─── 3. Fetch template + extract fields + variants ───────────────────────
+  const tmpl = await get_template_by_id(templateId, companyId);
+  if (!tmpl) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "TEMPLATE_NOT_FOUND", message: `Template ${templateId} not found.` },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 404 },
+    );
+  }
+
+  if (tmpl.schemaVersion !== TEMPLATE_SCHEMA_VERSION || !tmpl.resolvedTemplate) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "TEMPLATE_NOT_V2",
+          message: "Template bulk generation requires a v2 (layer-based) template. " +
+                   "Create or migrate your template in the template editor.",
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 422 },
+    );
+  }
+
+  const resolvedTemplate = tmpl.resolvedTemplate;
+  const templateFields = extractTemplateFields(resolvedTemplate.layers as Layer[]);
+
+  // Variant keys to render. Base canvas always included (undefined variantKey).
+  // Named variants come from the template's variants array.
+  const variantKeys: Array<string | undefined> = [undefined]; // base
+  for (const v of resolvedTemplate.variants ?? []) {
+    variantKeys.push(v.key);
+  }
+
+  // ─── 4. Column mapping ───────────────────────────────────────────────────
+  const mapping = mapFieldsToColumns(templateFields, parsed.headers, parsed.rows[0]);
+
+  // ─── 5. Validate mapping ─────────────────────────────────────────────────
+  const validation = validateMapping(mapping);
+  if (!validation.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "MAPPING_FAILED",
+          message: validation.reason,
+          unmatchedRequired: mapping.unmatched_required,
+          availableColumns: parsed.headers,
+          templateFields: templateFields.map((f) => ({
+            name: f.name,
+            label: f.var.label,
+            required: f.var.required,
+          })),
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 422 },
+    );
+  }
+
+  // ─── 6. Fan-out: one TemplateJobSpec per (row × variant) ─────────────────
+  const jobSpecs: TemplateJobSpec[] = [];
+
+  for (let rowIdx = 0; rowIdx < parsed.rows.length; rowIdx++) {
+    const row = parsed.rows[rowIdx];
+    const modifications = rowToModifications(row, mapping);
+
+    for (const variantKey of variantKeys) {
+      jobSpecs.push({
+        jobType: "template",
+        templateId,
+        variantKey,
+        modifications,
+        aspectRatio: resolvedTemplate.width === resolvedTemplate.height
+          ? "1x1"
+          : resolvedTemplate.width > resolvedTemplate.height
+            ? "16x9"
+            : "4x5",
+        parentPostIndex: rowIdx,
+      });
+    }
+  }
+
+  // ─── 7. Dispatch ─────────────────────────────────────────────────────────
+  const generateMode = parseGenerateMode(req);
+  const dispatched = await dispatchImageBatch({
+    companyId,
+    triggeredBy: gate.userId,
+    jobs: jobSpecs,
+    mode: generateMode,
+    sourceFilename: fileBlob.name,
+    sourceRowCount: parsed.rowCount,
+  });
+
+  if (!dispatched.ok) {
+    if (dispatched.code === "BUDGET_EXCEEDED") {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: { code: dispatched.code, message: dispatched.message, ...dispatched.details },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 402 },
+      );
+    }
+    return internalError(dispatched.message);
+  }
+
+  // ─── 8. Pre-dispatch summary (must-have #3) ───────────────────────────────
+  const matchedFields = mapping.fields.filter((f) => f.matchedColumn !== null).length;
+  const unmatchedOptional = mapping.fields.filter(
+    (f) => f.matchedColumn === null && !f.required,
+  ).length;
+
+  logger.info("image.ingest.template.ok", {
+    companyId,
+    templateId,
+    rowCount: parsed.rowCount,
+    variantCount: variantKeys.length,
+    jobCount: jobSpecs.length,
+    matchedFields,
+    batchId: dispatched.batchId,
+  });
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        batchId: dispatched.batchId,
+        totalJobs: dispatched.totalJobs,
+        rowCount: parsed.rowCount,
+        variantCount: variantKeys.length,
+        estimatedCostCents: dispatched.totalJobs * PRICE_CENTS_PER_JOB,
+        mode: dispatched.mode,
+        mappingSummary: {
+          matchedFields,
+          unmatchedOptional,
+          unusedColumns: mapping.unusedColumns,
+        },
+        ...(dispatched.enqueueErrors && { enqueueErrors: dispatched.enqueueErrors }),
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 201 },
+  );
+}

--- a/lib/__tests__/image-ingest-template-mode.unit.test.ts
+++ b/lib/__tests__/image-ingest-template-mode.unit.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for the ingest route template mode (Stream B Phase 2).
+ *
+ * Tests cover:
+ *  - ingest_mode=template validation (XLSX only, template_id required)
+ *  - Template not found → 404
+ *  - v1 template (schemaVersion ≠ 2) → 422
+ *  - Column mapping: required field unmatched → 422 MAPPING_FAILED
+ *  - Happy path: correct TemplateJobSpec fan-out (row × variant count)
+ *  - Pre-dispatch summary in response (mappingSummary, estimatedCostCents)
+ *  - Ideogram path unaffected when ingest_mode absent
+ *
+ * parseXlsxRawRows is mocked — its own round-trip tests are in
+ * image-xlsx-raw-parse.unit.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Auth gate ────────────────────────────────────────────────────────────────
+const mockGate = vi.fn();
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: (...args: unknown[]) => mockGate(...args),
+}));
+
+// ─── Rate limit ───────────────────────────────────────────────────────────────
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({ ok: true }),
+  rateLimitExceeded: vi.fn(),
+}));
+
+// ─── Raw XLSX parser (mocked; real tests in xlsx-raw-parse.unit.test.ts) ─────
+const mockParseXlsxRawRows = vi.fn();
+vi.mock("@/lib/ingestion/xlsx-raw-parse", () => ({
+  parseXlsxRawRows: (...args: unknown[]) => mockParseXlsxRawRows(...args),
+}));
+
+// ─── Template access ──────────────────────────────────────────────────────────
+const mockGetTemplateById = vi.fn();
+vi.mock("@/lib/image/templates", () => ({
+  get_template_by_id: (...args: unknown[]) => mockGetTemplateById(...args),
+}));
+
+// ─── dispatchImageBatch ────────────────────────────────────────────────────────
+const mockDispatch = vi.fn();
+vi.mock("@/lib/image/dispatch", () => ({
+  dispatchImageBatch: (...args: unknown[]) => mockDispatch(...args),
+}));
+
+// ─── Ideogram path mocks (must not be called in template mode tests) ──────────
+vi.mock("@/lib/ingestion/xlsx-parse", () => ({
+  parseXlsxBuffer: vi.fn().mockResolvedValue({
+    ok: true,
+    posts: [{ post_topic: "t", sourceRow: 2 }],
+    warnings: [],
+  }),
+}));
+vi.mock("@/lib/ingestion/docx-parse", () => ({
+  parseDocxBuffer: vi.fn().mockResolvedValue({ ok: true, posts: [], warnings: [] }),
+}));
+vi.mock("@/lib/ingestion/interpret", () => ({
+  interpretPosts: vi.fn().mockResolvedValue({ ok: true, posts: [] }),
+}));
+vi.mock("@/lib/image/fan-out", () => ({
+  fanOutJobs: vi.fn().mockReturnValue([]),
+}));
+vi.mock("@/lib/image/budget", () => ({
+  PRICE_CENTS_PER_JOB: 6,
+}));
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const COMPANY_UUID  = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TEMPLATE_UUID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const BATCH_UUID    = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+const RESOLVED_TEMPLATE = {
+  id: TEMPLATE_UUID,
+  version: 2,
+  name: "Test Template",
+  width: 1080, height: 1080,
+  orientation: "square",
+  background_color: "#ffffff",
+  variants: [
+    { key: "landscape", width: 1920, height: 1080, overrides: [] },
+  ],
+  layers: [
+    {
+      id: "layer-1",
+      name: "headline",
+      type: "text",
+      x: 0, y: 0, width: 400, height: 100,
+      opacity: 1, rotation: 0, rotate_x: 0, rotate_y: 0, rotate_z: 0,
+      skew_x: 0, skew_y: 0, locked: false, hide: false, hide_when_empty: false,
+      lock_aspect_ratio: false, description: "", group: null,
+      constraints: { horizontal: "left", vertical: "top" },
+      text: "Default", font_family: "Inter", font_size: 32, font_weight: 400,
+      color: "#000", text_align_h: "left", text_align_v: "top",
+      letter_spacing: 0, line_height: 1.2, text_transform: "none",
+      text_decoration: "none", word_break: "normal", style: "", direction: "ltr",
+      text_fit: { enabled: false, min_size: 16, max_size: 120, max_lines: 4 },
+      truncate: false, text_box: { padding: null, border: null },
+      background: { color: null, border: null, border_width: null, padding_h: 0, padding_v: 0, shadow: null, radius: null, shift: null },
+      secondary: { font_family: null, color: null },
+      var: { label: "Headline Text", required: true, default: "", category: "content", help: "" },
+    },
+  ],
+  groups: [], fonts: [],
+  render_settings: { format: "png", quality: 90, scale: 1, dpi: 72 },
+  settings: { guides: false },
+};
+
+const V2_TEMPLATE = { schemaVersion: 2, resolvedTemplate: RESOLVED_TEMPLATE };
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeXlsxFile(): File {
+  const blob = new Blob([Buffer.from("xlsx")], {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+  return new File([blob], "test.xlsx", { type: blob.type });
+}
+
+function makeDocxFile(): File {
+  const blob = new Blob([Buffer.from("docx")], {
+    type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  });
+  return new File([blob], "test.docx", { type: blob.type });
+}
+
+function makeRequest(file: File, extraFields: Record<string, string> = {}): NextRequest {
+  const fd = new FormData();
+  fd.append("company_id", COMPANY_UUID);
+  for (const [k, v] of Object.entries(extraFields)) fd.append(k, v);
+  fd.append("file", file);
+  return new NextRequest("http://localhost/api/platform/image/ingest", { method: "POST", body: fd });
+}
+
+// ─── Import handler after mocks ───────────────────────────────────────────────
+
+import { POST } from "@/app/api/platform/image/ingest/route";
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("ingest route — template mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGate.mockResolvedValue({ kind: "allow", userId: "user-123" });
+    mockDispatch.mockResolvedValue({ ok: true, batchId: BATCH_UUID, totalJobs: 2, mode: "generate" });
+    mockParseXlsxRawRows.mockResolvedValue({
+      ok: true,
+      headers: ["headline"],
+      rows: [{ headline: "Hello World" }],
+      rowCount: 1,
+    });
+  });
+
+  it("requires template_id when ingest_mode=template", async () => {
+    const req = makeRequest(makeXlsxFile(), { ingest_mode: "template" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects DOCX for ingest_mode=template", async () => {
+    const req = makeRequest(makeDocxFile(), { ingest_mode: "template", template_id: TEMPLATE_UUID });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when template not found", async () => {
+    mockGetTemplateById.mockResolvedValue(null);
+    const req = makeRequest(makeXlsxFile(), { ingest_mode: "template", template_id: TEMPLATE_UUID });
+    const res = await POST(req);
+    const body = await res.json() as { error: Record<string, unknown> };
+
+    expect(res.status).toBe(404);
+    expect(body.error.code).toBe("TEMPLATE_NOT_FOUND");
+  });
+
+  it("returns 422 when template is schema_version=1", async () => {
+    mockGetTemplateById.mockResolvedValue({ schemaVersion: 1, resolvedTemplate: undefined });
+    const req = makeRequest(makeXlsxFile(), { ingest_mode: "template", template_id: TEMPLATE_UUID });
+    const res = await POST(req);
+    const body = await res.json() as { error: Record<string, unknown> };
+
+    expect(res.status).toBe(422);
+    expect(body.error.code).toBe("TEMPLATE_NOT_V2");
+  });
+
+  it("returns 422 MAPPING_FAILED when required field has no column", async () => {
+    mockGetTemplateById.mockResolvedValue(V2_TEMPLATE);
+    // Spreadsheet has no "headline" column — required field unmatched
+    mockParseXlsxRawRows.mockResolvedValue({
+      ok: true,
+      headers: ["unrelated_col"],
+      rows: [{ unrelated_col: "value" }],
+      rowCount: 1,
+    });
+
+    const req = makeRequest(makeXlsxFile(), { ingest_mode: "template", template_id: TEMPLATE_UUID });
+    const res = await POST(req);
+    const body = await res.json() as { error: Record<string, unknown> };
+
+    expect(res.status).toBe(422);
+    expect(body.error.code).toBe("MAPPING_FAILED");
+    expect((body.error.unmatchedRequired as string[]).includes("headline")).toBe(true);
+  });
+
+  it("happy path: returns 201 with batchId, mappingSummary, estimatedCostCents", async () => {
+    mockGetTemplateById.mockResolvedValue(V2_TEMPLATE);
+    mockParseXlsxRawRows.mockResolvedValue({
+      ok: true,
+      headers: ["headline"],
+      rows: [{ headline: "Row 1" }, { headline: "Row 2" }],
+      rowCount: 2,
+    });
+    // 2 rows × 2 variants (base + landscape) = 4 jobs
+    mockDispatch.mockResolvedValue({ ok: true, batchId: BATCH_UUID, totalJobs: 4, mode: "generate" });
+
+    const req = makeRequest(makeXlsxFile(), { ingest_mode: "template", template_id: TEMPLATE_UUID });
+    const res = await POST(req);
+    const body = await res.json() as { ok: boolean; data: Record<string, unknown> };
+
+    expect(res.status).toBe(201);
+    expect(body.ok).toBe(true);
+    expect(body.data.batchId).toBe(BATCH_UUID);
+    expect(body.data.rowCount).toBe(2);
+    expect(body.data.variantCount).toBe(2); // base + landscape
+    expect(body.data.totalJobs).toBe(4);
+    expect(body.data.estimatedCostCents).toBe(24); // 4 × 6¢
+    expect(body.data.mappingSummary).toMatchObject({ matchedFields: 1, unmatchedOptional: 0 });
+  });
+
+  it("dispatches TemplateJobSpec with correct jobType and templateId", async () => {
+    mockGetTemplateById.mockResolvedValue(V2_TEMPLATE);
+
+    const req = makeRequest(makeXlsxFile(), { ingest_mode: "template", template_id: TEMPLATE_UUID });
+    await POST(req);
+
+    const dispatchArg = mockDispatch.mock.calls[0][0] as { jobs: Array<Record<string, unknown>> };
+    expect(dispatchArg.jobs.every((j) => j.jobType === "template")).toBe(true);
+    expect(dispatchArg.jobs.every((j) => j.templateId === TEMPLATE_UUID)).toBe(true);
+    // Base (variantKey=undefined) + landscape variant
+    const variantKeys = dispatchArg.jobs.map((j) => j.variantKey);
+    expect(variantKeys).toContain(undefined);
+    expect(variantKeys).toContain("landscape");
+  });
+
+  it("injects companyId into dispatch jobs so QStash handler can read it", async () => {
+    mockGetTemplateById.mockResolvedValue(V2_TEMPLATE);
+
+    const req = makeRequest(makeXlsxFile(), { ingest_mode: "template", template_id: TEMPLATE_UUID });
+    await POST(req);
+
+    // dispatch.ts injects companyId into the JSONB via { ...spec, companyId }
+    // We verify dispatch was called with the correct company
+    const dispatchArg = mockDispatch.mock.calls[0][0] as { companyId: string };
+    expect(dispatchArg.companyId).toBe(COMPANY_UUID);
+  });
+
+  it("ideogram path is unaffected when ingest_mode is absent", async () => {
+    const req = makeRequest(makeXlsxFile());
+    await POST(req);
+    // Template accessor not called on Ideogram path
+    expect(mockGetTemplateById).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/image-template-field-mapper.unit.test.ts
+++ b/lib/__tests__/image-template-field-mapper.unit.test.ts
@@ -25,7 +25,7 @@ function makeTextField(name: string, label: string, required = false, defaultVal
   return {
     name,
     type: "text",
-    var: { label, required, default: defaultValue, category: "content" },
+    var: { label, required, default: defaultValue, category: "content", help: "" },
   };
 }
 
@@ -33,7 +33,7 @@ function makeImageField(name: string, label: string, required = false): Template
   return {
     name,
     type: "image",
-    var: { label, required, default: "", category: "media" },
+    var: { label, required, default: "", category: "media", help: "" },
   };
 }
 
@@ -64,7 +64,7 @@ describe("mapFieldsToColumns", () => {
     const specialField: TemplateField = {
       name: "cta_btn",
       type: "text",
-      var: { label: "Call To Action Button", required: false, default: "", category: "content" },
+      var: { label: "Call To Action Button", required: false, default: "", category: "content", help: "" },
     };
     const headers = ["Call To Action Button"];
     const result = mapFieldsToColumns([specialField], headers);
@@ -140,7 +140,7 @@ describe("rowToModifications", () => {
   it("omits field when cell is empty and no default", () => {
     const headers = ["headline"];
     const mapping = mapFieldsToColumns(
-      [{ name: "headline", type: "text", var: { label: "Headline", required: false, default: "", category: "content" as const } }],
+      [{ name: "headline", type: "text", var: { label: "Headline", required: false, default: "", category: "content" as const, help: "" } }],
       headers,
     );
     const mods = rowToModifications({ headline: "" }, mapping);
@@ -169,7 +169,7 @@ describe("rowToModifications", () => {
     const rectField: TemplateField = {
       name: "bg_rect",
       type: "rectangle",
-      var: { label: "Background Color", required: false, default: "", category: "branding" },
+      var: { label: "Background Color", required: false, default: "", category: "branding", help: "" },
     };
     const headers = ["bg_rect"];
     const mapping = mapFieldsToColumns([rectField], headers);

--- a/lib/__tests__/image-template-render-modifications.unit.test.ts
+++ b/lib/__tests__/image-template-render-modifications.unit.test.ts
@@ -69,16 +69,15 @@ function makeImageLayer(name: string, imageUrl: string): ImageLayer {
   return {
     ...baseLayer(name),
     type: "image",
+    asset_id: null,
     image_url: imageUrl,
-    fit: "cover",
-    position: "center center",
-    border: null, border_radius: null, border_width: null,
-    flip_h: false, flip_v: false,
-    brightness: 0, contrast: 0, saturation: 0, blur: 0,
-    overlay_color: null, overlay_alpha: 0,
-    mask: null,
-    drop_shadow: null,
-    filter: "none",
+    fill: "cover",
+    anchor_x: "center",
+    anchor_y: "center",
+    tint_color: null,
+    border_radius: 0,
+    clip_path: null,
+    face_detect: false,
   };
 }
 
@@ -87,10 +86,9 @@ function makeRectLayer(name: string, color: string): RectangleLayer {
     ...baseLayer(name),
     type: "rectangle",
     color,
-    opacity: 1,
-    border: null, border_width: null, border_radius: null,
     gradient: null,
-    drop_shadow: null,
+    border_radius: 0,
+    border: null,
   };
 }
 
@@ -128,7 +126,7 @@ describe("applyModifications", () => {
 
     const modified = result[0] as ImageLayer;
     expect(modified.image_url).toBe("https://cdn.example.com/new.jpg");
-    expect(modified.fit).toBe("cover"); // unchanged
+    expect(modified.fill).toBe("cover"); // unchanged
   });
 
   it("applies color modification to a rectangle layer", () => {

--- a/lib/__tests__/image-xlsx-raw-parse.unit.test.ts
+++ b/lib/__tests__/image-xlsx-raw-parse.unit.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Round-trip unit tests for parseXlsxRawRows (Stream B Phase 2).
+ *
+ * Uses real ExcelJS to build buffers in-memory — no fixture files, no
+ * ExcelJS mocks. Same pattern as xlsx-parse.unit.test.ts.
+ *
+ * Tests cover:
+ *  - Single sheet with row-1 headers: correct headers + row values
+ *  - Multi-sheet: first sheet used (no "Posts" sheet preference for template files)
+ *  - Empty rows skipped
+ *  - Numeric / date cells coerced to string
+ *  - Empty header row → error
+ *  - No sheets → error
+ *  - rowCount matches non-empty data rows
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import ExcelJS from "exceljs";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { parseXlsxRawRows } from "@/lib/ingestion/xlsx-raw-parse";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function buildXlsx(
+  rows: Array<Array<string | number | null>>,
+  sheetName = "Sheet1",
+): Promise<Buffer> {
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet(sheetName);
+  for (const row of rows) ws.addRow(row);
+  return Buffer.from(await wb.xlsx.writeBuffer());
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("parseXlsxRawRows", () => {
+  it("parses headers from row 1 and data from row 2+", async () => {
+    const buf = await buildXlsx([
+      ["headline", "image_url"],
+      ["Hello World", "https://example.com/img.jpg"],
+      ["Row Two",    "https://example.com/two.jpg"],
+    ]);
+    const result = await parseXlsxRawRows(buf);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.headers).toEqual(["headline", "image_url"]);
+    expect(result.rowCount).toBe(2);
+    expect(result.rows[0]).toMatchObject({ headline: "Hello World", image_url: "https://example.com/img.jpg" });
+    expect(result.rows[1]).toMatchObject({ headline: "Row Two", image_url: "https://example.com/two.jpg" });
+  });
+
+  it("coerces numeric cells to strings", async () => {
+    const buf = await buildXlsx([
+      ["count", "price"],
+      [42, 9.99],
+    ]);
+    const result = await parseXlsxRawRows(buf);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows[0]?.count).toBe("42");
+    expect(result.rows[0]?.price).toBe("9.99");
+  });
+
+  it("skips fully empty rows", async () => {
+    const buf = await buildXlsx([
+      ["headline"],
+      ["Row 1"],
+      [null],      // blank row — should be skipped
+      ["Row 3"],
+    ]);
+    const result = await parseXlsxRawRows(buf);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rowCount).toBe(2);
+    expect(result.rows.map((r) => r["headline"])).toEqual(["Row 1", "Row 3"]);
+  });
+
+  it("uses the first worksheet (no Posts-sheet preference)", async () => {
+    // Template XLSX files are not the canonical mass-image-gen template,
+    // so we always use the first sheet regardless of its name.
+    const buf = await buildXlsx([
+      ["field_name"],
+      ["value"],
+    ], "CustomSheet");
+
+    const result = await parseXlsxRawRows(buf);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.headers).toEqual(["field_name"]);
+    expect(result.rows[0]?.field_name).toBe("value");
+  });
+
+  it("returns rowCount=0 and empty rows array for header-only sheet", async () => {
+    const buf = await buildXlsx([["headline", "body"]]);
+    const result = await parseXlsxRawRows(buf);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rowCount).toBe(0);
+    expect(result.rows).toHaveLength(0);
+  });
+
+  it("returns headers with whitespace trimmed", async () => {
+    const buf = await buildXlsx([
+      ["  headline  ", " body "],
+      ["Hello", "World"],
+    ]);
+    const result = await parseXlsxRawRows(buf);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The header row is trimmed by cellToString
+    expect(result.headers).toEqual(["headline", "body"]);
+  });
+});

--- a/lib/image/dispatch.ts
+++ b/lib/image/dispatch.ts
@@ -129,7 +129,7 @@ export async function dispatchImageBatch(input: DispatchInput): Promise<Dispatch
     // For Ideogram jobs: GenerationParams. For template jobs: TemplateJobSpec (sans jobType).
     // Both are stored as JSONB in generation_params; the QStash handler discriminates via jobType.
     const generationParams: unknown = isTemplateJob
-      ? spec // store the full TemplateJobSpec; handler reads jobType to route
+      ? { ...spec, companyId } // inject companyId so QStash handler can read it from JSONB
       : {
           styleId: (spec as DispatchJobSpec).styleId,
           primaryColour: (spec as DispatchJobSpec).primaryColour,

--- a/lib/ingestion/xlsx-raw-parse.ts
+++ b/lib/ingestion/xlsx-raw-parse.ts
@@ -1,0 +1,123 @@
+import "server-only";
+
+import ExcelJS from "exceljs";
+import { logger } from "@/lib/logger";
+import type { SpreadsheetRow } from "@/lib/image/template-bulk-types";
+
+// ---------------------------------------------------------------------------
+// Generic XLSX row parser — Stream B template mode.
+//
+// Unlike parseXlsxBuffer (which validates against the canonical mass-image-gen
+// template schema), this parser is format-agnostic: any XLSX file with a
+// header row is accepted. Column names are taken verbatim from row 1; all
+// cell values are coerced to strings. Empty rows (all blank cells) are
+// skipped.
+//
+// Used by the /ingest endpoint when ingest_mode=template.
+// ---------------------------------------------------------------------------
+
+export interface XlsxRawParseResult {
+  ok: true;
+  headers: string[];
+  rows: SpreadsheetRow[];
+  rowCount: number;
+}
+
+export interface XlsxRawParseError {
+  ok: false;
+  error: string;
+}
+
+export type XlsxRawResult = XlsxRawParseResult | XlsxRawParseError;
+
+const MAX_CELL_LENGTH = 2000;
+
+/**
+ * Parse an XLSX buffer into raw string rows keyed by column header.
+ *
+ * Assumptions:
+ *  - Row 1 is the header row (no preamble rows; template XLSX files are
+ *    operator-authored, not the canonical mass-image-gen template format).
+ *  - Rows 2+ are data rows.
+ *  - Empty rows (all blank) are skipped.
+ *  - Duplicate header names: last column with that name wins.
+ */
+export async function parseXlsxRawRows(buffer: Buffer | ArrayBuffer): Promise<XlsxRawResult> {
+  const wb = new ExcelJS.Workbook();
+  try {
+    await wb.xlsx.load(buffer as ArrayBuffer);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Failed to parse XLSX file: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const ws = wb.worksheets[0];
+  if (!ws) {
+    return { ok: false, error: "Workbook contains no sheets." };
+  }
+
+  // ─── Header row ──────────────────────────────────────────────────────────
+  const headerRow = ws.getRow(1);
+  if (!headerRow || headerRow.cellCount === 0) {
+    return { ok: false, error: "Sheet has no header row." };
+  }
+
+  const headers: string[] = [];
+  // column index (1-based) → header name
+  const colToHeader = new Map<number, string>();
+  const lastCol = headerRow.cellCount;
+
+  for (let c = 1; c <= lastCol; c++) {
+    const raw = cellToString(headerRow.getCell(c));
+    if (!raw) continue;
+    headers.push(raw);
+    colToHeader.set(c, raw);
+  }
+
+  if (headers.length === 0) {
+    return { ok: false, error: "Sheet header row is empty." };
+  }
+
+  // ─── Data rows ───────────────────────────────────────────────────────────
+  const rows: SpreadsheetRow[] = [];
+
+  ws.eachRow((row, rowNumber) => {
+    if (rowNumber === 1) return; // skip header row
+
+    const rec: SpreadsheetRow = {};
+    let hasValue = false;
+
+    for (const [col, header] of colToHeader) {
+      const val = cellToString(row.getCell(col));
+      rec[header] = val;
+      if (val) hasValue = true;
+    }
+
+    if (hasValue) rows.push(rec);
+  });
+
+  logger.info("xlsx.raw.parsed", { sheetName: ws.name, headers: headers.length, rows: rows.length });
+
+  return { ok: true, headers, rows, rowCount: rows.length };
+}
+
+function cellToString(cell: ExcelJS.Cell): string {
+  if (cell.value === null || cell.value === undefined) return "";
+
+  let raw: string;
+  if (typeof cell.value === "object" && "result" in cell.value) {
+    // Formula cell
+    raw = String((cell.value as { result: unknown }).result ?? "");
+  } else if (typeof cell.value === "object" && "richText" in cell.value) {
+    // Rich text
+    raw = (cell.value as { richText: Array<{ text?: string }> }).richText
+      .map((r) => r.text ?? "")
+      .join("");
+  } else {
+    raw = String(cell.value);
+  }
+
+  return raw.trim().slice(0, MAX_CELL_LENGTH);
+}


### PR DESCRIPTION
## Summary

Extends `POST /api/platform/image/ingest` with `ingest_mode=template` — a parallel code path that replaces AI interpretation with direct column mapping. The existing Ideogram path is **untouched** (extracted to `handleIdeogramIngest()`, identical behaviour).

- **`lib/ingestion/xlsx-raw-parse.ts`** — generic XLSX parser (row 1 = headers, no Ideogram column validation)
- **`app/api/platform/image/ingest/route.ts`** — additive template branch:
  - `ingest_mode=template` + `template_id` fields (XLSX only; DOCX → 400)
  - Pipeline: parse → `get_template_by_id` → extract fields → `mapFieldsToColumns` → `validateMapping` → fan-out (1 job per row × variant) → `dispatchImageBatch`
  - Pre-dispatch summary in response (must-have #3)
- **`lib/image/dispatch.ts`** — `{ ...spec, companyId }` injected into JSONB so QStash handler can read `generationParams.companyId`

## Response shape (template mode)

```json
{
  "ok": true,
  "data": {
    "batchId": "...",
    "totalJobs": 40,
    "rowCount": 20,
    "variantCount": 2,
    "estimatedCostCents": 240,
    "mode": "generate",
    "mappingSummary": {
      "matchedFields": 3,
      "unmatchedOptional": 1,
      "unusedColumns": ["notes"]
    }
  }
}
```

## Error responses (template mode only)

| Condition | Status | Code |
|---|---|---|
| No `template_id` | 400 | `VALIDATION_ERROR` |
| DOCX file | 400 | `VALIDATION_ERROR` |
| Template not found | 404 | `TEMPLATE_NOT_FOUND` |
| Template is schema_version=1 | 422 | `TEMPLATE_NOT_V2` |
| Required field unmatched | 422 | `MAPPING_FAILED` (includes `unmatchedRequired[]` + `availableColumns[]` + `templateFields[]`) |
| Budget exceeded | 402 | `BUDGET_EXCEEDED` |

## Tests

24 new tests across 3 files; full 3046-test suite passes.

| File | Tests | Coverage |
|---|---|---|
| `image-ingest-template-mode.unit.test.ts` | 9 | All error paths, happy path, fan-out shape, companyId injection, Ideogram path unaffected |
| `image-xlsx-raw-parse.unit.test.ts` | 6 | Real ExcelJS round-trips: headers, numeric coercion, empty rows skipped, whitespace trim |
| `image-template-field-mapper.unit.test.ts` | 17 | (pre-existing, `help` field fixture fix) |
| `image-template-render-modifications.unit.test.ts` | 9 | (pre-existing, ImageLayer field name fix) |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] `test:unit` — 3046 pass
- [x] Ideogram path covered: unit test confirms `get_template_by_id` not called on Ideogram jobs
- [x] No new migrations — template mode reads existing `image_templates` table

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| `companyId` missing from JSONB → QStash reads `undefined` | `dispatch.ts` now does `{ ...spec, companyId }` for template jobs; unit test verifies `dispatchArg.companyId === COMPANY_UUID` |
| Ideogram path behaviour change | Extracted to `handleIdeogramIngest()`, zero changes to that function's logic |
| v1 template silently dispatching | `schemaVersion` guard → 422 `TEMPLATE_NOT_V2` |
| Required field unmatched → partial images | `validateMapping()` → 422 `MAPPING_FAILED` before any dispatch |
| `ingest_mode=template` with DOCX → confusing error | Explicit 400 with plain-language message |