### PR TITLE
feat(nav): image gen under Social — Images group + Page builder rename

### DIFF
--- a/components/nav/nav-config.ts
+++ b/components/nav/nav-config.ts
@@ -88,13 +88,13 @@ export const primaryNavItems: PrimaryNavItem[] = [
   },
   {
     key: "batches",
-    label: "Batches",
+    label: "Page builder",
     icon: "layers",
     href: "/admin/batches",
     pathPrefixes: ["/admin/batches"],
     testId: "nav-batches",
     sectionNav: {
-      title: "Batches",
+      title: "Page builder",
       showSiteSelector: true,
       siteIdSegment: 3,
       siteSelectPath: "/admin/batches/{siteId}",
@@ -138,6 +138,14 @@ export const primaryNavItems: PrimaryNavItem[] = [
             { label: "Sharing", href: "/company/social/sharing", testId: "cnav-sharing", requiresCompanyAdmin: true },
             { label: "Analytics", href: "/company/social/analytics", testId: "cnav-analytics" },
             { label: "Insights", href: "/company/social/insights", testId: "cnav-insights" },
+          ],
+        },
+        {
+          label: "Images",
+          items: [
+            { label: "Generate", href: "/company/image/ingest", testId: "cnav-image-generate" },
+            { label: "Templates", href: "/company/image/templates", testId: "cnav-image-templates" },
+            { label: "Batch history", href: "/company/image/batches", testId: "cnav-image-batches" },
           ],
         },
         {


### PR DESCRIPTION
## Summary

Two edits to `components/nav/nav-config.ts`. No routes move. No redirects. No page heading changes.

## Changes

### 1. "Images" group added to Social section nav

```
Social
  Calendar
  Posts
  Connections
  Media
  Sharing
  Analytics
  Insights
  ─── Images ───     ← new group
  Generate           /company/image/ingest
  Templates          /company/image/templates
  Batch history      /company/image/batches
  ─── Account ───
  Users
  Brand
```

**Active state:** `SectionNav.isItemActive()` uses `pathname.startsWith(resolved + "/")`, so sub-pages automatically highlight their parent item:
- `/company/image/batches/[id]` → "Batch history" highlighted
- `/company/image/templates/[id]/edit` → "Templates" highlighted

**Social primary rail:** `pathPrefixes: ["/company/"]` already captures `/company/image/*` — Social highlights in the primary rail on all image pages. No change needed to the prefix.

### 2. "Batches" primary rail label → "Page builder"

Section nav title also updated. URL (`/admin/batches`), `testId` (`nav-batches`), and the page `<h1>` heading are unchanged — this is a display label only. Resolves the naming collision documented in `docs/briefs/image-generator/IMAGE_GEN_IA_PROPOSAL.md §4`.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] `test:unit` — 3046 pass (no nav config tests exist; this file is config not logic)
- [x] e2e/batches.spec.ts checks page `<h1>` headings only, not nav labels — unaffected

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Social section nav becomes too long for small screens | 11 items + 2 groups — still within comfortable scroll range; overflow-y-auto on aside element |
| `/company/image/*` double-highlights (both primary Social + section Images) | Correct behaviour: Social is the primary section, Images is the sub-item within it |
| e2e test breakage from label change | e2e tests reference page headings (`<h1>`), not nav labels — both unaffected |