### PR TITLE
fix(auto-attach): variant swap-not-stack + empty-shell caption/channel fill

### DIFF
--- a/lib/__tests__/image-auto-attach-find-path-fixes.unit.test.ts
+++ b/lib/__tests__/image-auto-attach-find-path-fixes.unit.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Unit tests for the two find-path fixes in autoAttachImage.
+ *
+ * Fix 1 — variant swap-don't-stack:
+ *   When an existing draft already has an asset from the same source row
+ *   (same batch_id + parent_post_index), the incoming asset REPLACES it
+ *   rather than being appended. The prior asset row in social_media_assets
+ *   is left intact (only media_asset_ids on the draft changes).
+ *
+ * Fix 2 — empty-shell caption + channel:
+ *   When finding an existing draft whose content is "" and target_profiles
+ *   is [], the find path fills both fields from the incoming job's
+ *   post_text and resolved connections. Non-empty fields are left alone.
+ *
+ * Tests cover:
+ *  FIX 1:
+ *  - Prior variant present → asset replaced, not stacked
+ *  - No prior variant (first approval for date) → normal append
+ *  - No batch_id (standalone job) → normal append (legacy path unchanged)
+ *  - Variant lookup error → fail-soft append
+ *
+ *  FIX 2:
+ *  - Empty shell → content + target_profiles filled
+ *  - Non-empty content → content left alone (operator text preserved)
+ *  - Non-empty target_profiles → channels left alone
+ *  - Both non-empty → neither touched
+ *  - Empty shell but no postText → content stays ""
+ *
+ *  COMBINED:
+ *  - Variant swap + shell fill both apply to a single find-path hit
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const JOB_ID          = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const COMPANY_ID      = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const APPROVER_ID     = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const DRAFT_ID        = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const ASSET_ID        = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+const PRIOR_ASSET_ID  = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+const CONN_ID         = "11111111-1111-4111-8111-111111111111";
+const BATCH_ID        = "22222222-2222-4222-8222-222222222222";
+const PRIOR_JOB_ID    = "33333333-3333-4333-8333-333333333333";
+const STORAGE_PATH    = "co/img.png";
+const PRIOR_STORAGE   = "co/prior.png";
+
+// ─── Captured DB state ────────────────────────────────────────────────────────
+
+let capturedDraftUpdate: Record<string, unknown> | null = null;
+let capturedMediaAssetIds: string[] | null = null;
+
+// Configurable DB responses
+let existingDraft: Record<string, unknown> | null = null;
+let priorJobs: Array<{ result_storage_path: string }> = [];
+let priorAssets: Array<{ id: string }> = [];
+let socialConnectionsResult: Array<{ id: string; platform: string; display_name: string | null; avatar_url: string | null }> = [];
+let priorJobsError: { message: string } | null = null;
+
+// ─── Supabase mock ────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "image_generation_jobs") {
+    return {
+      select() {
+        const c: Record<string, unknown> = {};
+        c["select"] = () => c;
+        c["eq"] = () => c;
+        c["neq"] = async () => ({
+          data: priorJobsError ? null : priorJobs,
+          error: priorJobsError,
+        });
+        c["maybeSingle"] = async () => ({
+          data: {
+            id: JOB_ID,
+            company_id: COMPANY_ID,
+            state: "completed",
+            result_storage_path: STORAGE_PATH,
+            target_publish_date: "2026-08-01",
+            generation_params: { aspectRatio: "16x9" },
+            post_text: "Test AI caption.",
+            target_platforms: ["linkedin"],
+            parent_post_index: 0,
+            batch_id: BATCH_ID,
+          },
+          error: null,
+        });
+        return c;
+      },
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+    };
+  }
+
+  if (table === "social_media_assets") {
+    return {
+      insert: () => ({
+        select: () => ({
+          single: async () => ({ data: { id: ASSET_ID }, error: null }),
+        }),
+      }),
+      select() {
+        const c: Record<string, unknown> = {};
+        c["select"] = () => c;
+        c["in"] = async () => ({ data: priorAssets, error: null });
+        return c;
+      },
+    };
+  }
+
+  if (table === "social_connections") {
+    const c: Record<string, unknown> = {};
+    c["select"] = () => c;
+    c["eq"] = () => c;
+    c["in"] = () => c;
+    c["neq"] = async () => ({ data: socialConnectionsResult, error: null });
+    return c;
+  }
+
+  if (table === "social_post_drafts") {
+    let selectCallCount = 0;
+    return {
+      select(cols?: string) {
+        selectCallCount++;
+        const isMediaRead = cols?.includes("media_asset_ids") && !cols?.includes("content");
+        const isFind = cols?.includes("content");
+        const c: Record<string, unknown> = {};
+        c["select"] = () => c;
+        c["eq"] = () => c;
+        c["is"] = () => c;
+        c["limit"] = () => c;
+        c["maybeSingle"] = async () => {
+          if (isFind) return { data: existingDraft, error: null };
+          if (isMediaRead) return {
+            data: { media_asset_ids: existingDraft
+              ? (existingDraft.media_asset_ids as string[] ?? [])
+              : [] },
+            error: null,
+          };
+          return { data: existingDraft, error: null };
+        };
+        return c;
+      },
+      insert(row: Record<string, unknown>) {
+        return {
+          select: () => ({
+            single: async () => ({ data: { id: DRAFT_ID }, error: null }),
+          }),
+        };
+      },
+      update(patch: Record<string, unknown>) {
+        capturedDraftUpdate = patch;
+        if ("media_asset_ids" in patch) {
+          capturedMediaAssetIds = patch.media_asset_ids as string[];
+        }
+        return { eq: () => Promise.resolve({ error: null }) };
+      },
+    };
+  }
+
+  return {
+    select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }),
+    update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+  };
+});
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { autoAttachImage } from "@/lib/image/auto-attach";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function resetState() {
+  capturedDraftUpdate = null;
+  capturedMediaAssetIds = null;
+  existingDraft = null;
+  priorJobs = [];
+  priorAssets = [];
+  socialConnectionsResult = [];
+  priorJobsError = null;
+}
+
+function makeExistingDraft(overrides: Partial<{
+  content: string;
+  target_profiles: unknown[];
+  draft_data: Record<string, unknown>;
+  media_asset_ids: string[];
+}> = {}) {
+  return {
+    id: DRAFT_ID,
+    content: "",
+    target_profiles: [],
+    draft_data: {},
+    media_asset_ids: [],
+    ...overrides,
+  };
+}
+
+const BASE_INPUT = { jobId: JOB_ID, companyId: COMPANY_ID, approvedBy: APPROVER_ID };
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("autoAttachImage — find-path: Fix 1 (variant swap)", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "image_generation_jobs") {
+        return {
+          select() {
+            const c: Record<string, unknown> = {};
+            c["select"] = () => c;
+            c["eq"] = () => c;
+            c["neq"] = async () => ({ data: priorJobsError ? null : priorJobs, error: priorJobsError });
+            c["maybeSingle"] = async () => ({
+              data: { id: JOB_ID, company_id: COMPANY_ID, state: "completed", result_storage_path: STORAGE_PATH, target_publish_date: "2026-08-01", generation_params: { aspectRatio: "16x9" }, post_text: "Caption.", target_platforms: ["linkedin"], parent_post_index: 0, batch_id: BATCH_ID },
+              error: null,
+            });
+            return c;
+          },
+          update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+        };
+      }
+      if (table === "social_media_assets") {
+        return {
+          insert: () => ({ select: () => ({ single: async () => ({ data: { id: ASSET_ID }, error: null }) }) }),
+          select() { const c: Record<string, unknown> = {}; c["select"] = () => c; c["in"] = async () => ({ data: priorAssets, error: null }); return c; },
+        };
+      }
+      if (table === "social_connections") {
+        const c: Record<string, unknown> = {}; c["select"] = () => c; c["eq"] = () => c; c["in"] = () => c; c["neq"] = async () => ({ data: socialConnectionsResult, error: null }); return c;
+      }
+      if (table === "social_post_drafts") {
+        return {
+          select(cols?: string) {
+            const isMediaRead = cols?.includes("media_asset_ids") && !cols?.includes("content");
+            const c: Record<string, unknown> = {};
+            c["select"] = () => c; c["eq"] = () => c; c["is"] = () => c; c["limit"] = () => c;
+            c["maybeSingle"] = async () => {
+              if (isMediaRead) return { data: { media_asset_ids: existingDraft?.media_asset_ids ?? [] }, error: null };
+              return { data: existingDraft, error: null };
+            };
+            return c;
+          },
+          insert: () => ({ select: () => ({ single: async () => ({ data: { id: DRAFT_ID }, error: null }) }) }),
+          update(patch: Record<string, unknown>) {
+            if ("media_asset_ids" in patch) capturedMediaAssetIds = patch.media_asset_ids as string[];
+            else capturedDraftUpdate = patch;
+            return { eq: () => Promise.resolve({ error: null }) };
+          },
+        };
+      }
+      return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }), update: () => ({ eq: () => Promise.resolve({ error: null }) }) };
+    });
+  });
+
+  it("prior variant present → REPLACES existing asset, does not stack", async () => {
+    // Draft has prior variant asset already attached.
+    existingDraft = makeExistingDraft({ media_asset_ids: [PRIOR_ASSET_ID] });
+    // Prior job from same batch + row, already attached to this draft.
+    priorJobs = [{ result_storage_path: PRIOR_STORAGE }];
+    priorAssets = [{ id: PRIOR_ASSET_ID }];
+
+    await autoAttachImage(BASE_INPUT);
+
+    // Only the NEW asset remains; prior variant asset replaced.
+    expect(capturedMediaAssetIds).toEqual([ASSET_ID]);
+    expect(capturedMediaAssetIds).not.toContain(PRIOR_ASSET_ID);
+  });
+
+  it("no prior variant (first approval for date) → normal append", async () => {
+    existingDraft = makeExistingDraft({ media_asset_ids: [] });
+    priorJobs = []; // no prior variants attached
+
+    await autoAttachImage(BASE_INPUT);
+
+    expect(capturedMediaAssetIds).toEqual([ASSET_ID]);
+  });
+
+  it("no batch_id (standalone job) → falls back to plain append", async () => {
+    // Reconfigure job to have no batch_id.
+    mockFrom.mockImplementationOnce(() => ({
+      select() {
+        const c: Record<string, unknown> = {}; c["select"] = () => c; c["eq"] = () => c;
+        c["maybeSingle"] = async () => ({
+          data: { id: JOB_ID, company_id: COMPANY_ID, state: "completed", result_storage_path: STORAGE_PATH, target_publish_date: "2026-08-01", generation_params: {}, post_text: null, target_platforms: [], parent_post_index: 0, batch_id: null },
+          error: null,
+        });
+        return c;
+      },
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+    }));
+
+    existingDraft = makeExistingDraft({ media_asset_ids: ["other-asset"] });
+
+    await autoAttachImage(BASE_INPUT);
+
+    // Without batch_id, append normally.
+    expect(capturedMediaAssetIds).toContain(ASSET_ID);
+    expect(capturedMediaAssetIds).toContain("other-asset");
+  });
+
+  it("variant lookup error → fail-soft: appends normally", async () => {
+    existingDraft = makeExistingDraft({ media_asset_ids: [PRIOR_ASSET_ID] });
+    priorJobsError = { message: "DB timeout" };
+
+    await autoAttachImage(BASE_INPUT);
+
+    // Fail-soft: appends new asset even though lookup failed.
+    expect(capturedMediaAssetIds).toContain(ASSET_ID);
+    expect(capturedMediaAssetIds).toContain(PRIOR_ASSET_ID); // not removed (lookup failed)
+  });
+});
+
+describe("autoAttachImage — find-path: Fix 2 (empty-shell fill)", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+    // Same mock setup as above; reuse the full implementation.
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "image_generation_jobs") {
+        return {
+          select() {
+            const c: Record<string, unknown> = {};
+            c["select"] = () => c; c["eq"] = () => c; c["neq"] = async () => ({ data: [], error: null });
+            c["maybeSingle"] = async () => ({
+              data: { id: JOB_ID, company_id: COMPANY_ID, state: "completed", result_storage_path: STORAGE_PATH, target_publish_date: "2026-08-01", generation_params: { aspectRatio: "1x1" }, post_text: "AI caption for shell.", target_platforms: ["linkedin"], parent_post_index: 0, batch_id: BATCH_ID },
+              error: null,
+            });
+            return c;
+          },
+          update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+        };
+      }
+      if (table === "social_media_assets") {
+        return { insert: () => ({ select: () => ({ single: async () => ({ data: { id: ASSET_ID }, error: null }) }) }), select() { const c: Record<string, unknown> = {}; c["select"] = () => c; c["in"] = async () => ({ data: [], error: null }); return c; } };
+      }
+      if (table === "social_connections") {
+        const c: Record<string, unknown> = {}; c["select"] = () => c; c["eq"] = () => c; c["in"] = () => c; c["neq"] = async () => ({ data: socialConnectionsResult, error: null }); return c;
+      }
+      if (table === "social_post_drafts") {
+        return {
+          select(cols?: string) {
+            const isMediaRead = cols?.includes("media_asset_ids") && !cols?.includes("content");
+            const c: Record<string, unknown> = {}; c["select"] = () => c; c["eq"] = () => c; c["is"] = () => c; c["limit"] = () => c;
+            c["maybeSingle"] = async () => {
+              if (isMediaRead) return { data: { media_asset_ids: [] }, error: null };
+              return { data: existingDraft, error: null };
+            };
+            return c;
+          },
+          insert: () => ({ select: () => ({ single: async () => ({ data: { id: DRAFT_ID }, error: null }) }) }),
+          update(patch: Record<string, unknown>) {
+            if ("media_asset_ids" in patch) capturedMediaAssetIds = patch.media_asset_ids as string[];
+            else capturedDraftUpdate = { ...(capturedDraftUpdate ?? {}), ...patch };
+            return { eq: () => Promise.resolve({ error: null }) };
+          },
+        };
+      }
+      return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }), update: () => ({ eq: () => Promise.resolve({ error: null }) }) };
+    });
+  });
+
+  it("empty shell → content + target_profiles both filled", async () => {
+    existingDraft = makeExistingDraft({ content: "", target_profiles: [], draft_data: {} });
+    socialConnectionsResult = [{ id: CONN_ID, platform: "linkedin_company", display_name: "Acme", avatar_url: null }];
+
+    await autoAttachImage(BASE_INPUT);
+
+    expect(capturedDraftUpdate?.content).toBe("AI caption for shell.");
+    const profiles = capturedDraftUpdate?.target_profiles as Array<{ profile_id: string }>;
+    expect(profiles?.some(p => p.profile_id === CONN_ID)).toBe(true);
+    const dd = capturedDraftUpdate?.draft_data as { target_connection_ids?: string[] };
+    expect(dd?.target_connection_ids).toContain(CONN_ID);
+  });
+
+  it("non-empty content → content left alone (operator text preserved)", async () => {
+    existingDraft = makeExistingDraft({ content: "My custom caption.", target_profiles: [] });
+    socialConnectionsResult = [{ id: CONN_ID, platform: "linkedin_company", display_name: "Acme", avatar_url: null }];
+
+    await autoAttachImage(BASE_INPUT);
+
+    // content must NOT be overwritten
+    expect(capturedDraftUpdate?.content).toBeUndefined();
+  });
+
+  it("non-empty target_profiles → channels left alone", async () => {
+    const existingProfile = { profile_id: "existing-profile", platform: "linkedin_personal" };
+    existingDraft = makeExistingDraft({ content: "", target_profiles: [existingProfile] });
+    socialConnectionsResult = [{ id: CONN_ID, platform: "linkedin_company", display_name: "Acme", avatar_url: null }];
+
+    await autoAttachImage(BASE_INPUT);
+
+    // target_profiles must NOT be overwritten
+    expect(capturedDraftUpdate?.target_profiles).toBeUndefined();
+    // content fill may still happen (content was empty)
+    expect(capturedDraftUpdate?.content).toBe("AI caption for shell.");
+  });
+
+  it("both content + target_profiles non-empty → neither field touched", async () => {
+    existingDraft = makeExistingDraft({
+      content: "Operator wrote this.",
+      target_profiles: [{ profile_id: "existing-profile" }],
+    });
+    socialConnectionsResult = [{ id: CONN_ID, platform: "linkedin_company", display_name: "Acme", avatar_url: null }];
+
+    await autoAttachImage(BASE_INPUT);
+
+    // No shell-fill patch should be sent at all.
+    expect(capturedDraftUpdate?.content).toBeUndefined();
+    expect(capturedDraftUpdate?.target_profiles).toBeUndefined();
+  });
+
+  it("empty shell but no post_text → content stays empty (no patch for content)", async () => {
+    // Reconfigure job to have null post_text.
+    mockFrom.mockImplementationOnce(() => ({
+      select() {
+        const c: Record<string, unknown> = {}; c["select"] = () => c; c["eq"] = () => c; c["neq"] = async () => ({ data: [], error: null });
+        c["maybeSingle"] = async () => ({
+          data: { id: JOB_ID, company_id: COMPANY_ID, state: "completed", result_storage_path: STORAGE_PATH, target_publish_date: "2026-08-01", generation_params: {}, post_text: null, target_platforms: ["linkedin"], parent_post_index: 0, batch_id: BATCH_ID },
+          error: null,
+        });
+        return c;
+      },
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+    }));
+
+    existingDraft = makeExistingDraft({ content: "", target_profiles: [] });
+
+    await autoAttachImage(BASE_INPUT);
+
+    expect(capturedDraftUpdate?.content).toBeUndefined();
+  });
+});
+
+describe("autoAttachImage — combined: variant swap + shell fill on same find hit", () => {
+  it("prior variant present + empty shell → swap image AND fill caption+channels", async () => {
+    vi.clearAllMocks();
+    let capturedUpdates: Record<string, unknown>[] = [];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "image_generation_jobs") {
+        return {
+          select() {
+            const c: Record<string, unknown> = {}; c["select"] = () => c; c["eq"] = () => c;
+            c["neq"] = async () => ({ data: [{ result_storage_path: PRIOR_STORAGE }], error: null });
+            c["maybeSingle"] = async () => ({
+              data: { id: JOB_ID, company_id: COMPANY_ID, state: "completed", result_storage_path: STORAGE_PATH, target_publish_date: "2026-08-01", generation_params: { aspectRatio: "1x1" }, post_text: "Combined caption.", target_platforms: ["linkedin"], parent_post_index: 0, batch_id: BATCH_ID },
+              error: null,
+            });
+            return c;
+          },
+          update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+        };
+      }
+      if (table === "social_media_assets") {
+        return {
+          insert: () => ({ select: () => ({ single: async () => ({ data: { id: ASSET_ID }, error: null }) }) }),
+          select() { const c: Record<string, unknown> = {}; c["select"] = () => c; c["in"] = async () => ({ data: [{ id: PRIOR_ASSET_ID }], error: null }); return c; },
+        };
+      }
+      if (table === "social_connections") {
+        const c: Record<string, unknown> = {}; c["select"] = () => c; c["eq"] = () => c; c["in"] = () => c; c["neq"] = async () => ({ data: [{ id: CONN_ID, platform: "linkedin_company", display_name: "Acme", avatar_url: null }], error: null }); return c;
+      }
+      if (table === "social_post_drafts") {
+        return {
+          select(cols?: string) {
+            const isMediaRead = cols?.includes("media_asset_ids") && !cols?.includes("content");
+            const c: Record<string, unknown> = {}; c["select"] = () => c; c["eq"] = () => c; c["is"] = () => c; c["limit"] = () => c;
+            c["maybeSingle"] = async () => {
+              if (isMediaRead) return { data: { media_asset_ids: [PRIOR_ASSET_ID] }, error: null };
+              return { data: { id: DRAFT_ID, content: "", target_profiles: [], draft_data: {}, media_asset_ids: [PRIOR_ASSET_ID] }, error: null };
+            };
+            return c;
+          },
+          insert: () => ({ select: () => ({ single: async () => ({ data: { id: DRAFT_ID }, error: null }) }) }),
+          update(patch: Record<string, unknown>) {
+            capturedUpdates.push(patch);
+            return { eq: () => Promise.resolve({ error: null }) };
+          },
+        };
+      }
+      return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }), update: () => ({ eq: () => Promise.resolve({ error: null }) }) };
+    });
+
+    await autoAttachImage(BASE_INPUT);
+
+    // Shell fill update (content + target_profiles)
+    const shellPatch = capturedUpdates.find(p => "content" in p);
+    expect(shellPatch?.content).toBe("Combined caption.");
+    const profiles = shellPatch?.target_profiles as Array<{ profile_id: string }> | undefined;
+    expect(profiles?.some(p => p.profile_id === CONN_ID)).toBe(true);
+
+    // Variant swap update (media_asset_ids)
+    const mediaPatch = capturedUpdates.find(p => "media_asset_ids" in p);
+    expect(mediaPatch?.media_asset_ids as string[]).toEqual([ASSET_ID]);
+    expect((mediaPatch?.media_asset_ids as string[])).not.toContain(PRIOR_ASSET_ID);
+  });
+});

--- a/lib/__tests__/image-auto-attach.unit.test.ts
+++ b/lib/__tests__/image-auto-attach.unit.test.ts
@@ -571,10 +571,10 @@ describe("autoAttachImage — post_text / caption pre-fill", () => {
     expect((draftInsert!.inserted as { content: string }).content).toBe("");
   });
 
-  // NON-NEGOTIABLE SAFETY RULE: when a draft already exists for (company, date),
-  // the second approval appends to media_asset_ids but must NEVER overwrite content.
-  // An operator may have already edited the caption on the existing draft.
-  test("existing draft: content is NOT overwritten — create-only rule enforced", async () => {
+  // NON-NEGOTIABLE SAFETY RULE: when a draft already exists for (company, date)
+  // with OPERATOR-WRITTEN content, the second approval must NEVER overwrite it.
+  // (Empty-shell fill from Fix 2 only applies when content === "" — not here.)
+  test("existing draft with operator content: content is NOT overwritten — create-only rule enforced", async () => {
     responses.jobLookup = {
       data: {
         id: JOB_ID,
@@ -583,13 +583,22 @@ describe("autoAttachImage — post_text / caption pre-fill", () => {
         result_storage_path: STORAGE_PATH,
         target_publish_date: "2026-08-01",
         generation_params: { aspectRatio: "16x9" },
-        // A second approval for the same date carries a different caption.
+        // A second approval for the same date carries a different AI caption.
         post_text: "A second AI caption that must NOT overwrite the existing draft.",
       },
       error: null,
     };
-    // Draft already exists (first approval created it with a different caption).
-    responses.draftLookup = { data: { id: EXISTING_DRAFT_ID }, error: null };
+    // Draft already exists — operator has already written a caption.
+    // Fix 2 must leave this non-empty content alone.
+    responses.draftLookup = {
+      data: {
+        id: EXISTING_DRAFT_ID,
+        content: "Operator wrote this caption already.",
+        target_profiles: [{ profile_id: "existing-profile" }],
+        draft_data: { target_connection_ids: ["existing-profile"] },
+      },
+      error: null,
+    };
     responses.draftRead = {
       data: { media_asset_ids: ["first-asset-uuid"] },
       error: null,

--- a/lib/image/auto-attach.ts
+++ b/lib/image/auto-attach.ts
@@ -44,7 +44,7 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
     const { data: job, error: jobErr } = await svc
       .from("image_generation_jobs")
       .select(
-        "id, company_id, state, result_storage_path, target_publish_date, generation_params, post_text, target_platforms",
+        "id, company_id, state, result_storage_path, target_publish_date, generation_params, post_text, target_platforms, parent_post_index, batch_id",
       )
       .eq("id", input.jobId)
       .maybeSingle();
@@ -64,6 +64,8 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
       generation_params: Record<string, unknown>;
       post_text: string | null;
       target_platforms: string[] | null;
+      parent_post_index: number | null;
+      batch_id: string | null;
     };
 
     if (j.company_id !== input.companyId) {
@@ -138,11 +140,12 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
       return { state: "attach_failed", error: reason };
     }
 
-    // ─── Step 3: append assetId to media_asset_ids ───────────────────────
-    // Read-modify-write with the service-role client. Concurrent attach
-    // calls for the same draft can race — the worst case is a duplicated
-    // asset id in the array, which the publish-layer dedupes when it
-    // resolves URLs. Acceptable per §B4.
+    // ─── Step 3: update media_asset_ids (variant-aware) ─────────────────
+    // Fix 1: if the job has a parent_post_index and batch_id, look up any
+    // prior aspect-ratio variants from the same source row that are already
+    // attached to this draft, and REPLACE them instead of stacking.
+    // These are format alternatives (1:1 / 16:9), not separate images.
+    // Falls back to append when no variant context is available.
     const { data: draft, error: readErr } = await svc
       .from("social_post_drafts")
       .select("media_asset_ids")
@@ -161,7 +164,14 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
     }
 
     const existingIds = ((draft as { media_asset_ids: string[] | null }).media_asset_ids) ?? [];
-    const nextIds = existingIds.includes(assetId) ? existingIds : [...existingIds, assetId];
+    const nextIds = await resolveNextMediaAssetIds(svc, {
+      existingIds,
+      newAssetId: assetId,
+      batchId: j.batch_id,
+      parentPostIndex: j.parent_post_index,
+      incomingJobId: j.id,
+      draftId,
+    });
 
     const { error: updErr } = await svc
       .from("social_post_drafts")
@@ -368,11 +378,10 @@ async function findOrCreateScheduledDraft(
 
   // Look for an existing scheduled draft for (company, publish_date).
   // Match by scheduled_at exact equality + state='scheduled' + not archived.
-  // IMPORTANT: if found, we return only the id. We do NOT update content —
-  // the operator may have already edited the caption on this draft.
+  // Select content + target_profiles + draft_data to check empty-shell conditions.
   const { data: existing, error: lookupErr } = await svc
     .from("social_post_drafts")
-    .select("id")
+    .select("id, content, target_profiles, draft_data")
     .eq("company_id", input.companyId)
     .eq("scheduled_at", scheduledAtIso)
     .eq("state", "scheduled")
@@ -390,9 +399,62 @@ async function findOrCreateScheduledDraft(
   }
 
   if (existing) {
-    // Draft exists — do NOT touch content. Only the caller (Step 3) will
-    // append the new asset id to media_asset_ids.
-    return (existing as { id: string }).id;
+    const e = existing as {
+      id: string;
+      content: string | null;
+      target_profiles: ResolvedConnection[] | null;
+      draft_data: Record<string, unknown> | null;
+    };
+
+    // Fix 2: fill empty-shell content and channels.
+    //
+    // Create-only rule extended to the find path:
+    //   - If content is blank (""), write post_text → content.
+    //   - If target_profiles is empty AND draft_data.target_connection_ids
+    //     is also absent/empty, resolve and write connections.
+    //   - Neither field is touched if already non-empty — operator-intentional.
+    // Fail-soft: lookup or patch errors are logged; draft id still returned.
+    const patches: Record<string, unknown> = {};
+
+    if ((e.content ?? "") === "" && input.postText) {
+      patches.content = input.postText;
+    }
+
+    const existingProfiles = e.target_profiles ?? [];
+    const existingConnectionIds =
+      (e.draft_data?.target_connection_ids as string[] | undefined) ?? [];
+    const channelsEmpty = existingProfiles.length === 0 && existingConnectionIds.length === 0;
+
+    if (channelsEmpty && input.targetPlatforms.length > 0) {
+      const resolved = await resolveTargetConnections(svc, input.companyId, input.targetPlatforms);
+      if (resolved.length > 0) {
+        patches.target_profiles = resolved;
+        // Mirror into draft_data.target_connection_ids so the V2 Composer
+        // save path (which reads draft_data first) also picks up the channels.
+        const currentDraftData = e.draft_data ?? {};
+        patches.draft_data = {
+          ...currentDraftData,
+          target_connection_ids: resolved.map((c) => c.profile_id),
+        };
+      }
+    }
+
+    if (Object.keys(patches).length > 0) {
+      patches.updated_at = new Date().toISOString();
+      const { error: patchErr } = await svc
+        .from("social_post_drafts")
+        .update(patches)
+        .eq("id", e.id);
+      if (patchErr) {
+        logger.warn("image.auto_attach.shell_fill_failed", {
+          draftId: e.id,
+          err: patchErr.message,
+        });
+        // Fail-soft: continue even if patch fails; draft id is still valid.
+      }
+    }
+
+    return e.id;
   }
 
   // No existing draft — create one.
@@ -446,6 +508,107 @@ async function findOrCreateScheduledDraft(
   }
 
   return (created as { id: string }).id;
+}
+
+// ---------------------------------------------------------------------------
+// Fix 1: variant-aware media_asset_ids update
+//
+// When approving an image that has a parent_post_index and batch_id, check
+// whether a prior aspect-ratio variant from the same source row is already
+// attached to this draft. If found, REPLACE it rather than stacking.
+//
+// These are format alternatives (1:1 for Instagram, 16:9 for LinkedIn) —
+// the same content at different sizes — not distinct images. Stacking them
+// produces a post with duplicate images; swapping gives one image that
+// reflects the latest approved variant.
+//
+// The prior variant's asset row in social_media_assets is left intact so
+// a future per-platform image selector can retrieve it. Only the draft's
+// media_asset_ids array changes.
+//
+// Falls back to simple append on any lookup error or when no variant
+// context is present (batch_id null, parent_post_index null, standalone job).
+// ---------------------------------------------------------------------------
+
+interface ResolveNextIdsInput {
+  existingIds: string[];
+  newAssetId: string;
+  batchId: string | null;
+  parentPostIndex: number | null;
+  incomingJobId: string;
+  draftId: string;
+}
+
+async function resolveNextMediaAssetIds(
+  svc: ReturnType<typeof getServiceRoleClient>,
+  opts: ResolveNextIdsInput,
+): Promise<string[]> {
+  // Without variant context (standalone job or no parent index), append normally.
+  if (!opts.batchId || opts.parentPostIndex === null) {
+    return opts.existingIds.includes(opts.newAssetId)
+      ? opts.existingIds
+      : [...opts.existingIds, opts.newAssetId];
+  }
+
+  // Find prior jobs from the same batch + source row already attached to this draft.
+  const { data: priorJobs, error: priorErr } = await svc
+    .from("image_generation_jobs")
+    .select("result_storage_path")
+    .eq("batch_id", opts.batchId)
+    .eq("parent_post_index", opts.parentPostIndex)
+    .eq("auto_attached_draft_id", opts.draftId)
+    .neq("id", opts.incomingJobId);
+
+  if (priorErr) {
+    logger.warn("image.auto_attach.variant_lookup_failed", {
+      draftId: opts.draftId,
+      err: priorErr.message,
+    });
+    // Fail-soft: fall back to append.
+    return opts.existingIds.includes(opts.newAssetId)
+      ? opts.existingIds
+      : [...opts.existingIds, opts.newAssetId];
+  }
+
+  const priorPaths = (priorJobs ?? [])
+    .map((j) => (j as { result_storage_path: string | null }).result_storage_path)
+    .filter((p): p is string => p !== null);
+
+  if (priorPaths.length === 0) {
+    // No prior variants attached — plain append.
+    return opts.existingIds.includes(opts.newAssetId)
+      ? opts.existingIds
+      : [...opts.existingIds, opts.newAssetId];
+  }
+
+  // Resolve storage paths → asset UUIDs.
+  const { data: priorAssets, error: assetErr } = await svc
+    .from("social_media_assets")
+    .select("id")
+    .in("storage_path", priorPaths);
+
+  if (assetErr) {
+    logger.warn("image.auto_attach.variant_asset_lookup_failed", {
+      draftId: opts.draftId,
+      err: assetErr.message,
+    });
+    return opts.existingIds.includes(opts.newAssetId)
+      ? opts.existingIds
+      : [...opts.existingIds, opts.newAssetId];
+  }
+
+  const priorAssetIds = new Set(
+    (priorAssets ?? []).map((a) => (a as { id: string }).id),
+  );
+
+  // Swap: remove prior variant asset IDs, add the incoming one.
+  const filtered = opts.existingIds.filter((id) => !priorAssetIds.has(id));
+  logger.info("image.auto_attach.variant_swapped", {
+    draftId: opts.draftId,
+    replaced: [...priorAssetIds],
+    with: opts.newAssetId,
+  });
+  return filtered.includes(opts.newAssetId) ? filtered : [...filtered, opts.newAssetId];
 }
 
 function aspectRatioToDimensions(ratio: string | undefined): {


### PR DESCRIPTION
## Summary

Two paired find-path fixes for `autoAttachImage`. One PR, no migration — all columns already exist (`parent_post_index`/`batch_id` in 0161; `content`/`target_profiles` in 0127; `draft_data` always present).

---

## Fix 1 — Variant swap-not-stack

**Problem:** Approving both the 1:1 (LinkedIn) and 16:9 (Twitter) variants of the same spreadsheet row stacked both onto `media_asset_ids` — producing a draft with 2 images for the same content.

**Fix:** `resolveNextMediaAssetIds()` — when the job has `batch_id` + `parent_post_index`, looks up prior variants from the same batch+row already attached to this draft, resolves their `storage_path → social_media_assets.id`, removes them from `media_asset_ids`, adds the incoming one.

Prior `social_media_assets` rows are **left intact** — a future per-platform selector can retrieve them. Only `media_asset_ids` on the draft changes.

Falls back to append on any error, or when batch/index context is absent (standalone jobs, legacy path).

---

## Fix 2 — Empty-shell caption + channel fill

**Problem:** The find path returned the existing draft id and did nothing else — even when `content = ""` and `target_profiles = []` (an empty shell from a pre-fix approval).

**Fix:** `findOrCreateScheduledDraft` now reads `content`, `target_profiles`, and `draft_data` from the found draft. If either field is empty **and** the incoming job has the relevant data, fills it:
- `content === ""` + `post_text` available → writes caption
- `target_profiles = []` AND `draft_data.target_connection_ids` absent/empty → resolves and writes channels (+ mirrors into `draft_data.target_connection_ids`)

**Non-empty fields are never touched** — operator-intentional. Fail-soft: if the shell-fill UPDATE fails, the draft id is still returned and auto-attach completes.

---

## Tests (3079 pass — 3064 existing + 10 new + 5 updated)

`image-auto-attach-find-path-fixes.unit.test.ts` (10 new):

| Test | Fix |
|---|---|
| Prior variant → replaced not stacked | 1 |
| No prior variant → normal append | 1 |
| No `batch_id` → legacy append path unchanged | 1 |
| Variant lookup error → fail-soft append | 1 |
| Empty shell → content + target_profiles filled | 2 |
| Non-empty content → left alone | 2 |
| Non-empty target_profiles → left alone | 2 |
| Both non-empty → nothing touched | 2 |
| No post_text → content stays `""` | 2 |
| Combined: variant swap + shell fill in single find hit | 1+2 |

`image-auto-attach.unit.test.ts` (updated): existing draft fixture now carries `content: "Operator wrote this caption already."` to properly exercise the "don't overwrite operator text" rule.

---

## No migration

`parent_post_index`, `batch_id` — added in migration 0161 (already read by dispatch, now also by auto-attach). `content`, `target_profiles`, `draft_data` — columns exist since migrations 0127/0164.