### PR TITLE
feat(image-gen): stream B phase 3 — batch ZIP download

### DIFF
--- a/app/api/platform/image/batch/[id]/download/route.ts
+++ b/app/api/platform/image/batch/[id]/download/route.ts
@@ -1,0 +1,357 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { Zip, ZipPassThrough } from "fflate";
+
+import { internalError, notFound, validateUuidParam, validationError } from "@/lib/http";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// GET /api/platform/image/batch/[id]/download?company_id=UUID
+//
+// Stream a ZIP of all completed images in a batch.
+//
+// Auth: company_id query param → requireCanDoForApi("create_post").
+//       Batch must belong to that company (company-scope guard).
+//
+// Pipeline:
+//   1. Fetch batch + auth check
+//   2. Fetch all completed jobs (result_storage_path not null)
+//   3. Batch-sign storage paths
+//   4. Stream ZIP: fetch images 10-at-a-time via semaphore, append each to
+//      a fflate streaming Zip as it arrives, pipe bytes to the response
+//      immediately (client download starts on the first chunk)
+//   5. Append manifest.txt listing skipped images (fetch failures)
+//
+// Caps:
+//   Hard cap: 500 completed images → 413
+//   Soft cap: >100 images → X-Download-Warning header (in response)
+//
+// ZIP file layout:
+//   row-{parentPostIndex}/{variantKey ?? "base"}-{jobId[0:8]}.png
+//   manifest.txt   (present only when ≥1 image skipped)
+//
+// Stream semantics: fflate Zip emits chunks as each image is appended.
+// ZipPassThrough is used (level=0) because PNGs are already compressed.
+// Memory profile: 10 concurrent image buffers in flight, not the full set.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // 5 min — same as QStash handler TTL
+
+const IMAGE_GEN_BUCKET = process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
+const SIGNED_URL_TTL = 900; // 15 min — enough for the download stream
+const FETCH_CONCURRENCY = 10;
+const HARD_CAP = 500;
+const SOFT_WARNING_THRESHOLD = 100;
+const IMAGE_FETCH_TIMEOUT_MS = 20_000;
+
+interface CompletedJob {
+  id: string;
+  result_storage_path: string;
+  parent_post_index: number | null;
+  generation_params: Record<string, unknown> | null;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const idCheck = validateUuidParam(id, "id");
+  if (!idCheck.ok) return idCheck.response;
+  const batchId = idCheck.value;
+
+  // company_id from query (required for auth scope)
+  const companyId = new URL(req.url).searchParams.get("company_id");
+  if (!companyId) return validationError("company_id query param is required.");
+
+  const svc = getServiceRoleClient();
+
+  // ─── 1. Fetch batch + company-scope check ────────────────────────────────
+  const { data: batch, error: batchErr } = await svc
+    .from("image_generation_batches")
+    .select("id, company_id, state, total_jobs")
+    .eq("id", batchId)
+    .single();
+
+  if (batchErr || !batch) {
+    if (batchErr?.code === "PGRST116") return notFound(`Batch ${batchId} not found.`);
+    logger.error("image.batch.download.fetch_failed", { batchId, error: batchErr?.message });
+    return internalError("Failed to fetch batch.");
+  }
+
+  // Company-scope guard: batch must belong to the requesting company.
+  if ((batch.company_id as string) !== companyId) {
+    return notFound(`Batch ${batchId} not found.`);
+  }
+
+  const gate = await requireCanDoForApi(companyId, "create_post");
+  if (gate.kind === "deny") return gate.response;
+
+  // ─── 2. Fetch completed jobs ──────────────────────────────────────────────
+  const { data: jobs, error: jobsErr } = await svc
+    .from("image_generation_jobs")
+    .select("id, result_storage_path, parent_post_index, generation_params")
+    .eq("batch_id", batchId)
+    .eq("state", "completed")
+    .not("result_storage_path", "is", null)
+    .order("parent_post_index", { ascending: true, nullsFirst: true })
+    .order("created_at", { ascending: true });
+
+  if (jobsErr) {
+    logger.error("image.batch.download.jobs_failed", { batchId, error: jobsErr.message });
+    return internalError("Failed to fetch batch jobs.");
+  }
+
+  const completedJobs = (jobs ?? []) as CompletedJob[];
+
+  if (completedJobs.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: { code: "NO_COMPLETED_IMAGES", message: "Batch has no completed images to download." } },
+      { status: 422 },
+    );
+  }
+
+  if (completedJobs.length > HARD_CAP) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "BATCH_TOO_LARGE",
+          message: `Batch has ${completedJobs.length} images; maximum download is ${HARD_CAP}. Filter by variant or split the batch.`,
+        },
+      },
+      { status: 413 },
+    );
+  }
+
+  // ─── 3. Batch-sign storage paths ─────────────────────────────────────────
+  const paths = completedJobs.map((j) => j.result_storage_path);
+  const { data: signed, error: signErr } = await svc.storage
+    .from(IMAGE_GEN_BUCKET)
+    .createSignedUrls(paths, SIGNED_URL_TTL);
+
+  if (signErr || !signed) {
+    logger.error("image.batch.download.sign_failed", { batchId, error: signErr?.message });
+    return internalError("Failed to generate download URLs.");
+  }
+
+  // Build path → signedUrl map (Supabase returns them in the same order).
+  const signedByPath = new Map<string, string>();
+  for (const s of signed) {
+    if (s.signedUrl && s.path) signedByPath.set(s.path, s.signedUrl);
+  }
+
+  // ─── 4. Stream ZIP via fflate ─────────────────────────────────────────────
+  //
+  // Strategy:
+  //   - fflate Zip emits chunks via callback as each file is appended.
+  //   - We pipe those chunks directly into a TransformStream writer.
+  //   - The TransformStream.readable is the response body — client bytes
+  //     start flowing after the first image is appended, not after all are done.
+  //   - ZipPassThrough (level=0) is used because PNGs are already deflate-
+  //     compressed; re-compressing wastes CPU for negligible size gain.
+  //   - A semaphore limits concurrent Supabase Storage fetches to FETCH_CONCURRENCY.
+  //   - Per-image failures: skip + record to manifest (Steven's ask).
+
+  const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+  const writer = writable.getWriter();
+
+  const skipped: Array<{ entryName: string; reason: string }> = [];
+
+  // Run the ZIP construction in the background — the async function resolves
+  // after the last byte is written, but the readable is already being consumed.
+  void buildZip({
+    jobs: completedJobs,
+    signedByPath,
+    writer,
+    skipped,
+    batchId,
+  });
+
+  const filename = `batch-${batchId.slice(0, 8)}.zip`;
+  const headers = new Headers({
+    "Content-Type": "application/zip",
+    "Content-Disposition": `attachment; filename="${filename}"`,
+    "Cache-Control": "no-store",
+  });
+
+  if (completedJobs.length > SOFT_WARNING_THRESHOLD) {
+    headers.set(
+      "X-Download-Warning",
+      `large-batch: ${completedJobs.length} images; download may take 30-60s`,
+    );
+  }
+
+  logger.info("image.batch.download.started", {
+    batchId,
+    companyId,
+    imageCount: completedJobs.length,
+  });
+
+  return new NextResponse(readable, { headers });
+}
+
+// ─── ZIP builder (runs in background, writes to stream writer) ───────────────
+
+async function buildZip({
+  jobs,
+  signedByPath,
+  writer,
+  skipped,
+  batchId,
+}: {
+  jobs: CompletedJob[];
+  signedByPath: Map<string, string>;
+  writer: WritableStreamDefaultWriter<Uint8Array>;
+  skipped: Array<{ entryName: string; reason: string }>;
+  batchId: string;
+}): Promise<void> {
+  // fflate Zip emits chunks synchronously as each file is pushed.
+  // We collect them into a micro-queue and drain asynchronously to avoid
+  // blocking the event loop on large images.
+  const chunkQueue: Uint8Array[] = [];
+  let zipFinalized = false;
+  let zipError: Error | null = null;
+
+  const zip = new Zip((err, chunk, final) => {
+    if (err) { zipError = err; return; }
+    chunkQueue.push(chunk);
+    if (final) zipFinalized = true;
+  });
+
+  // Drain the chunk queue to the writer.
+  async function drain(): Promise<void> {
+    while (chunkQueue.length > 0) {
+      const chunk = chunkQueue.shift()!;
+      await writer.write(chunk);
+    }
+  }
+
+  // Semaphore: at most FETCH_CONCURRENCY images in-flight at once.
+  let inFlight = 0;
+  const queue: Array<() => void> = [];
+
+  function acquireSlot(): Promise<void> {
+    if (inFlight < FETCH_CONCURRENCY) {
+      inFlight++;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => queue.push(resolve));
+  }
+
+  function releaseSlot(): void {
+    inFlight--;
+    const next = queue.shift();
+    if (next) { inFlight++; next(); }
+  }
+
+  try {
+    // Fan out image fetches, respecting the semaphore.
+    await Promise.all(
+      jobs.map(async (job) => {
+        const entryName = buildEntryName(job);
+
+        await acquireSlot();
+        try {
+          const signedUrl = signedByPath.get(job.result_storage_path);
+          if (!signedUrl) {
+            skipped.push({ entryName, reason: "no_signed_url" });
+            return;
+          }
+
+          let imgBuf: Buffer;
+          try {
+            const resp = await fetch(signedUrl, {
+              signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS),
+            });
+            if (!resp.ok) {
+              skipped.push({ entryName, reason: `http_${resp.status}` });
+              logger.warn("image.batch.download.fetch_failed", {
+                batchId, jobId: job.id, status: resp.status,
+              });
+              return;
+            }
+            imgBuf = Buffer.from(await resp.arrayBuffer());
+          } catch (err) {
+            skipped.push({
+              entryName,
+              reason: err instanceof Error && err.name === "TimeoutError"
+                ? "timeout"
+                : "fetch_error",
+            });
+            logger.warn("image.batch.download.fetch_error", {
+              batchId, jobId: job.id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            return;
+          }
+
+          // Append image to ZIP. ZipPassThrough = store (no re-compression).
+          const entry = new ZipPassThrough(entryName);
+          zip.add(entry);
+          entry.push(imgBuf, true);
+
+          // Drain accumulated chunks to the writer after each image.
+          await drain();
+        } finally {
+          releaseSlot();
+        }
+      }),
+    );
+
+    // Append manifest.txt if any images were skipped.
+    if (skipped.length > 0) {
+      const lines = [
+        `manifest.txt — skipped images in batch ${batchId}`,
+        `Generated: ${new Date().toISOString()}`,
+        "",
+        ...skipped.map((s) => `SKIPPED  ${s.entryName}  reason: ${s.reason}`),
+        "",
+        `Total skipped: ${skipped.length} / ${jobs.length}`,
+      ];
+      const manifestBuf = Buffer.from(lines.join("\n"), "utf-8");
+      const manifestEntry = new ZipPassThrough("manifest.txt");
+      zip.add(manifestEntry);
+      manifestEntry.push(manifestBuf, true);
+      await drain();
+    }
+
+    // Finalise ZIP — emits central directory + end-of-central-directory record.
+    zip.end();
+    if (zipError) throw zipError;
+    await drain(); // flush final record chunks
+
+    logger.info("image.batch.download.complete", {
+      batchId,
+      total: jobs.length,
+      skipped: skipped.length,
+    });
+  } catch (err) {
+    logger.error("image.batch.download.zip_error", {
+      batchId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    await writer.abort(err instanceof Error ? err : new Error(String(err)));
+    return;
+  }
+
+  await writer.close();
+}
+
+// ─── ZIP entry name ───────────────────────────────────────────────────────────
+
+function buildEntryName(job: CompletedJob): string {
+  const rowPart = job.parent_post_index !== null ? `row-${job.parent_post_index}` : "row-unknown";
+
+  // variantKey is stored in generation_params.variantKey for template jobs.
+  const params = job.generation_params;
+  const variantKey =
+    params && typeof params.variantKey === "string" ? params.variantKey : null;
+  const variantPart = variantKey ?? "base";
+
+  const shortId = job.id.slice(0, 8);
+  return `${rowPart}/${variantPart}-${shortId}.png`;
+}

--- a/components/image/BatchResultsClient.tsx
+++ b/components/image/BatchResultsClient.tsx
@@ -123,6 +123,20 @@ export function BatchResultsClient({ batchId, companyId }: { batchId: string; co
           {isRunning && (
             <div className="h-4 w-4 rounded-full border-2 border-primary border-t-transparent animate-spin" aria-label="Running" />
           )}
+          {batch.completedJobs > 0 && !isRunning && (
+            <Button
+              variant="outline"
+              size="sm"
+              asChild
+            >
+              <a
+                href={`/api/platform/image/batch/${batchId}/download?company_id=${companyId}`}
+                download
+              >
+                Download all ({batch.completedJobs})
+              </a>
+            </Button>
+          )}
           <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
             batch.state === "completed" ? "bg-green-100 text-green-700"
             : batch.state === "failed" ? "bg-red-100 text-red-700"

--- a/lib/__tests__/image-batch-download.unit.test.ts
+++ b/lib/__tests__/image-batch-download.unit.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Unit tests for GET /api/platform/image/batch/[id]/download (Stream B Phase 3).
+ *
+ * Tests cover:
+ *  - Company-scope guard: batch company_id must match query company_id
+ *  - 404 when batch not found
+ *  - 404 when batch belongs to a different company
+ *  - 422 when batch has no completed jobs
+ *  - 413 when completed job count exceeds hard cap (500)
+ *  - 200 streaming response with correct headers
+ *  - ZIP content: correct entry names for base and variant jobs
+ *  - Per-image failure: skipped entry + manifest.txt included
+ *  - Soft-warning header when >100 images
+ *
+ * The streaming ZIP body is collected in tests using Response.arrayBuffer()
+ * and unzipped with fflate.unzip to assert entry names.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { unzipSync } from "fflate";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Auth gate ────────────────────────────────────────────────────────────────
+const mockGate = vi.fn();
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: (...args: unknown[]) => mockGate(...args),
+}));
+
+// ─── Supabase ─────────────────────────────────────────────────────────────────
+// Build an infinitely-chainable mock (same approach as fork test).
+function makeChain(leaf: Record<string, unknown>) {
+  const proxy: Record<string, unknown> = {};
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop: string) {
+      if (prop === "then") return undefined;
+      if (prop in leaf) return leaf[prop];
+      return vi.fn().mockReturnValue(new Proxy({}, handler));
+    },
+  };
+  return new Proxy(proxy, handler);
+}
+
+const mockSvc = {
+  from: vi.fn(),
+  storage: {
+    from: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => mockSvc),
+}));
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const COMPANY_UUID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const OTHER_UUID   = "99999999-9999-4999-8999-999999999999";
+const BATCH_UUID   = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const JOB_UUID_1   = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const JOB_UUID_2   = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+const TINY_PNG = Buffer.from(
+  "89504e470d0a1a0a0000000d49484452000000010000000108020000009001" +
+  "2e000000" + "0c4944415408d76360f8cfc00000000200013400129f00000000049454e44ae426082",
+  "hex",
+);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeRequest(batchId: string, companyId: string): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/platform/image/batch/${batchId}/download?company_id=${companyId}`,
+  );
+}
+
+type QueryChain = {
+  select: () => QueryChain;
+  eq: () => QueryChain;
+  not: () => QueryChain;
+  order: () => QueryChain;
+  single: () => Promise<{ data: unknown; error: null | { code?: string; message?: string } }>;
+};
+
+/** Wire up mockSvc.from() to return given data for sequential calls. */
+function setupDb({
+  batch,
+  jobs,
+  batchError,
+}: {
+  batch?: Record<string, unknown> | null;
+  jobs?: Record<string, unknown>[];
+  batchError?: { code?: string; message?: string } | null;
+}): void {
+  let callCount = 0;
+  mockSvc.from.mockImplementation(() => {
+    callCount++;
+    if (callCount === 1) {
+      // First call: batch fetch
+      const q: QueryChain = {
+        select: () => q,
+        eq: () => q,
+        not: () => q,
+        order: () => q,
+        single: async () => ({ data: batch ?? null, error: batchError ?? null }),
+      };
+      return q;
+    }
+    // Second call: jobs fetch
+    const q: QueryChain = {
+      select: () => q,
+      eq: () => q,
+      not: () => q,
+      order: () => q,
+      single: async () => ({ data: null, error: null }),
+    };
+    // Return jobs array for the jobs query
+    return {
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            not: () => ({
+              order: () => ({
+                order: () => ({ data: jobs ?? [], error: null }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+  });
+}
+
+function setupSignedUrls(urlMap: Record<string, string>): void {
+  mockSvc.storage.from.mockReturnValue({
+    createSignedUrls: async (paths: string[]) => ({
+      data: paths.map((p) => ({ path: p, signedUrl: urlMap[p] ?? null })),
+      error: null,
+    }),
+  });
+}
+
+// ─── Import handler after mocks ───────────────────────────────────────────────
+
+import { GET } from "@/app/api/platform/image/batch/[id]/download/route";
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("batch download route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGate.mockResolvedValue({ kind: "allow", userId: "user-1" });
+  });
+
+  it("returns 404 when batch is not found", async () => {
+    setupDb({ batch: null, batchError: { code: "PGRST116" } });
+    const res = await GET(makeRequest(BATCH_UUID, COMPANY_UUID), { params: Promise.resolve({ id: BATCH_UUID }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when batch belongs to a different company", async () => {
+    setupDb({ batch: { id: BATCH_UUID, company_id: OTHER_UUID, state: "completed", total_jobs: 1 } });
+    const res = await GET(makeRequest(BATCH_UUID, COMPANY_UUID), { params: Promise.resolve({ id: BATCH_UUID }) });
+    // company_id mismatch → notFound
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 422 when batch has no completed jobs", async () => {
+    setupDb({
+      batch: { id: BATCH_UUID, company_id: COMPANY_UUID, state: "running", total_jobs: 2 },
+      jobs: [],
+    });
+    const res = await GET(makeRequest(BATCH_UUID, COMPANY_UUID), { params: Promise.resolve({ id: BATCH_UUID }) });
+    expect(res.status).toBe(422);
+    const body = await res.json() as { error: { code: string } };
+    expect(body.error.code).toBe("NO_COMPLETED_IMAGES");
+  });
+
+  it("returns 413 when completed job count exceeds hard cap", async () => {
+    const manyJobs = Array.from({ length: 501 }, (_, i) => ({
+      id: `job-${i}`,
+      result_storage_path: `path/${i}.png`,
+      parent_post_index: i,
+      generation_params: null,
+    }));
+    setupDb({
+      batch: { id: BATCH_UUID, company_id: COMPANY_UUID, state: "completed", total_jobs: 501 },
+      jobs: manyJobs,
+    });
+    const res = await GET(makeRequest(BATCH_UUID, COMPANY_UUID), { params: Promise.resolve({ id: BATCH_UUID }) });
+    expect(res.status).toBe(413);
+  });
+
+  it("returns 200 streaming response with correct content-type header", async () => {
+    setupDb({
+      batch: { id: BATCH_UUID, company_id: COMPANY_UUID, state: "completed", total_jobs: 1 },
+      jobs: [{ id: JOB_UUID_1, result_storage_path: "c1/img.png", parent_post_index: 0, generation_params: null }],
+    });
+    setupSignedUrls({ "c1/img.png": "https://storage.example.com/c1/img.png" });
+
+    // Mock fetch for the signed URL image download
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => TINY_PNG.buffer,
+    });
+
+    const res = await GET(makeRequest(BATCH_UUID, COMPANY_UUID), { params: Promise.resolve({ id: BATCH_UUID }) });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/zip");
+    expect(res.headers.get("Content-Disposition")).toContain(".zip");
+  });
+
+  it("ZIP contains correct entry name for base variant job", async () => {
+    setupDb({
+      batch: { id: BATCH_UUID, company_id: COMPANY_UUID, state: "completed", total_jobs: 1 },
+      jobs: [{ id: JOB_UUID_1, result_storage_path: "c1/img.png", parent_post_index: 2, generation_params: { jobType: "template" } }],
+    });
+    setupSignedUrls({ "c1/img.png": "https://storage.example.com/c1/img.png" });
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, arrayBuffer: async () => TINY_PNG.buffer });
+
+    const res = await GET(makeRequest(BATCH_UUID, COMPANY_UUID), { params: Promise.resolve({ id: BATCH_UUID }) });
+    const buf = Buffer.from(await res.arrayBuffer());
+    const entries = unzipSync(buf);
+
+    const expectedName = `row-2/base-${JOB_UUID_1.slice(0, 8)}.png`;
+    expect(Object.keys(entries)).toContain(expectedName);
+  });
+
+  it("ZIP contains correct entry name for named variant job", async () => {
+    setupDb({
+      batch: { id: BATCH_UUID, company_id: COMPANY_UUID, state: "completed", total_jobs: 1 },
+      jobs: [{
+        id: JOB_UUID_1,
+        result_storage_path: "c1/img.png",
+        parent_post_index: 0,
+        generation_params: { jobType: "template", variantKey: "landscape" },
+      }],
+    });
+    setupSignedUrls({ "c1/img.png": "https://storage.example.com/c1/img.png" });
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, arrayBuffer: async () => TINY_PNG.buffer });
+
+    const res = await GET(makeRequest(BATCH_UUID, COMPANY_UUID), { params: Promise.resolve({ id: BATCH_UUID }) });
+    const buf = Buffer.from(await res.arrayBuffer());
+    const entries = unzipSync(buf);
+
+    const expectedName = `row-0/landscape-${JOB_UUID_1.slice(0, 8)}.png`;
+    expect(Object.keys(entries)).toContain(expectedName);
+  });
+
+  it("skips failed image fetch and includes manifest.txt", async () => {
+    setupDb({
+      batch: { id: BATCH_UUID, company_id: COMPANY_UUID, state: "completed", total_jobs: 2 },
+      jobs: [
+        { id: JOB_UUID_1, result_storage_path: "c1/img1.png", parent_post_index: 0, generation_params: null },
+        { id: JOB_UUID_2, result_storage_path: "c1/img2.png", parent_post_index: 1, generation_params: null },
+      ],
+    });
+    setupSignedUrls({
+      "c1/img1.png": "https://storage.example.com/c1/img1.png",
+      "c1/img2.png": "https://storage.example.com/c1/img2.png",
+    });
+
+    // First image succeeds; second returns 404
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, arrayBuffer: async () => TINY_PNG.buffer })
+      .mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const res = await GET(makeRequest(BATCH_UUID, COMPANY_UUID), { params: Promise.resolve({ id: BATCH_UUID }) });
+    const buf = Buffer.from(await res.arrayBuffer());
+    const entries = unzipSync(buf);
+    const entryNames = Object.keys(entries);
+
+    // Successful image present
+    expect(entryNames).toContain(`row-0/base-${JOB_UUID_1.slice(0, 8)}.png`);
+    // Failed image absent
+    expect(entryNames).not.toContain(`row-1/base-${JOB_UUID_2.slice(0, 8)}.png`);
+    // Manifest present
+    expect(entryNames).toContain("manifest.txt");
+
+    const manifest = Buffer.from(entries["manifest.txt"]!).toString("utf-8");
+    expect(manifest).toContain("SKIPPED");
+    expect(manifest).toContain(`row-1/base-${JOB_UUID_2.slice(0, 8)}.png`);
+    expect(manifest).toContain("http_404");
+  });
+
+  it("includes X-Download-Warning header when jobs exceed soft threshold", async () => {
+    const manyJobs = Array.from({ length: 101 }, (_, i) => ({
+      id: `jj-${i.toString().padStart(8, "0")}-0000-4000-8000-000000000000`,
+      result_storage_path: `path/${i}.png`,
+      parent_post_index: i,
+      generation_params: null,
+    }));
+    const urlMap: Record<string, string> = {};
+    for (let i = 0; i < 101; i++) urlMap[`path/${i}.png`] = `https://s.example.com/${i}.png`;
+
+    setupDb({
+      batch: { id: BATCH_UUID, company_id: COMPANY_UUID, state: "completed", total_jobs: 101 },
+      jobs: manyJobs,
+    });
+    setupSignedUrls(urlMap);
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, arrayBuffer: async () => TINY_PNG.buffer });
+
+    const res = await GET(makeRequest(BATCH_UUID, COMPANY_UUID), { params: Promise.resolve({ id: BATCH_UUID }) });
+    expect(res.headers.get("X-Download-Warning")).toMatch(/large-batch/);
+  });
+});


### PR DESCRIPTION
## Summary

Streaming ZIP download for all completed images in a batch, with per-image failure handling and a "Download all" button on the batch results page.

## New endpoint

`GET /api/platform/image/batch/[id]/download?company_id=UUID`

### Pipeline

1. Auth: `requireCanDoForApi(companyId, "create_post")`
2. Company-scope guard: `batch.company_id` must match `company_id` query param — mismatches return 404 (not 403, so no information leak)
3. Batch-sign all storage paths in one `createSignedUrls` call
4. Progressive streaming ZIP via `fflate ZipPassThrough` (level=0 — PNGs already compressed)
5. Fetch images 10-at-a-time via semaphore; each image appended to ZIP as it arrives (client bytes start flowing immediately, not after all images are downloaded)
6. Per-image failure (Steven's ask): skip image + append to `manifest.txt` listing reason. Job that 404s/times-out does NOT abort the ZIP.
7. `manifest.txt` appended to ZIP only when ≥1 image skipped

### Caps

| Condition | Response |
|---|---|
| 0 completed images | 422 `NO_COMPLETED_IMAGES` |
| >500 completed images | 413 `BATCH_TOO_LARGE` |
| >100 completed images | `X-Download-Warning: large-batch: N images...` header |

### ZIP layout

```
row-{parentPostIndex}/{variantKey ?? "base"}-{jobId[0:8]}.png
manifest.txt   (only present when ≥1 image skipped)
```

### manifest.txt example
```
manifest.txt — skipped images in batch bbbbbbbb
Generated: 2026-06-01T08:51:00.000Z

SKIPPED  row-1/base-dddddddd.png  reason: http_404
SKIPPED  row-3/landscape-eeeeeeee.png  reason: timeout

Total skipped: 2 / 40
```

## UI change

`BatchResultsClient.tsx` — "Download all (N)" button in the batch header. Visible only when `completedJobs > 0` and batch is not running. Uses `<a download>` so the browser handles the save-as dialog natively.

## Tests

9 unit tests, 3057 total pass.

| Test | Assertion |
|---|---|
| 404 batch not found | `PGRST116` error → 404 |
| 404 wrong company | `batch.company_id ≠ companyId` → 404 |
| 422 no completed | empty jobs → 422 `NO_COMPLETED_IMAGES` |
| 413 hard cap | 501 jobs → 413 `BATCH_TOO_LARGE` |
| 200 content-type | `application/zip`, `Content-Disposition: attachment` |
| ZIP entry name (base) | `row-2/base-cccccccc.png` |
| ZIP entry name (variant) | `row-0/landscape-cccccccc.png` |
| Skip + manifest | 1-of-2 fetches fails → skipped entry absent, manifest.txt present with SKIPPED line |
| Soft warning header | 101 jobs → `X-Download-Warning: large-batch` |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] `test:unit` — 3057 pass
- [x] `audit:static` — 0 HIGH
- [x] Company-scope: `batch.company_id !== companyId` → 404

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| One image 404 aborts whole ZIP | Per-image try/catch; skip + manifest; ZIP continues |
| Memory spike on large batches | Semaphore (10 concurrent); ZipPassThrough emits then discards each buffer |
| Signed URL expiry mid-stream | TTL=900s (15 min); at 10-concurrent, 500 images ≈ 50s total |
| Vercel timeout | `maxDuration=300`; 500×10-concurrent ≈ 50s, well within |
| Cross-company data leak | Company-scope guard before any job query; mismatch → 404 not 403 |