### PR TITLE
fix(composer): increase toolbar icon size from 14 to 20px

### DIFF
--- a/components/social/composer/ToolsRow.tsx
+++ b/components/social/composer/ToolsRow.tsx
@@ -507,9 +507,9 @@ function GifPanel({
 // AI uses Dialog (not Popover) to avoid overflowing the composer bounds.
 // Emoji, GIF, UTM remain Popover-anchored.
 const PANEL_TOOLS = [
-  { id: "emoji" as const, label: "Emoji",    icon: <Smile size={14} strokeWidth={1.75} aria-hidden /> },
-  { id: "gif" as const,   label: "GIF",      icon: <Film  size={14} strokeWidth={1.75} aria-hidden /> },
-  { id: "utm" as const,   label: "UTM tags", icon: <Tags  size={14} strokeWidth={1.75} aria-hidden /> },
+  { id: "emoji" as const, label: "Emoji",    icon: <Smile size={20} strokeWidth={1.75} aria-hidden /> },
+  { id: "gif" as const,   label: "GIF",      icon: <Film  size={20} strokeWidth={1.75} aria-hidden /> },
+  { id: "utm" as const,   label: "UTM tags", icon: <Tags  size={20} strokeWidth={1.75} aria-hidden /> },
 ] as const;
 
 export function ToolsRow({ companyId, onInsertText, onOpenMediaPicker, onAttachGif, platforms, className }: ToolsRowProps) {
@@ -527,7 +527,7 @@ export function ToolsRow({ companyId, onInsertText, onOpenMediaPicker, onAttachG
         data-testid="composer-tool-media"
         onClick={onOpenMediaPicker}
       >
-        <ImagePlus size={14} strokeWidth={1.75} aria-hidden />
+        <ImagePlus size={20} strokeWidth={1.75} aria-hidden />
         Media
       </Button>
 
@@ -539,7 +539,7 @@ export function ToolsRow({ companyId, onInsertText, onOpenMediaPicker, onAttachG
         aria-pressed={activePanel === "ai"}
         onClick={() => setActivePanel(activePanel === "ai" ? null : "ai")}
       >
-        <Sparkles size={14} strokeWidth={1.75} aria-hidden />
+        <Sparkles size={20} strokeWidth={1.75} aria-hidden />
         AI assistant
       </Button>
       <Dialog open={activePanel === "ai"} onOpenChange={(open) => setActivePanel(open ? "ai" : null)}>


### PR DESCRIPTION
## Summary

Increases the five Composer toolbar icons (Media, AI assistant, Emoji, GIF, UTM tags) from `size={14}` to `size={20}` — approximately 43% larger. Single-file change, scoped strictly to `ToolsRow.tsx`. No other icon sizes in the product are changed.

**Changed icons:** Media (`ImagePlus`), AI assistant (`Sparkles`), Emoji (`Smile`), GIF (`Film`), UTM tags (`Tags`)

**Unchanged:** GIF-panel close button (`CloseIcon size={14}` at line 446) — this is a UI control, not a primary toolbar icon.

The app-wide icon/font sizing pass (involving Caleb) is tracked separately in `docs/backlog/ux-debt.md` as P3.