### PR TITLE
feat(composer): resolve media_asset_ids → signed URLs when loading a draft

### DIFF
--- a/app/api/platform/social/drafts/[id]/route.ts
+++ b/app/api/platform/social/drafts/[id]/route.ts
@@ -126,7 +126,7 @@ export async function PATCH(
   const client = getServiceRoleClient();
   const { data: row } = await client
     .from("social_post_drafts")
-    .select("company_id, draft_data, draft_version")
+    .select("company_id, draft_data, draft_version, media_asset_ids")
     .eq("id", idCheck.value)
     .is("archived_at", null)
     .maybeSingle();
@@ -143,7 +143,7 @@ export async function PATCH(
     const {
       draft_version,
       content,
-      media_urls,
+      media_urls: rawMediaUrls,
       target_profile_ids,
       platform_variants,
       mode,
@@ -152,6 +152,18 @@ export async function PATCH(
       approval_required,
       approver_user_id,
     } = parsed.data;
+
+    // Strip Supabase-signed storage URLs from media_urls when this draft has
+    // media_asset_ids. Those signed URLs were injected by getDraft() for display
+    // only; re-persisting them alongside the permanent asset IDs causes duplicate
+    // images at publish time (the publish pipeline resolves asset IDs to fresh
+    // URLs independently). Non-Supabase URLs (external CDN, user uploads) are kept.
+    const draftAssetIds = (row.media_asset_ids as string[] | null) ?? [];
+    const supabaseStorageBase = (process.env.SUPABASE_URL ?? "") + "/storage/v1/object/sign/";
+    const media_urls =
+      draftAssetIds.length > 0
+        ? rawMediaUrls.filter((u) => !u.startsWith(supabaseStorageBase))
+        : rawMediaUrls;
 
     // Guard: cannot schedule a post with zero target channels.
     // A scheduled post with no targets is stuck — the publish cron has nothing to send to.

--- a/docs/backlog/ux-debt.md
+++ b/docs/backlog/ux-debt.md
@@ -24,3 +24,15 @@ Scan done 2026-04, none found on the primary surfaces:
 
 No `design_system_id`, `version_lock`, `wp_page_id`, `created_by_uuid`
 leaked into labels. Revisit if future surfaces add them.
+
+## Image gen — auto-attach caption refinement
+
+**Item:** `findOrCreateScheduledDraft` create-only rule blocks captions on pre-existing empty shells.
+
+**Current behaviour:** `content` is written only on new draft creation, never on update — correct for operator-edited drafts. But if an empty shell (`content = ""`) already exists for a date (e.g. from a pre-fix batch approval), a subsequent approval for the same date finds that draft, appends the image, and leaves `content = ""` — the caption is silently dropped even though the operator hasn't written anything.
+
+**Proposed refinement:** In the find path, if `existing_draft.content === ""` (blank, not just whitespace), write `post_text` to it. This fills empty shells while never overwriting real operator text (any non-empty content is treated as intentional and left alone).
+
+**Risk:** Requires reading `content` from the found draft (one extra field in the SELECT), then a conditional UPDATE. The update must be fail-soft — same contract as the rest of auto-attach. No schema change needed.
+
+**Scope:** `findOrCreateScheduledDraft` in `lib/image/auto-attach.ts` — add `content` to the find SELECT, add a conditional PATCH if found draft has blank content. New test: find-path with blank existing content → content updated; find-path with non-blank content → content NOT updated.

--- a/lib/__tests__/social-draft-media-resolve.unit.test.ts
+++ b/lib/__tests__/social-draft-media-resolve.unit.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for getDraft() media_asset_ids resolution (Gap 3 fix).
+ *
+ * Tests cover:
+ *  - Draft with media_asset_ids → media_urls in response contains signed URLs
+ *  - Draft with both media_asset_ids AND legacy media_urls → both appear in response
+ *  - Draft with no media_asset_ids → media_urls returned unchanged (zero regression)
+ *  - resolveMediaForPublish failure is fail-soft → draft returned without images (no throw)
+ *
+ * resolve-media.ts is mocked; getDraft itself is the system under test.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Supabase mock ────────────────────────────────────────────────────────────
+const mockDraftRow = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
+      maybeSingle: () => mockDraftRow(),
+    })),
+  })),
+}));
+
+// ─── resolve-media mock ───────────────────────────────────────────────────────
+const mockResolveMedia = vi.fn();
+vi.mock("@/lib/social/publishing/resolve-media", () => ({
+  resolveMediaForPublish: (...args: unknown[]) => mockResolveMedia(...args),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+import { getDraft } from "@/lib/platform/social/drafts";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DRAFT_ID   = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const COMPANY_ID = "bbbbbbbb-bbbb-4bbbb-8bbb-bbbbbbbbbbbb";
+const ASSET_ID_1 = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const ASSET_ID_2 = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const SIGNED_URL_1 = "https://project.supabase.co/storage/v1/object/sign/generated-images/path/1.png?token=abc";
+const SIGNED_URL_2 = "https://project.supabase.co/storage/v1/object/sign/generated-images/path/2.png?token=def";
+const LEGACY_URL  = "https://cdn.example.com/user-uploaded.jpg";
+
+function makeDraftRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DRAFT_ID,
+    company_id: COMPANY_ID,
+    state: "scheduled",
+    content: "Test caption",
+    media_urls: [],
+    media_asset_ids: null,
+    draft_version: 1,
+    draft_data: {},
+    scheduled_at: "2026-06-14T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("getDraft — media_asset_ids resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves media_asset_ids to signed URLs and merges into media_urls", async () => {
+    mockDraftRow.mockResolvedValue({
+      data: makeDraftRow({ media_asset_ids: [ASSET_ID_1], media_urls: [] }),
+      error: null,
+    });
+    mockResolveMedia.mockResolvedValue([SIGNED_URL_1]);
+
+    const result = await getDraft({ draftId: DRAFT_ID, companyId: COMPANY_ID });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.data as { media_urls: string[] }).media_urls).toEqual([SIGNED_URL_1]);
+
+    // resolveMediaForPublish was called with correct args
+    expect(mockResolveMedia).toHaveBeenCalledWith({
+      mediaAssetIds: [ASSET_ID_1],
+      legacyMediaUrls: [],
+    });
+  });
+
+  it("merges asset-resolved URLs with legacy media_urls (both sources preserved)", async () => {
+    mockDraftRow.mockResolvedValue({
+      data: makeDraftRow({
+        media_asset_ids: [ASSET_ID_1, ASSET_ID_2],
+        media_urls: [LEGACY_URL],
+      }),
+      error: null,
+    });
+    // resolve-media returns asset URLs first, then legacy (same as the publish pipeline)
+    mockResolveMedia.mockResolvedValue([SIGNED_URL_1, SIGNED_URL_2, LEGACY_URL]);
+
+    const result = await getDraft({ draftId: DRAFT_ID, companyId: COMPANY_ID });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const urls = (result.data as { media_urls: string[] }).media_urls;
+    expect(urls).toContain(SIGNED_URL_1);
+    expect(urls).toContain(SIGNED_URL_2);
+    expect(urls).toContain(LEGACY_URL);
+  });
+
+  it("skips resolution and returns media_urls unchanged when media_asset_ids is empty", async () => {
+    mockDraftRow.mockResolvedValue({
+      data: makeDraftRow({ media_asset_ids: [], media_urls: [LEGACY_URL] }),
+      error: null,
+    });
+
+    const result = await getDraft({ draftId: DRAFT_ID, companyId: COMPANY_ID });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.data as { media_urls: string[] }).media_urls).toEqual([LEGACY_URL]);
+    expect(mockResolveMedia).not.toHaveBeenCalled();
+  });
+
+  it("skips resolution and returns media_urls unchanged when media_asset_ids is null", async () => {
+    mockDraftRow.mockResolvedValue({
+      data: makeDraftRow({ media_asset_ids: null, media_urls: [LEGACY_URL] }),
+      error: null,
+    });
+
+    const result = await getDraft({ draftId: DRAFT_ID, companyId: COMPANY_ID });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.data as { media_urls: string[] }).media_urls).toEqual([LEGACY_URL]);
+    expect(mockResolveMedia).not.toHaveBeenCalled();
+  });
+
+  it("fail-soft: resolution error returns draft with original media_urls, does not throw", async () => {
+    mockDraftRow.mockResolvedValue({
+      data: makeDraftRow({ media_asset_ids: [ASSET_ID_1], media_urls: [] }),
+      error: null,
+    });
+    mockResolveMedia.mockRejectedValue(new Error("Supabase storage unavailable"));
+
+    const result = await getDraft({ draftId: DRAFT_ID, companyId: COMPANY_ID });
+
+    // Must not throw — Composer must still open even if images can't be resolved
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Falls back to original media_urls (empty) — no images shown but no crash
+    expect((result.data as { media_urls: string[] }).media_urls).toEqual([]);
+  });
+});

--- a/lib/platform/social/drafts.ts
+++ b/lib/platform/social/drafts.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
 import type { ApiResponse } from "@/lib/tool-schemas";
 
 // ---------------------------------------------------------------------------
@@ -163,9 +164,39 @@ export async function getDraft(params: {
     };
   }
 
+  // Resolve media_asset_ids → signed URLs so the Composer can display
+  // auto-attached images (Gap 3 fix). Uses the same resolveMediaForPublish
+  // logic as the publish pipeline — no duplication.
+  //
+  // Resolution is merged into media_urls for the API response only.
+  // The DB row is not modified here; asset IDs remain the authoritative source.
+  const row = data as Record<string, unknown>;
+  const rawAssetIds = (row.media_asset_ids as string[] | null) ?? [];
+  let resolvedData = data;
+
+  if (rawAssetIds.length > 0) {
+    try {
+      const { resolveMediaForPublish } = await import("@/lib/social/publishing/resolve-media");
+      const rawMediaUrls = (row.media_urls as string[] | null) ?? [];
+      const resolvedUrls = await resolveMediaForPublish({
+        mediaAssetIds: rawAssetIds,
+        legacyMediaUrls: rawMediaUrls,
+      });
+      resolvedData = { ...data, media_urls: resolvedUrls };
+    } catch (err) {
+      // Fail-soft: if resolution fails, return the draft without images rather
+      // than blocking the Composer from opening. The publish pipeline will
+      // re-resolve from media_asset_ids at publish time.
+      logger.warn("social.drafts.get.asset_resolve_failed", {
+        draftId: params.draftId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   return {
     ok: true,
-    data: data as unknown as Draft,
+    data: resolvedData as unknown as Draft,
     timestamp: new Date().toISOString(),
   };
 }


### PR DESCRIPTION
## Summary

Closes Gap 3 from \`IMAGE_TO_POST_FLOW.md\`. Auto-attached images (stored as \`media_asset_ids\` UUIDs in \`social_post_drafts\`) are now visible in the Composer editor when opening a draft.

## Root cause

\`getDraft()\` returned drafts with \`media_urls = []\` even when \`media_asset_ids\` contained asset UUIDs. \`mapV1ToV2Draft\` in \`ComposerMountV2\` only reads \`media_urls\`, so thumbnails never appeared.

## Fix

**\`lib/platform/social/drafts.ts\` — \`getDraft()\`:** If the fetched draft has non-empty \`media_asset_ids\`, calls \`resolveMediaForPublish()\` (the same function the publish pipeline uses — no duplication) to resolve UUIDs → signed storage URLs, then merges the result into \`media_urls\` before returning. Fail-soft: if resolution throws, the draft is returned with original \`media_urls\` so the Composer still opens. No DB writes.

**\`app/api/platform/social/drafts/[id]/route.ts\` PATCH handler:** Reads \`media_asset_ids\` from the row (added to SELECT). Before writing \`media_urls\` to DB, strips any Supabase signed storage URLs (matching \`SUPABASE_URL/storage/v1/object/sign/\`) when the draft has \`media_asset_ids\`. This prevents the contamination scenario: without this, a user saving after opening would persist the display-only signed URL alongside the permanent asset ID, causing the publish pipeline to send the same image twice. External CDN and user-upload URLs are unaffected.

## Both media paths preserved

| Source | Behaviour |
|---|---|
| Legacy \`media_urls\` (external URLs, V1 uploads) | Unchanged — returned as-is, saved as-is |
| \`media_asset_ids\` (auto-attach from image batches) | Resolved at load, stripped at save — asset IDs remain authoritative |

## Tests (3058 pass)

New \`social-draft-media-resolve.unit.test.ts\`:
- \`media_asset_ids\` → signed URLs in \`media_urls\` response
- Both sources merged correctly (asset URLs first, legacy URLs appended)
- Empty/null \`media_asset_ids\` → no resolution, no regression
- Resolution failure → fail-soft, draft still returned

## Pre-PR checklist

- [x] Lint, typecheck all green
- [x] \`test:unit\` — 3058 pass
- [x] Legacy \`media_urls\` path unaffected (confirmed by null/empty tests)
- [x] No migration — display-only change, no schema changes