### PR TITLE
feat(auto-attach): prefill target_profiles on auto-created drafts (Gap 2)

### DIFF
--- a/lib/__tests__/image-auto-attach-target-profiles.unit.test.ts
+++ b/lib/__tests__/image-auto-attach-target-profiles.unit.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for Gap 2: target_profiles prefill on auto-created drafts.
+ *
+ * Tests cover:
+ *  1. One matching connection → target_profiles + draft_data.target_connection_ids populated
+ *  2. No matching connection → target_profiles: [], draft still created (graceful skip)
+ *  3. Mixed (linkedin connected, facebook not) → only linkedin in target_profiles
+ *  4. Business-over-personal preference: linkedin_company beats linkedin_personal
+ *  5. Existing draft (find path) → NO INSERT called (create-only rule enforced)
+ *  6. Both linkedin variants + facebook → 2 entries, personal excluded
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Shared test state (captured by mock closures) ────────────────────────────
+
+let capturedDraftInsert: Record<string, unknown> | null = null;
+let existingDraftForDate: { id: string } | null = null;
+let socialConnectionsResult: Array<{ id: string; platform: string; display_name: string | null; avatar_url: string | null }> = [];
+
+// ─── Supabase mock — full chain supporting all operations in autoAttachImage ──
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({
+    from(table: string) {
+      // image_generation_jobs: load job (select chain) + markJobAttachState (update chain)
+      if (table === "image_generation_jobs") {
+        return {
+          select() {
+            const c: Record<string, unknown> = {};
+            c["select"] = () => c;
+            c["eq"] = () => c;
+            c["maybeSingle"] = async () => ({
+              data: {
+                id: JOB_ID,
+                company_id: COMPANY_ID,
+                state: "completed",
+                result_storage_path: STORAGE_PATH,
+                target_publish_date: "2026-07-01",
+                generation_params: { aspectRatio: "1x1" },
+                post_text: "Test caption.",
+                target_platforms: ["linkedin", "facebook"],
+              },
+              error: null,
+            });
+            return c;
+          },
+          update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+        };
+      }
+
+      // social_media_assets: insert asset row
+      if (table === "social_media_assets") {
+        return {
+          insert: () => ({
+            select: () => ({
+              single: async () => ({ data: { id: ASSET_ID }, error: null }),
+            }),
+          }),
+        };
+      }
+
+      // social_connections: lookup company's connected accounts
+      if (table === "social_connections") {
+        const c: Record<string, unknown> = {};
+        c["select"] = () => c;
+        c["eq"] = () => c;
+        c["in"] = () => c;
+        c["neq"] = async () => ({ data: socialConnectionsResult, error: null });
+        return c;
+      }
+
+      // social_post_drafts: find-or-create draft + read media_asset_ids + update media_asset_ids
+      // Distinguish the two SELECT calls by the columns requested:
+      //   "id"             → draft lookup (find-or-create)
+      //   "media_asset_ids"→ read-before-update (Step 3 in autoAttachImage)
+      if (table === "social_post_drafts") {
+        return {
+          select(cols?: string) {
+            const isMediaRead = cols?.includes("media_asset_ids");
+            const c: Record<string, unknown> = {};
+            c["select"] = () => c;
+            c["eq"] = () => c;
+            c["is"] = () => c;
+            c["limit"] = () => c;
+            c["maybeSingle"] = async () => ({
+              data: isMediaRead ? { media_asset_ids: [] } : existingDraftForDate,
+              error: null,
+            });
+            return c;
+          },
+          insert(row: Record<string, unknown>) {
+            capturedDraftInsert = row;
+            return {
+              select: () => ({
+                single: async () => ({ data: { id: NEW_DRAFT_ID }, error: null }),
+              }),
+            };
+          },
+          update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+        };
+      }
+
+      // Fallthrough: return a no-op chain
+      const noop: Record<string, unknown> = {};
+      noop["select"] = () => noop;
+      noop["eq"] = () => noop;
+      noop["update"] = () => ({ eq: () => Promise.resolve({ error: null }) });
+      noop["maybeSingle"] = async () => ({ data: null, error: null });
+      return noop;
+    },
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { autoAttachImage } from "@/lib/image/auto-attach";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const JOB_ID       = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const COMPANY_ID   = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const APPROVER_ID  = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const NEW_DRAFT_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const EXISTING_DRAFT_ID = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+const ASSET_ID     = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+const STORAGE_PATH = "co/img.png";
+
+const LI_PERSONAL_ID = "11111111-1111-4111-8111-111111111111";
+const LI_COMPANY_ID  = "22222222-2222-4222-8222-222222222222";
+const FB_PAGE_ID     = "33333333-3333-4333-8333-333333333333";
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("autoAttachImage — target_profiles prefill (Gap 2)", () => {
+  beforeEach(() => {
+    capturedDraftInsert = null;
+    existingDraftForDate = null;
+    socialConnectionsResult = [];
+    vi.clearAllMocks();
+  });
+
+  it("one matching connection → target_profiles and draft_data.target_connection_ids populated", async () => {
+    socialConnectionsResult = [
+      { id: LI_COMPANY_ID, platform: "linkedin_company", display_name: "Acme Ltd", avatar_url: null },
+    ];
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID, companyId: COMPANY_ID, approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attached");
+    expect(capturedDraftInsert).not.toBeNull();
+
+    const profiles = capturedDraftInsert!.target_profiles as Array<{ profile_id: string; platform: string }>;
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]!.profile_id).toBe(LI_COMPANY_ID);
+    expect(profiles[0]!.platform).toBe("linkedin_company");
+
+    const draftData = capturedDraftInsert!.draft_data as { target_connection_ids: string[] };
+    expect(draftData.target_connection_ids).toEqual([LI_COMPANY_ID]);
+  });
+
+  it("no matching connection → target_profiles: [], draft created without channels", async () => {
+    socialConnectionsResult = [];
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID, companyId: COMPANY_ID, approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attached");
+    expect(capturedDraftInsert).not.toBeNull();
+    expect(capturedDraftInsert!.target_profiles).toEqual([]);
+    const dd = capturedDraftInsert!.draft_data as Record<string, unknown>;
+    expect(dd.target_connection_ids).toBeUndefined();
+  });
+
+  it("mixed: linkedin connected, facebook not → only linkedin in target_profiles", async () => {
+    socialConnectionsResult = [
+      { id: LI_COMPANY_ID, platform: "linkedin_company", display_name: "Acme Ltd", avatar_url: null },
+      // No facebook_page — not connected
+    ];
+
+    await autoAttachImage({ jobId: JOB_ID, companyId: COMPANY_ID, approvedBy: APPROVER_ID });
+
+    const profiles = capturedDraftInsert!.target_profiles as Array<{ profile_id: string }>;
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]!.profile_id).toBe(LI_COMPANY_ID);
+  });
+
+  it("business-over-personal: linkedin_company preferred over linkedin_personal", async () => {
+    // Both variants connected — company must win (per baked-in preference)
+    socialConnectionsResult = [
+      { id: LI_PERSONAL_ID, platform: "linkedin_personal", display_name: "Alice", avatar_url: null },
+      { id: LI_COMPANY_ID,  platform: "linkedin_company",  display_name: "Acme",  avatar_url: null },
+    ];
+
+    await autoAttachImage({ jobId: JOB_ID, companyId: COMPANY_ID, approvedBy: APPROVER_ID });
+
+    const profiles = capturedDraftInsert!.target_profiles as Array<{ profile_id: string }>;
+    const linkedinIds = profiles
+      .map((p) => p.profile_id)
+      .filter((id) => id === LI_COMPANY_ID || id === LI_PERSONAL_ID);
+    // Exactly one linkedin entry, and it must be the company page
+    expect(linkedinIds).toHaveLength(1);
+    expect(linkedinIds[0]).toBe(LI_COMPANY_ID);
+  });
+
+  it("existing draft (find path) → no INSERT, target_profiles untouched (create-only rule)", async () => {
+    existingDraftForDate = { id: EXISTING_DRAFT_ID };
+    socialConnectionsResult = [
+      { id: LI_COMPANY_ID, platform: "linkedin_company", display_name: "Acme", avatar_url: null },
+    ];
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID, companyId: COMPANY_ID, approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attached");
+    // No INSERT — existing draft was found, not created
+    expect(capturedDraftInsert).toBeNull();
+  });
+
+  it("both linkedin variants + facebook → 2 entries, personal excluded", async () => {
+    socialConnectionsResult = [
+      { id: LI_PERSONAL_ID, platform: "linkedin_personal", display_name: "Alice",   avatar_url: null },
+      { id: LI_COMPANY_ID,  platform: "linkedin_company",  display_name: "Acme",    avatar_url: null },
+      { id: FB_PAGE_ID,     platform: "facebook_page",     display_name: "Acme FB", avatar_url: null },
+    ];
+
+    await autoAttachImage({ jobId: JOB_ID, companyId: COMPANY_ID, approvedBy: APPROVER_ID });
+
+    const profiles = capturedDraftInsert!.target_profiles as Array<{ profile_id: string }>;
+    const ids = profiles.map((p) => p.profile_id);
+    expect(ids).toContain(LI_COMPANY_ID);   // company page selected
+    expect(ids).toContain(FB_PAGE_ID);      // facebook included
+    expect(ids).not.toContain(LI_PERSONAL_ID); // personal excluded
+    expect(ids).toHaveLength(2);
+  });
+});

--- a/lib/__tests__/social-draft-media-resolve.unit.test.ts
+++ b/lib/__tests__/social-draft-media-resolve.unit.test.ts
@@ -82,7 +82,7 @@ describe("getDraft — media_asset_ids resolution", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect((result.data as { media_urls: string[] }).media_urls).toEqual([SIGNED_URL_1]);
+    expect((result.data as unknown as { media_urls: string[] }).media_urls).toEqual([SIGNED_URL_1]);
 
     // resolveMediaForPublish was called with correct args
     expect(mockResolveMedia).toHaveBeenCalledWith({
@@ -106,7 +106,7 @@ describe("getDraft — media_asset_ids resolution", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    const urls = (result.data as { media_urls: string[] }).media_urls;
+    const urls = (result.data as unknown as { media_urls: string[] }).media_urls;
     expect(urls).toContain(SIGNED_URL_1);
     expect(urls).toContain(SIGNED_URL_2);
     expect(urls).toContain(LEGACY_URL);
@@ -122,7 +122,7 @@ describe("getDraft — media_asset_ids resolution", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect((result.data as { media_urls: string[] }).media_urls).toEqual([LEGACY_URL]);
+    expect((result.data as unknown as { media_urls: string[] }).media_urls).toEqual([LEGACY_URL]);
     expect(mockResolveMedia).not.toHaveBeenCalled();
   });
 
@@ -136,7 +136,7 @@ describe("getDraft — media_asset_ids resolution", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect((result.data as { media_urls: string[] }).media_urls).toEqual([LEGACY_URL]);
+    expect((result.data as unknown as { media_urls: string[] }).media_urls).toEqual([LEGACY_URL]);
     expect(mockResolveMedia).not.toHaveBeenCalled();
   });
 
@@ -153,6 +153,6 @@ describe("getDraft — media_asset_ids resolution", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     // Falls back to original media_urls (empty) — no images shown but no crash
-    expect((result.data as { media_urls: string[] }).media_urls).toEqual([]);
+    expect((result.data as unknown as { media_urls: string[] }).media_urls).toEqual([]);
   });
 });

--- a/lib/image/auto-attach.ts
+++ b/lib/image/auto-attach.ts
@@ -44,7 +44,7 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
     const { data: job, error: jobErr } = await svc
       .from("image_generation_jobs")
       .select(
-        "id, company_id, state, result_storage_path, target_publish_date, generation_params, post_text",
+        "id, company_id, state, result_storage_path, target_publish_date, generation_params, post_text, target_platforms",
       )
       .eq("id", input.jobId)
       .maybeSingle();
@@ -63,6 +63,7 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
       target_publish_date: string | null;
       generation_params: Record<string, unknown>;
       post_text: string | null;
+      target_platforms: string[] | null;
     };
 
     if (j.company_id !== input.companyId) {
@@ -128,6 +129,7 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
       publishDate: j.target_publish_date,
       approvedBy: input.approvedBy,
       postText: j.post_text ?? null,
+      targetPlatforms: (j.target_platforms as string[] | null) ?? [],
     });
 
     if (!draftId) {
@@ -224,6 +226,120 @@ async function markJobAttachState(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Platform code → social_connections.platform resolution
+//
+// Spreadsheet target_platforms use generic codes ("linkedin", "facebook").
+// social_connections.platform uses bundle.social-specific sub-types.
+// This map defines which DB platform values satisfy each generic code,
+// ordered by PREFERENCE: business/company pages first, personal pages last.
+//
+// Preference rule (baked in per spec):
+//   If a company has BOTH linkedin_personal AND linkedin_company, use
+//   linkedin_company — the normal business-posting target. The same
+//   "prefer company/business account over personal" logic applies to
+//   any platform that has a personal vs business variant.
+// ---------------------------------------------------------------------------
+
+type DbPlatform = "linkedin_personal" | "linkedin_company" | "facebook_page"
+  | "instagram_business" | "x" | "gbp";
+
+const GENERIC_TO_DB_PLATFORMS: Record<string, DbPlatform[]> = {
+  // Business page preferred over personal page.
+  linkedin:           ["linkedin_company", "linkedin_personal"],
+  linkedin_landscape: ["linkedin_company", "linkedin_personal"],
+  // Only one DB variant per platform below.
+  instagram:          ["instagram_business"],
+  instagram_story:    ["instagram_business"],
+  facebook:           ["facebook_page"],
+  facebook_story:     ["facebook_page"],
+  x:                  ["x"],
+  gbp:                ["gbp"],
+};
+
+interface ResolvedConnection {
+  profile_id: string;
+  platform: string;
+  account_name: string | null;
+  account_avatar_url: string | null;
+}
+
+/**
+ * Resolve generic platform codes to the company's connected social accounts.
+ *
+ * For each generic code, picks the highest-priority connected DB platform
+ * (business over personal). Silently skips platforms the company hasn't
+ * connected. Returns [] if the lookup fails (fail-soft contract).
+ */
+async function resolveTargetConnections(
+  svc: ReturnType<typeof getServiceRoleClient>,
+  companyId: string,
+  genericPlatformCodes: string[],
+): Promise<ResolvedConnection[]> {
+  // Collect the unique set of DB platform values needed across all codes.
+  const dbPlatformsNeeded = new Set<DbPlatform>();
+  for (const code of genericPlatformCodes) {
+    for (const dbP of GENERIC_TO_DB_PLATFORMS[code] ?? []) {
+      dbPlatformsNeeded.add(dbP);
+    }
+  }
+
+  if (dbPlatformsNeeded.size === 0) return [];
+
+  const { data, error } = await svc
+    .from("social_connections")
+    .select("id, platform, display_name, avatar_url")
+    .eq("company_id", companyId)
+    .in("platform", [...dbPlatformsNeeded])
+    .neq("status", "disconnected");
+
+  if (error) {
+    logger.warn("image.auto_attach.connections_lookup_failed", {
+      companyId,
+      err: error.message,
+    });
+    return [];
+  }
+
+  const rows = (data ?? []) as Array<{
+    id: string;
+    platform: string;
+    display_name: string | null;
+    avatar_url: string | null;
+  }>;
+
+  // Build a map of dbPlatform → connection row (one per platform sub-type).
+  const byDbPlatform = new Map<string, (typeof rows)[0]>();
+  for (const row of rows) {
+    byDbPlatform.set(row.platform, row);
+  }
+
+  // For each generic code, pick the highest-priority matching connection.
+  // Deduplicate by connection id so two generic codes that resolve to the
+  // same DB platform (e.g. linkedin + linkedin_landscape) don't add duplicates.
+  const seen = new Set<string>();
+  const resolved: ResolvedConnection[] = [];
+
+  for (const code of genericPlatformCodes) {
+    const candidates = GENERIC_TO_DB_PLATFORMS[code] ?? [];
+    for (const dbPlatform of candidates) {
+      const conn = byDbPlatform.get(dbPlatform);
+      if (conn && !seen.has(conn.id)) {
+        seen.add(conn.id);
+        resolved.push({
+          profile_id: conn.id,
+          platform: conn.platform,
+          account_name: conn.display_name,
+          account_avatar_url: conn.avatar_url,
+        });
+        break; // highest-priority match found for this generic code
+      }
+    }
+  }
+
+  return resolved;
+}
+
 interface FindOrCreateDraftInput {
   companyId: string;
   publishDate: string; // YYYY-MM-DD
@@ -235,6 +351,12 @@ interface FindOrCreateDraftInput {
    * the operator may have already edited the caption on an existing draft.
    */
   postText: string | null;
+  /**
+   * Generic platform codes from the spreadsheet row (e.g. ["linkedin", "facebook"]).
+   * Resolved to the company's actual connected social_connections on new draft
+   * creation only. Empty array or unmatched codes are silently skipped.
+   */
+  targetPlatforms: string[];
 }
 
 async function findOrCreateScheduledDraft(
@@ -273,10 +395,25 @@ async function findOrCreateScheduledDraft(
     return (existing as { id: string }).id;
   }
 
-  // No existing draft — create one. Pre-fill content from the AI-generated
-  // caption if available; fall back to empty string so the operator can write
-  // from scratch. This is the ONLY place content is set; it is never
-  // overwritten after creation.
+  // No existing draft — create one.
+  //
+  // Resolve target platforms → connected social accounts (fail-soft: returns []
+  // on error or when no matching connections exist, so the draft is still created).
+  const resolvedConnections = await resolveTargetConnections(
+    svc,
+    input.companyId,
+    input.targetPlatforms,
+  );
+
+  // target_profiles stores the full connection shape for the Composer display layer.
+  // draft_data.target_connection_ids stores the UUIDs for the V2 save/publish path.
+  // Both must be written — mapV1ToV2Draft reads target_connection_ids first (§draft_data
+  // mirroring convention), falling back to target_profiles. Writing both is safe.
+  const connectionIds = resolvedConnections.map((c) => c.profile_id);
+
+  // Pre-fill content from the AI-generated caption if available; fall back to
+  // empty string. This is the ONLY place content is set; never overwritten after
+  // creation (create-only rule — same as target_profiles and content).
   const { data: created, error: createErr } = await svc
     .from("social_post_drafts")
     .insert({
@@ -287,10 +424,14 @@ async function findOrCreateScheduledDraft(
       content: input.postText ?? "",
       media_urls: [],
       media_asset_ids: [],
-      target_profiles: [],
+      target_profiles: resolvedConnections,
       platform_variants: {},
       scheduled_at: scheduledAtIso,
       approval_required: false,
+      // Mirror connection IDs into draft_data for the V2 Composer save path.
+      draft_data: connectionIds.length > 0
+        ? { target_connection_ids: connectionIds }
+        : {},
     })
     .select("id")
     .single();


### PR DESCRIPTION
## Summary

Closes Gap 2 from \`IMAGE_TO_POST_FLOW.md\`. When a spreadsheet row has \`target_platforms\` (e.g. \`["linkedin", "facebook"]\`), the auto-created draft now has the company's connected social accounts pre-selected — so the Composer preview renders immediately and the post is one click from publishing.

## Platform resolution

Spreadsheet codes (`"linkedin"`, `"facebook"`, etc.) map to `social_connections.platform` sub-types with a preference ordering baked in:

| Generic code | DB candidates | Preference |
|---|---|---|
| `linkedin` / `linkedin_landscape` | `linkedin_company`, `linkedin_personal` | **business page first** |
| `instagram` / `instagram_story` | `instagram_business` | only one variant |
| `facebook` / `facebook_story` | `facebook_page` | only one variant |
| `x` | `x` | only one variant |
| `gbp` | `gbp` | only one variant |

If a company has both `linkedin_personal` and `linkedin_company`, `linkedin_company` is selected. Personal account is never included when a company page is available.

## What's written on new draft creation

- `social_post_drafts.target_profiles`: `[{ profile_id, platform, account_name, account_avatar_url }]` — full connection shape for the Composer display layer
- `draft_data.target_connection_ids`: `[uuid, ...]` — mirror for the V2 Composer save path (`mapV1ToV2Draft` reads this first)

## Safety guarantees

- **Create-only rule**: only on new draft creation. Existing drafts (find path) are never touched — `capturedDraftInsert` is null in the find-path test.
- **Fail-soft**: if the `social_connections` lookup throws, `resolveTargetConnections()` returns `[]` and the draft is created with `target_profiles: []` (current behaviour, no regression).
- **Graceful skip**: if no connection exists for a platform in the spreadsheet, that platform is silently omitted. No error, no blocking.
- **Deduplication**: if two generic codes resolve to the same DB platform (e.g. `linkedin` + `linkedin_landscape` both → `linkedin_company`), the connection appears once.

## Tests (6 new, 3064 total pass)

| Test | Assertion |
|---|---|
| One matching connection | `target_profiles` + `draft_data.target_connection_ids` populated |
| No matching connection | `target_profiles: []`, draft still created |
| Mixed (linkedin ✓, facebook ✗) | Only linkedin in `target_profiles` |
| Business-over-personal | `linkedin_company` beats `linkedin_personal` |
| Existing draft (find path) | No INSERT — create-only rule enforced |
| Both linkedin variants + facebook | 2 entries; personal excluded |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] `test:unit` — 3064 pass
- [x] No migration — reads from existing `social_connections` table
- [x] Additive only — existing draft find path unchanged