### PR TITLE
feat(image-gen): persist post_text through pipeline — caption bridge

### DIFF
--- a/app/api/platform/image/ingest/route.ts
+++ b/app/api/platform/image/ingest/route.ts
@@ -211,6 +211,15 @@ async function handleIdeogramIngest({
   }
   const jobSpecs = fanOutJobs(interpreted.posts, publishDateBySourceRow);
 
+  // Build caption map: parentPostIndex (0-based) → AI-generated social copy.
+  // fanOutJobs assigns parentPostIndex = the array index of the InterpretedPost,
+  // which is the same as the index here. Multiple jobs per row (different aspect
+  // ratios) share the same parentPostIndex and therefore the same caption.
+  const postTextByParentIndex: Record<number, string> = {};
+  interpreted.posts.forEach((p, i) => {
+    if (p.post_text) postTextByParentIndex[i] = p.post_text;
+  });
+
   const mode = parseGenerateMode(req);
   const dispatched = await dispatchImageBatch({
     companyId,
@@ -219,6 +228,7 @@ async function handleIdeogramIngest({
     mode,
     sourceFilename: fileBlob.name,
     sourceRowCount: interpreted.posts.length,
+    postTextByParentIndex,
   });
 
   if (!dispatched.ok) {

--- a/lib/__tests__/image-auto-attach.unit.test.ts
+++ b/lib/__tests__/image-auto-attach.unit.test.ts
@@ -506,3 +506,119 @@ describe("autoAttachImage — failure paths", () => {
     expect(result.error).toMatch(/state=running/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// post_text persistence — caption pre-fill and create-only safety rule
+// ---------------------------------------------------------------------------
+
+describe("autoAttachImage — post_text / caption pre-fill", () => {
+  const AI_CAPTION = "Here's a compelling social caption written by Claude.";
+
+  test("new draft: content is set from post_text when caption is present", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: COMPANY_ID,
+        state: "completed",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: "2026-08-01",
+        generation_params: { aspectRatio: "1x1" },
+        post_text: AI_CAPTION,
+      },
+      error: null,
+    };
+    responses.draftLookup = { data: null, error: null }; // no existing draft
+    responses.draftInsert = { data: { id: NEW_DRAFT_ID }, error: null };
+    responses.draftRead = { data: { media_asset_ids: [] }, error: null };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attached");
+
+    const draftInsert = calls.find((c) => c.table === "social_post_drafts" && c.op === "insert");
+    expect(draftInsert).toBeDefined();
+    expect((draftInsert!.inserted as { content: string }).content).toBe(AI_CAPTION);
+  });
+
+  test("new draft: content is empty string when post_text is null (no AI caption available)", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: COMPANY_ID,
+        state: "completed",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: "2026-08-02",
+        generation_params: { aspectRatio: "4x5" },
+        post_text: null,
+      },
+      error: null,
+    };
+    responses.draftLookup = { data: null, error: null };
+    responses.draftInsert = { data: { id: NEW_DRAFT_ID }, error: null };
+    responses.draftRead = { data: { media_asset_ids: [] }, error: null };
+
+    await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    const draftInsert = calls.find((c) => c.table === "social_post_drafts" && c.op === "insert");
+    expect((draftInsert!.inserted as { content: string }).content).toBe("");
+  });
+
+  // NON-NEGOTIABLE SAFETY RULE: when a draft already exists for (company, date),
+  // the second approval appends to media_asset_ids but must NEVER overwrite content.
+  // An operator may have already edited the caption on the existing draft.
+  test("existing draft: content is NOT overwritten — create-only rule enforced", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: COMPANY_ID,
+        state: "completed",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: "2026-08-01",
+        generation_params: { aspectRatio: "16x9" },
+        // A second approval for the same date carries a different caption.
+        post_text: "A second AI caption that must NOT overwrite the existing draft.",
+      },
+      error: null,
+    };
+    // Draft already exists (first approval created it with a different caption).
+    responses.draftLookup = { data: { id: EXISTING_DRAFT_ID }, error: null };
+    responses.draftRead = {
+      data: { media_asset_ids: ["first-asset-uuid"] },
+      error: null,
+    };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attached");
+    expect(result.draftId).toBe(EXISTING_DRAFT_ID);
+
+    // ASSERT: no INSERT into social_post_drafts — find path, not create path.
+    const draftInserts = calls.filter(
+      (c) => c.table === "social_post_drafts" && c.op === "insert",
+    );
+    expect(draftInserts).toHaveLength(0);
+
+    // ASSERT: the UPDATE to social_post_drafts only touches media_asset_ids —
+    // never content.
+    const draftUpdate = calls.find(
+      (c) => c.op === "update" && c.table === "social_post_drafts",
+    );
+    expect(draftUpdate).toBeDefined();
+    const patch = draftUpdate!.patch as Record<string, unknown>;
+    expect("content" in patch).toBe(false); // content must not appear in the patch at all
+    expect(patch.media_asset_ids).toContain(ASSET_ID);
+    expect(patch.media_asset_ids).toContain("first-asset-uuid");
+  });
+});

--- a/lib/__tests__/image-dispatch-post-text.unit.test.ts
+++ b/lib/__tests__/image-dispatch-post-text.unit.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for post_text persistence in dispatchImageBatch (migration 0170).
+ *
+ * Tests cover:
+ *  - postTextByParentIndex is written to each job's post_text column
+ *  - jobs sharing a parentPostIndex get the same caption
+ *  - jobs with no entry in postTextByParentIndex get post_text=null
+ *  - callers that don't pass postTextByParentIndex (template mode, mood board)
+ *    get post_text=null — zero regression on existing callers
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+// ─── Supabase chain ───────────────────────────────────────────────────────────
+// Records every .insert() call so we can assert on what was written.
+
+const insertedJobs: Array<Record<string, unknown>> = [];
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "platform_companies") {
+    return {
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { monthly_image_gen_budget_cents: 1_000_000 },
+            error: null,
+          }),
+        }),
+      }),
+    };
+  }
+  if (table === "image_gen_spend") {
+    return {
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+      }),
+    };
+  }
+  if (table === "image_generation_batches") {
+    return {
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: "batch-uuid" }, error: null,
+          }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    };
+  }
+  if (table === "image_generation_jobs") {
+    return {
+      insert: vi.fn((row: Record<string, unknown>) => {
+        insertedJobs.push(row);
+        return {
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { id: `job-${insertedJobs.length}` }, error: null,
+            }),
+          }),
+        };
+      }),
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    };
+  }
+  return { insert: vi.fn(), select: vi.fn(), update: vi.fn() };
+});
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/image/enqueue", () => ({
+  enqueueImageJob: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { dispatchImageBatch } from "@/lib/image/dispatch";
+
+const COMPANY_UUID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+const BASE_SPEC = {
+  styleId: "clean_corporate" as const,
+  primaryColour: "#123456",
+  compositionType: "split_layout" as const,
+  aspectRatio: "1x1" as const,
+};
+
+beforeEach(() => {
+  insertedJobs.length = 0;
+  vi.clearAllMocks();
+  // Re-wire mockFrom after clearAllMocks
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "platform_companies") {
+      return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: { monthly_image_gen_budget_cents: 1_000_000 }, error: null }) }) }) };
+    }
+    if (table === "image_gen_spend") {
+      return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) }) }) }) };
+    }
+    if (table === "image_generation_batches") {
+      return { insert: vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: "batch-uuid" }, error: null }) }) }), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }) };
+    }
+    if (table === "image_generation_jobs") {
+      return {
+        insert: vi.fn((row: Record<string, unknown>) => {
+          insertedJobs.push(row);
+          return { select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: `job-${insertedJobs.length}` }, error: null }) }) };
+        }),
+        update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+      };
+    }
+    return { insert: vi.fn(), select: vi.fn(), update: vi.fn() };
+  });
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("dispatchImageBatch — postTextByParentIndex", () => {
+  it("writes the correct caption to each job's post_text column", async () => {
+    await dispatchImageBatch({
+      companyId: COMPANY_UUID,
+      triggeredBy: "user-1",
+      jobs: [
+        { ...BASE_SPEC, parentPostIndex: 0 },
+        { ...BASE_SPEC, aspectRatio: "4x5", parentPostIndex: 0 }, // same row, different ratio
+        { ...BASE_SPEC, parentPostIndex: 1 },
+      ],
+      mode: "generate",
+      postTextByParentIndex: {
+        0: "Caption for row zero.",
+        1: "Caption for row one.",
+      },
+    });
+
+    expect(insertedJobs).toHaveLength(3);
+    // Both aspect-ratio variants of row 0 share the same caption.
+    expect(insertedJobs[0]?.post_text).toBe("Caption for row zero.");
+    expect(insertedJobs[1]?.post_text).toBe("Caption for row zero.");
+    // Row 1 gets its own caption.
+    expect(insertedJobs[2]?.post_text).toBe("Caption for row one.");
+  });
+
+  it("writes post_text=null for jobs with no entry in the caption map", async () => {
+    await dispatchImageBatch({
+      companyId: COMPANY_UUID,
+      triggeredBy: "user-1",
+      jobs: [
+        { ...BASE_SPEC, parentPostIndex: 0 },
+        { ...BASE_SPEC, parentPostIndex: 1 }, // no entry for row 1
+      ],
+      mode: "generate",
+      postTextByParentIndex: { 0: "Only row zero has a caption." },
+    });
+
+    expect(insertedJobs[0]?.post_text).toBe("Only row zero has a caption.");
+    expect(insertedJobs[1]?.post_text).toBeNull();
+  });
+
+  it("writes post_text=null for all jobs when postTextByParentIndex is absent", async () => {
+    // Simulates template mode, mood board, or direct batch dispatch — callers
+    // that don't pass captions. Zero regression: existing behaviour unchanged.
+    await dispatchImageBatch({
+      companyId: COMPANY_UUID,
+      triggeredBy: "user-1",
+      jobs: [
+        { ...BASE_SPEC, parentPostIndex: 0 },
+        { ...BASE_SPEC, parentPostIndex: 1 },
+      ],
+      mode: "generate",
+      // postTextByParentIndex deliberately omitted
+    });
+
+    expect(insertedJobs[0]?.post_text).toBeNull();
+    expect(insertedJobs[1]?.post_text).toBeNull();
+  });
+
+  it("handles jobs with parentPostIndex=null gracefully — post_text=null", async () => {
+    await dispatchImageBatch({
+      companyId: COMPANY_UUID,
+      triggeredBy: "user-1",
+      jobs: [
+        // parentPostIndex omitted → undefined → null in the insert
+        { ...BASE_SPEC },
+      ],
+      mode: "generate",
+      postTextByParentIndex: { 0: "This caption has no matching job." },
+    });
+
+    expect(insertedJobs[0]?.post_text).toBeNull();
+  });
+});

--- a/lib/image/auto-attach.ts
+++ b/lib/image/auto-attach.ts
@@ -44,7 +44,7 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
     const { data: job, error: jobErr } = await svc
       .from("image_generation_jobs")
       .select(
-        "id, company_id, state, result_storage_path, target_publish_date, generation_params",
+        "id, company_id, state, result_storage_path, target_publish_date, generation_params, post_text",
       )
       .eq("id", input.jobId)
       .maybeSingle();
@@ -62,6 +62,7 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
       result_storage_path: string | null;
       target_publish_date: string | null;
       generation_params: Record<string, unknown>;
+      post_text: string | null;
     };
 
     if (j.company_id !== input.companyId) {
@@ -126,6 +127,7 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
       companyId: input.companyId,
       publishDate: j.target_publish_date,
       approvedBy: input.approvedBy,
+      postText: j.post_text ?? null,
     });
 
     if (!draftId) {
@@ -226,6 +228,13 @@ interface FindOrCreateDraftInput {
   companyId: string;
   publishDate: string; // YYYY-MM-DD
   approvedBy: string;
+  /**
+   * AI-generated social caption from the source spreadsheet row.
+   * Written to content ONLY when creating a new draft — never overwrites an
+   * existing draft's content. This is the non-negotiable create-only rule:
+   * the operator may have already edited the caption on an existing draft.
+   */
+  postText: string | null;
 }
 
 async function findOrCreateScheduledDraft(
@@ -237,6 +246,8 @@ async function findOrCreateScheduledDraft(
 
   // Look for an existing scheduled draft for (company, publish_date).
   // Match by scheduled_at exact equality + state='scheduled' + not archived.
+  // IMPORTANT: if found, we return only the id. We do NOT update content —
+  // the operator may have already edited the caption on this draft.
   const { data: existing, error: lookupErr } = await svc
     .from("social_post_drafts")
     .select("id")
@@ -257,12 +268,15 @@ async function findOrCreateScheduledDraft(
   }
 
   if (existing) {
+    // Draft exists — do NOT touch content. Only the caller (Step 3) will
+    // append the new asset id to media_asset_ids.
     return (existing as { id: string }).id;
   }
 
-  // Create a placeholder scheduled draft. Empty content + empty target_profiles;
-  // the operator will fill those in later. created_by/updated_by are required
-  // FKs to auth.users; we pass the approver's id.
+  // No existing draft — create one. Pre-fill content from the AI-generated
+  // caption if available; fall back to empty string so the operator can write
+  // from scratch. This is the ONLY place content is set; it is never
+  // overwritten after creation.
   const { data: created, error: createErr } = await svc
     .from("social_post_drafts")
     .insert({
@@ -270,7 +284,7 @@ async function findOrCreateScheduledDraft(
       created_by: input.approvedBy,
       updated_by: input.approvedBy,
       state: "scheduled",
-      content: "",
+      content: input.postText ?? "",
       media_urls: [],
       media_asset_ids: [],
       target_profiles: [],

--- a/lib/image/dispatch.ts
+++ b/lib/image/dispatch.ts
@@ -40,6 +40,14 @@ export interface DispatchInput {
   mode: BatchMode;
   sourceFilename?: string;
   sourceRowCount?: number;
+  /**
+   * AI-generated social captions keyed by parentPostIndex.
+   * Populated by the Ideogram ingest path (from interpretPosts()).
+   * Written to image_generation_jobs.post_text so auto-attach can pre-fill
+   * social_post_drafts.content on draft creation.
+   * Absent for template mode, mood board, and direct batch dispatch.
+   */
+  postTextByParentIndex?: Record<number, string>;
 }
 
 export type DispatchResult =
@@ -140,6 +148,15 @@ export async function dispatchImageBatch(input: DispatchInput): Promise<Dispatch
           count: 1,
         };
 
+    // Look up the AI-generated caption for this job's source row (Ideogram path only).
+    // parentPostIndex is the zero-based row index shared by all aspect-ratio variants
+    // of the same source row, so multiple jobs for the same row carry the same caption.
+    const parentIdx = spec.parentPostIndex ?? null;
+    const postText =
+      parentIdx !== null && input.postTextByParentIndex?.[parentIdx]
+        ? input.postTextByParentIndex[parentIdx]
+        : null;
+
     const { data: job, error: jobErr } = await svc
       .from("image_generation_jobs")
       .insert({
@@ -149,7 +166,8 @@ export async function dispatchImageBatch(input: DispatchInput): Promise<Dispatch
         generation_params: generationParams,
         target_platforms: spec.targetPlatforms ?? null,
         target_publish_date: spec.targetPublishDate ?? null,
-        parent_post_index: spec.parentPostIndex ?? null,
+        parent_post_index: parentIdx,
+        post_text: postText,
       })
       .select("id")
       .single();

--- a/supabase/migrations/0170_image_generation_jobs_post_text.sql
+++ b/supabase/migrations/0170_image_generation_jobs_post_text.sql
@@ -1,0 +1,25 @@
+-- Migration 0170: Add post_text to image_generation_jobs
+--
+-- Stores the AI-generated social caption (from interpretPosts()) alongside
+-- each image generation job so that auto-attach can pre-fill
+-- social_post_drafts.content instead of creating a shell with content=''.
+--
+-- Design decisions:
+--   - Nullable: template jobs, mood board, and manual dispatches have no
+--     caption. NULL is the correct sentinel — auto-attach treats it as "no
+--     caption available" and falls back to content=''.
+--   - Not in generation_params JSONB: JSONB is for image rendering config;
+--     a caption is post metadata. Keeping them separate avoids coupling
+--     image rendering to social publishing concerns.
+--   - No backfill: all existing jobs get NULL (correct — we cannot recover
+--     captions that were never stored).
+--   - Online-safe: ADD COLUMN with a nullable type acquires no row-level
+--     lock in Postgres. Zero-downtime.
+
+ALTER TABLE image_generation_jobs
+  ADD COLUMN IF NOT EXISTS post_text TEXT NULL;
+
+COMMENT ON COLUMN image_generation_jobs.post_text IS
+  'AI-generated social caption from the Ideogram ingest path (interpretPosts). '
+  'NULL for template jobs, mood-board jobs, and any job dispatched without a source post. '
+  'Written to social_post_drafts.content on auto-attach (creation only, never overwritten).';


### PR DESCRIPTION
## Summary

Closes the keystone gap identified in `IMAGE_TO_POST_FLOW.md §5 Gap 1`. AI-generated captions (`post_text` from `interpretPosts()`) now survive from ingest all the way to `social_post_drafts.content`. **Approve** now produces a draft that is substantially a real post, needing only human review — not full manual authoring.

## The bridge

```
interpretPosts()              → post_text in InterpretedPost[]   (was: discarded)
postTextByParentIndex map     → Record<number, string>           (new)
dispatchImageBatch()          → written to image_generation_jobs.post_text  (new column)
autoAttachImage()             → reads post_text from job         (new field in SELECT)
findOrCreateScheduledDraft()  → content = post_text ?? ""        (was: always "")
```

## Migration 0170

```sql
ALTER TABLE image_generation_jobs ADD COLUMN post_text TEXT NULL;
```

Additive, online-safe, zero backfill. Deploys automatically: `deploy-migrations.yml` triggers on merge to main when `supabase/migrations/**` changes.

## Create-only safety rule — non-negotiable

`content` is populated **only on new draft creation**. When `findOrCreateScheduledDraft` finds an existing draft for `(company, date)`, it returns the existing `id` and touches **nothing else** — the operator may have already edited the caption. Only `media_asset_ids` is appended on the find path.

Proven by test: `"existing draft: content is NOT overwritten"` asserts that the UPDATE patch sent to `social_post_drafts` contains no `content` key at all.

## What is unchanged

| Surface | Changed? |
|---|---|
| `fanOutJobs()` | ❌ unchanged |
| `DispatchJobSpec` | ❌ unchanged |
| Template mode (`ingest_mode=template`) | ❌ unchanged — template jobs get `post_text=null` |
| Composer / publisher | ❌ unchanged — reads `content` column normally; pre-populated content is transparent |
| All existing `dispatchImageBatch` callers that omit `postTextByParentIndex` | ❌ unchanged — get `post_text=null` |

## Tests (3053 pass)

**New tests in `image-auto-attach.unit.test.ts`:**
- `new draft: content is set from post_text when caption is present` — verifies caption flows through
- `new draft: content is empty string when post_text is null` — null-safety
- `existing draft: content is NOT overwritten — create-only rule enforced` — asserts `"content" in patch === false`

**New file `image-dispatch-post-text.unit.test.ts`:**
- Multi-aspect-ratio jobs for same row share the same caption
- Jobs with no entry in the map get `post_text=null`
- Map omitted entirely → `post_text=null` (zero regression for existing callers)
- `parentPostIndex=null` → `post_text=null`

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] `test:unit` — 3053 pass
- [x] Migration is `ADD COLUMN IF NOT EXISTS` — safe to re-run
- [x] No Composer or publisher changes
- [x] Risks: create-only rule enforced by test; template path unaffected by test; migration is non-destructive

## Browser verification target

Upload a spreadsheet with `body_text` + a `publish_date` column → generate → Approve an image → open the draft in the Composer → caption pre-filled from `body_text`/`post_text`, not empty.