### PR TITLE
fix(calendar): resolve media_asset_ids for day-panel thumbnails

### DIFF
--- a/app/api/platform/social/drafts/calendar-view/route.ts
+++ b/app/api/platform/social/drafts/calendar-view/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
 import { validationError } from "@/lib/http";
 
 export const runtime = "nodejs";
@@ -35,7 +36,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const svc = getServiceRoleClient();
   let query = svc
     .from("social_post_drafts")
-    .select("id, state, scheduled_at, published_at, content, media_urls, target_profiles, parent_draft_id, link_url")
+    .select("id, state, scheduled_at, published_at, content, media_urls, media_asset_ids, target_profiles, parent_draft_id, link_url")
     .eq("company_id", companyId)
     .is("archived_at", null)
     .or(`scheduled_at.gte.${from},published_at.gte.${from}`)
@@ -52,25 +53,99 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     );
   }
 
+  // Resolve media_asset_ids → signed URLs for thumbnail display.
+  // Same pattern as getDraft() (PR #1223) but batched for efficiency:
+  // one social_media_assets SELECT + one createSignedUrls call covers
+  // all posts in the calendar range.
+  //
+  // We only need the FIRST asset per post (primary_media_url), so we
+  // collect only the first asset ID from each row that has media_asset_ids
+  // but empty/missing media_urls.
+  const IMAGE_GEN_BUCKET = process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
+  const SIGNED_URL_TTL = 3600;
+
+  // Build a map: assetId → signedUrl for all first-asset IDs in this batch.
+  const assetIdToSignedUrl = new Map<string, string>();
+
+  const firstAssetIds = (data ?? [])
+    .map((row) => {
+      const hasLegacy = ((row.media_urls as string[] | null) ?? []).length > 0;
+      if (hasLegacy) return null; // legacy media_urls take precedence — no resolution needed
+      const ids = (row.media_asset_ids as string[] | null) ?? [];
+      return ids[0] ?? null; // only the first asset (for primary_media_url)
+    })
+    .filter((id): id is string => id !== null);
+
+  const uniqueFirstIds = [...new Set(firstAssetIds)];
+
+  if (uniqueFirstIds.length > 0) {
+    try {
+      // Fetch storage paths in one query.
+      const { data: assetRows, error: assetErr } = await svc
+        .from("social_media_assets")
+        .select("id, storage_path")
+        .in("id", uniqueFirstIds);
+
+      if (assetErr) {
+        logger.warn("calendar_view.asset_lookup_failed", { err: assetErr.message });
+      } else if (assetRows && assetRows.length > 0) {
+        // Batch-sign all storage paths in one call.
+        const paths = (assetRows as Array<{ id: string; storage_path: string }>)
+          .map((r) => r.storage_path);
+        const { data: signed, error: signErr } = await svc.storage
+          .from(IMAGE_GEN_BUCKET)
+          .createSignedUrls(paths, SIGNED_URL_TTL);
+
+        if (signErr) {
+          logger.warn("calendar_view.asset_sign_failed", { err: signErr.message });
+        } else {
+          // Build assetId → signedUrl map using the signed results (same order as paths).
+          const pathToSigned = new Map<string, string>();
+          for (const s of signed ?? []) {
+            if (s.signedUrl && s.path) pathToSigned.set(s.path, s.signedUrl);
+          }
+          for (const row of assetRows as Array<{ id: string; storage_path: string }>) {
+            const url = pathToSigned.get(row.storage_path);
+            if (url) assetIdToSignedUrl.set(row.id, url);
+          }
+        }
+      }
+    } catch (err) {
+      // Fail-soft: thumbnails will be missing but calendar still loads.
+      logger.warn("calendar_view.asset_resolve_threw", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   const posts = (data ?? [])
     .filter((row) => {
       if (profileIds.length === 0) return true;
       const profiles = (row.target_profiles as Array<{ profile_id: string }> | null) ?? [];
       return profiles.some((p) => profileIds.includes(p.profile_id));
     })
-    .map((row) => ({
-      id: row.id as string,
-      state: row.state as string,
-      scheduled_at: row.scheduled_at as string | null,
-      published_at: row.published_at as string | null,
-      content_excerpt: ((row.content as string | null) ?? "").slice(0, 100),
-      primary_media_url: ((row.media_urls as string[] | null) ?? [])[0] ?? null,
-      link_url: (row.link_url as string | null) ?? null,
-      target_profiles: ((row.target_profiles as Array<{ profile_id: string }> | null) ?? []).map(
-        (p) => ({ platform: null, account_avatar_url: null, profile_id: p.profile_id }),
-      ),
-      is_recurring_child: row.parent_draft_id !== null,
-    }));
+    .map((row) => {
+      // primary_media_url: legacy media_urls first, then first resolved asset ID.
+      const legacyUrls = (row.media_urls as string[] | null) ?? [];
+      const assetIds = (row.media_asset_ids as string[] | null) ?? [];
+      const primaryMediaUrl =
+        legacyUrls[0] ??
+        (assetIds[0] ? (assetIdToSignedUrl.get(assetIds[0]) ?? null) : null);
+
+      return {
+        id: row.id as string,
+        state: row.state as string,
+        scheduled_at: row.scheduled_at as string | null,
+        published_at: row.published_at as string | null,
+        content_excerpt: ((row.content as string | null) ?? "").slice(0, 100),
+        primary_media_url: primaryMediaUrl,
+        link_url: (row.link_url as string | null) ?? null,
+        target_profiles: ((row.target_profiles as Array<{ profile_id: string }> | null) ?? []).map(
+          (p) => ({ platform: null, account_avatar_url: null, profile_id: p.profile_id }),
+        ),
+        is_recurring_child: row.parent_draft_id !== null,
+      };
+    });
 
   const responseData = { posts, range: { from, to } };
 

--- a/lib/__tests__/social-calendar-view-thumbnail.unit.test.ts
+++ b/lib/__tests__/social-calendar-view-thumbnail.unit.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for calendar-view thumbnail resolution (media_asset_ids → signed URL).
+ *
+ * Tests cover:
+ *  - Draft with media_asset_ids and no media_urls → primary_media_url from signed URL
+ *  - Legacy draft (media_urls only) → primary_media_url from media_urls (unchanged)
+ *  - Draft with both → legacy media_urls takes precedence (no resolution needed)
+ *  - Fail-soft: asset lookup error → primary_media_url null, calendar still loads
+ *  - No media at all → primary_media_url null
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Auth gate ────────────────────────────────────────────────────────────────
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: vi.fn().mockResolvedValue({ kind: "allow", userId: "user-1" }),
+}));
+
+// ─── Supabase ─────────────────────────────────────────────────────────────────
+const COMPANY_ID   = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ASSET_ID_1   = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const STORAGE_PATH = "co/template-composite/img.png";
+const SIGNED_URL   = "https://proj.supabase.co/storage/v1/object/sign/generated-images/co/img.png?token=abc";
+const LEGACY_URL   = "https://cdn.example.com/legacy.jpg";
+
+let mockDrafts: Array<Record<string, unknown>> = [];
+let mockAssets: Array<{ id: string; storage_path: string }> = [];
+let mockSignedUrls: Array<{ path: string; signedUrl: string }> = [];
+let assetLookupShouldError = false;
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "social_post_drafts") {
+    const c: Record<string, unknown> = {};
+    c["select"] = () => c;
+    c["eq"] = () => c;
+    c["is"] = () => c;
+    c["or"] = () => c;
+    c["order"] = () => c;
+    c["limit"] = async () => ({
+      data: mockDrafts,
+      error: null,
+    });
+    return c;
+  }
+  if (table === "social_media_assets") {
+    const c: Record<string, unknown> = {};
+    c["select"] = () => c;
+    c["in"] = async () => ({
+      data: assetLookupShouldError ? null : mockAssets,
+      error: assetLookupShouldError ? { message: "DB error" } : null,
+    });
+    return c;
+  }
+  return {};
+});
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({
+    from: mockFrom,
+    storage: {
+      from: () => ({
+        createSignedUrls: async () => ({
+          data: mockSignedUrls,
+          error: null,
+        }),
+      }),
+    },
+  })),
+}));
+
+import { GET } from "@/app/api/platform/social/drafts/calendar-view/route";
+
+function makeRequest(): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/platform/social/drafts/calendar-view?company_id=${COMPANY_ID}&from=2026-06-01&to=2026-06-30`,
+  );
+}
+
+function makeDraft(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "draft-1",
+    state: "scheduled",
+    scheduled_at: "2026-06-14T00:00:00Z",
+    published_at: null,
+    content: "Test caption",
+    media_urls: [],
+    media_asset_ids: [],
+    target_profiles: [],
+    parent_draft_id: null,
+    link_url: null,
+    ...overrides,
+  };
+}
+
+describe("calendar-view — primary_media_url resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDrafts = [];
+    mockAssets = [];
+    mockSignedUrls = [];
+    assetLookupShouldError = false;
+    // Re-wire mockFrom after clearAllMocks
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "social_post_drafts") {
+        const c: Record<string, unknown> = {};
+        c["select"] = () => c; c["eq"] = () => c; c["is"] = () => c; c["or"] = () => c; c["order"] = () => c;
+        c["limit"] = async () => ({ data: mockDrafts, error: null });
+        return c;
+      }
+      if (table === "social_media_assets") {
+        const c: Record<string, unknown> = {};
+        c["select"] = () => c;
+        c["in"] = async () => ({ data: assetLookupShouldError ? null : mockAssets, error: assetLookupShouldError ? { message: "DB error" } : null });
+        return c;
+      }
+      return {};
+    });
+  });
+
+  it("draft with media_asset_ids and no media_urls → primary_media_url from signed URL", async () => {
+    mockDrafts = [makeDraft({ media_asset_ids: [ASSET_ID_1], media_urls: [] })];
+    mockAssets = [{ id: ASSET_ID_1, storage_path: STORAGE_PATH }];
+    mockSignedUrls = [{ path: STORAGE_PATH, signedUrl: SIGNED_URL }];
+
+    const res = await GET(makeRequest());
+    const body = await res.json() as { ok: boolean; data: { posts: Array<{ primary_media_url: string | null }> } };
+
+    expect(res.status).toBe(200);
+    expect(body.data.posts[0]!.primary_media_url).toBe(SIGNED_URL);
+  });
+
+  it("legacy draft (media_urls only) → primary_media_url from media_urls, no resolution", async () => {
+    mockDrafts = [makeDraft({ media_urls: [LEGACY_URL], media_asset_ids: [] })];
+
+    const res = await GET(makeRequest());
+    const body = await res.json() as { ok: boolean; data: { posts: Array<{ primary_media_url: string | null }> } };
+
+    expect(body.data.posts[0]!.primary_media_url).toBe(LEGACY_URL);
+    // No asset lookup needed for legacy drafts
+    expect(mockFrom).not.toHaveBeenCalledWith("social_media_assets");
+  });
+
+  it("draft with both media_urls and media_asset_ids → legacy media_urls takes precedence", async () => {
+    mockDrafts = [makeDraft({ media_urls: [LEGACY_URL], media_asset_ids: [ASSET_ID_1] })];
+
+    const res = await GET(makeRequest());
+    const body = await res.json() as { ok: boolean; data: { posts: Array<{ primary_media_url: string | null }> } };
+
+    expect(body.data.posts[0]!.primary_media_url).toBe(LEGACY_URL);
+    expect(mockFrom).not.toHaveBeenCalledWith("social_media_assets");
+  });
+
+  it("fail-soft: asset lookup error → primary_media_url null, calendar still loads", async () => {
+    mockDrafts = [makeDraft({ media_asset_ids: [ASSET_ID_1], media_urls: [] })];
+    assetLookupShouldError = true;
+
+    const res = await GET(makeRequest());
+    const body = await res.json() as { ok: boolean; data: { posts: Array<{ primary_media_url: string | null }> } };
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.posts[0]!.primary_media_url).toBeNull();
+  });
+
+  it("no media at all → primary_media_url null", async () => {
+    mockDrafts = [makeDraft({ media_urls: [], media_asset_ids: [] })];
+
+    const res = await GET(makeRequest());
+    const body = await res.json() as { ok: boolean; data: { posts: Array<{ primary_media_url: string | null }> } };
+
+    expect(body.data.posts[0]!.primary_media_url).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Calendar day-panel showed no thumbnail even when a draft had auto-attached images (`media_asset_ids`) because the calendar-view API only read `media_urls`. Same gap as PR #1223 fixed for the Composer — applied here with a batched pattern efficient for up to 200 calendar posts.

## Change

`app/api/platform/social/drafts/calendar-view/route.ts`:
- Adds `media_asset_ids` to the SELECT
- Collects the **first** asset ID from each post that has assets but no legacy URLs (we only need `primary_media_url` — one per post)
- Batch-resolves: one `social_media_assets` SELECT + one `createSignedUrls` call for all posts in range
- `primary_media_url` = `legacy_media_urls[0]` first, then `resolved_asset_url` — legacy drafts unaffected

**Fail-soft:** if asset lookup or signing fails, `primary_media_url` is `null` and the calendar still loads normally.

**No schema change** — both columns exist since migrations 0127 and 0164.

## Tests (5 new)
- `media_asset_ids` only → signed URL in `primary_media_url`
- Legacy `media_urls` only → unchanged behaviour
- Both → legacy takes precedence, no asset resolution triggered
- Lookup error → null thumbnail, 200 response
- No media → null thumbnail