### PR TITLE
feat(composer): add delete post action with confirm step

### DIFF
--- a/components/__tests__/composer-delete-post.test.tsx
+++ b/components/__tests__/composer-delete-post.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Test: Composer "Delete post" button calls DELETE endpoint and closes.
+ *
+ * - Delete button only appears when draft.id is set (editing existing draft)
+ * - Delete button absent for new drafts (no id)
+ * - Clicking Delete shows ConfirmDialog (no immediate delete)
+ * - Confirming in dialog calls DELETE /api/platform/social/drafts/[id]
+ * - After delete, onClose is called
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+vi.mock("swr", () => ({ mutate: vi.fn(), default: vi.fn(() => ({ data: null })) }));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock("date-fns-tz", () => ({
+  toZonedTime: (d: Date) => d,
+  fromZonedTime: (d: Date) => d,
+}));
+
+// Stub heavy child components so the test focuses on delete behaviour only.
+vi.mock("@/components/social/composer/ComposerEditor", () => ({
+  // Render the schedulingSlot prop so the delete button inside it is testable.
+  ComposerEditor: ({ schedulingSlot }: { schedulingSlot?: React.ReactNode }) => (
+    <div data-testid="composer-editor">{schedulingSlot}</div>
+  ),
+}));
+vi.mock("@/components/social/composer/ProfileSelector", () => ({
+  ProfileSelector: () => <div data-testid="profile-selector" />,
+}));
+vi.mock("@/components/social/composer/SchedulingCard", () => ({
+  SchedulingCard: () => <div data-testid="scheduling-card" />,
+  defaultSchedulingCardValue: () => ({
+    mode: "draft",
+    scheduledTimes: [],
+    approvalRequired: false,
+    plannedForAt: null,
+    recurrence: null,
+  }),
+}));
+vi.mock("@/components/social/composer/PreviewCard", () => ({
+  PreviewCard: () => <div data-testid="preview-card" />,
+}));
+vi.mock("@/components/social/calendar/SocialCalendarGrid", () => ({
+  SocialCalendarGrid: () => <div data-testid="calendar-grid" />,
+}));
+vi.mock("@/components/social/composer/ComposerErrorBoundary", () => ({
+  ComposerErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/components/social/composer/UnsavedChangesDialog", () => ({
+  UnsavedChangesDialog: () => null,
+}));
+
+import { ComposerOverlay } from "@/components/social/composer/ComposerOverlay";
+import type { Draft } from "@/lib/social/types";
+
+const DRAFT_ID  = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+const BASE_DRAFT: Draft = {
+  id: DRAFT_ID,
+  draft_version: 1,
+  content: "Test post",
+  media_urls: [],
+  target_profile_ids: [],
+  platform_variants: {},
+  approval_required: false,
+};
+
+function renderComposer(draft: Draft, onClose = vi.fn()) {
+  return render(
+    <ComposerOverlay
+      open
+      onClose={onClose}
+      initialDraft={draft}
+      companyId="co-1"
+      companyTimezone="UTC"
+      availableConnections={[]}
+    />,
+  );
+}
+
+describe("ComposerOverlay — delete post", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+  });
+
+  it("shows Delete post button when draft.id is set", () => {
+    renderComposer(BASE_DRAFT);
+    expect(screen.getByTestId("delete-post-btn")).toBeInTheDocument();
+  });
+
+  it("does NOT show Delete post button for new (unsaved) drafts", () => {
+    const newDraft: Draft = { ...BASE_DRAFT, id: undefined };
+    renderComposer(newDraft);
+    expect(screen.queryByTestId("delete-post-btn")).toBeNull();
+  });
+
+  it("clicking Delete post shows confirm dialog, does NOT immediately delete", () => {
+    renderComposer(BASE_DRAFT);
+    fireEvent.click(screen.getByTestId("delete-post-btn"));
+
+    // Dialog should now be visible
+    expect(screen.getByText("Delete this post?")).toBeInTheDocument();
+    // Fetch must NOT have been called yet
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("confirming in dialog calls DELETE and closes the Composer", async () => {
+    const onClose = vi.fn();
+    renderComposer(BASE_DRAFT, onClose);
+
+    fireEvent.click(screen.getByTestId("delete-post-btn"));
+    // Click the "Delete" confirm button in the dialog
+    const confirmBtn = screen.getByRole("button", { name: "Delete" });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        `/api/platform/social/drafts/${DRAFT_ID}`,
+        { method: "DELETE" },
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("cancelling the confirm dialog does not call DELETE", async () => {
+    renderComposer(BASE_DRAFT);
+    fireEvent.click(screen.getByTestId("delete-post-btn"));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/components/social/composer/ComposerOverlay.tsx
+++ b/components/social/composer/ComposerOverlay.tsx
@@ -12,6 +12,7 @@ import { SocialCalendarGrid } from "@/components/social/calendar/SocialCalendarG
 import { SchedulingCard, defaultSchedulingCardValue, type SchedulingCardValue } from "@/components/social/composer/SchedulingCard";
 import { UnsavedChangesDialog } from "@/components/social/composer/UnsavedChangesDialog";
 import { ComposerErrorBoundary } from "@/components/social/composer/ComposerErrorBoundary";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Pill } from "@/components/ui/pill";
 import { SocialPlatformIcon } from "@/components/ui/SocialPlatformIcon";
@@ -151,6 +152,7 @@ export function ComposerOverlay({
   );
   const [submitting, setSubmitting] = React.useState(false);
   const [submitError, setSubmitError] = React.useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
 
   // Unsaved-changes guard
   const [showDiscard, setShowDiscard] = React.useState(false);
@@ -268,6 +270,19 @@ export function ComposerOverlay({
       onClose();
     } catch {
       // ignore — UI shows nothing on failure; user can retry
+    }
+  }
+
+  async function handleDeletePost() {
+    if (!draft.id) return;
+    try {
+      await fetch(`/api/platform/social/drafts/${draft.id}`, { method: "DELETE" });
+      void swrMutate(
+        (key) => typeof key === "string" && key.includes("/api/platform/social/drafts/calendar-view"),
+      );
+      onClose();
+    } catch {
+      // ignore — draft may already be gone; calendar refresh via swrMutate covers it
     }
   }
 
@@ -488,6 +503,16 @@ export function ComposerOverlay({
           className="w-full rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:border-primary/40 hover:text-foreground transition-colors"
         >
           Convert to draft
+        </button>
+      )}
+      {draft.id && (
+        <button
+          type="button"
+          onClick={() => setShowDeleteConfirm(true)}
+          data-testid="delete-post-btn"
+          className="w-full rounded-md px-4 py-2 text-sm font-medium text-destructive/70 hover:text-destructive hover:bg-destructive/10 transition-colors"
+        >
+          Delete post
         </button>
       )}
     </div>
@@ -713,6 +738,16 @@ export function ComposerOverlay({
         onDiscard={handleDiscard}
         onCancel={() => { setShowDiscard(false); setPendingNavigateId(null); }}
         onSave={companyId ? () => void handleSaveFromDialog() : undefined}
+      />
+
+      <ConfirmDialog
+        open={showDeleteConfirm}
+        onOpenChange={setShowDeleteConfirm}
+        title="Delete this post?"
+        description="This will permanently remove the post from your calendar. This action cannot be undone."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={() => void handleDeletePost()}
       />
     </>
   );


### PR DESCRIPTION
## Summary

Adds a "Delete post" button to the Composer so unwanted posts can be removed from the calendar without leaving the editor.

## Behaviour

- **Button only visible** when editing an existing draft (`draft.id` is set — not for new unsaved posts)
- **Two-step confirm**: clicking "Delete post" opens a `ConfirmDialog` ("Delete this post? This cannot be undone.") — no single-click delete
- **Confirming** calls `DELETE /api/platform/social/drafts/[id]` (existing soft-delete route, `archived_at` set)
- **After delete**: SWR calendar cache invalidated + Composer closed
- **Cancelling** leaves the draft untouched

## Implementation

Reuses the existing `ConfirmDialog` component and `DELETE /api/platform/social/drafts/[id]` route. Pattern mirrors `handleConvertToDraft` — same SWR invalidation approach, same `onClose()` call. No new route needed.

## Tests (5 component tests)

- Delete button visible when `draft.id` set
- Delete button absent for new unsaved drafts
- First click shows confirm dialog, no immediate delete
- Confirming calls correct DELETE endpoint and closes Composer
- Cancelling does not call DELETE