### PR TITLE
fix(auto-attach): always create a new draft per approval — no find-and-merge

### DIFF
--- a/lib/__tests__/image-auto-attach-target-profiles.unit.test.ts
+++ b/lib/__tests__/image-auto-attach-target-profiles.unit.test.ts
@@ -211,8 +211,9 @@ describe("autoAttachImage — target_profiles prefill (Gap 2)", () => {
     expect(linkedinIds[0]).toBe(LI_COMPANY_ID);
   });
 
-  it("existing draft (find path) → no INSERT, target_profiles untouched (create-only rule)", async () => {
-    existingDraftForDate = { id: EXISTING_DRAFT_ID };
+  it("always-create: every approval INSERTs its own draft (never finds existing)", async () => {
+    // There is no find-existing logic anymore. Even if a draft for this date
+    // already exists, a second approval always creates a new one.
     socialConnectionsResult = [
       { id: LI_COMPANY_ID, platform: "linkedin_company", display_name: "Acme", avatar_url: null },
     ];
@@ -222,8 +223,11 @@ describe("autoAttachImage — target_profiles prefill (Gap 2)", () => {
     });
 
     expect(result.state).toBe("attached");
-    // No INSERT — existing draft was found, not created
-    expect(capturedDraftInsert).toBeNull();
+    // Always inserts — capturedDraftInsert is populated.
+    expect(capturedDraftInsert).not.toBeNull();
+    // target_profiles populated on the INSERT.
+    const profiles = capturedDraftInsert!.target_profiles as Array<{ profile_id: string }>;
+    expect(profiles.some(p => p.profile_id === LI_COMPANY_ID)).toBe(true);
   });
 
   it("both linkedin variants + facebook → 2 entries, personal excluded", async () => {

--- a/lib/__tests__/image-auto-attach.unit.test.ts
+++ b/lib/__tests__/image-auto-attach.unit.test.ts
@@ -227,11 +227,11 @@ describe("autoAttachImage — no publish date", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Path 2: attach to a brand-new draft
+// Path 2: always-create — one approval = one new draft, fully populated
 // ---------------------------------------------------------------------------
 
-describe("autoAttachImage — new draft", () => {
-  test("creates social_media_assets row + new social_post_drafts row; marks attached", async () => {
+describe("autoAttachImage — always creates a new draft", () => {
+  test("creates social_media_assets row + new social_post_drafts row with asset in INSERT; marks attached", async () => {
     responses.jobLookup = {
       data: {
         id: JOB_ID,
@@ -243,9 +243,7 @@ describe("autoAttachImage — new draft", () => {
       },
       error: null,
     };
-    responses.draftLookup = { data: null, error: null }; // no existing draft
     responses.draftInsert = { data: { id: NEW_DRAFT_ID }, error: null };
-    responses.draftRead = { data: { media_asset_ids: [] }, error: null };
 
     const result = await autoAttachImage({
       jobId: JOB_ID,
@@ -257,15 +255,11 @@ describe("autoAttachImage — new draft", () => {
     expect(result.draftId).toBe(NEW_DRAFT_ID);
     expect(result.assetId).toBe(ASSET_ID);
 
-    // Asset insert carried the right shape.
+    // Asset insert: correct shape and dimensions for 4x5.
     const assetInsert = calls.find((c) => c.table === "social_media_assets" && c.op === "insert");
     const row = assetInsert!.inserted as {
-      company_id: string;
-      storage_path: string;
-      uploaded_by: string;
-      width: number;
-      height: number;
-      mime_type: string;
+      company_id: string; storage_path: string; uploaded_by: string;
+      width: number; height: number; mime_type: string;
     };
     expect(row.company_id).toBe(COMPANY_ID);
     expect(row.storage_path).toBe(STORAGE_PATH);
@@ -274,20 +268,21 @@ describe("autoAttachImage — new draft", () => {
     expect(row.height).toBe(1280);
     expect(row.mime_type).toBe("image/jpeg");
 
-    // Draft was inserted because lookup returned null.
+    // Draft INSERT: asset is in the INSERT row (not a separate UPDATE).
     const draftInsert = calls.find((c) => c.table === "social_post_drafts" && c.op === "insert");
     expect(draftInsert).toBeDefined();
-    const draftRow = draftInsert!.inserted as { state: string; scheduled_at: string };
+    const draftRow = draftInsert!.inserted as {
+      state: string; scheduled_at: string; media_asset_ids: string[];
+    };
     expect(draftRow.state).toBe("scheduled");
     expect(draftRow.scheduled_at).toBe("2026-06-15T00:00:00.000Z");
+    expect(draftRow.media_asset_ids).toEqual([ASSET_ID]);
 
-    // media_asset_ids on the draft got the new asset appended.
-    const draftUpdate = calls.find(
+    // No UPDATE to social_post_drafts.media_asset_ids — asset is in the INSERT.
+    const draftUpdates = calls.filter(
       (c) => c.op === "update" && c.table === "social_post_drafts",
     );
-    expect((draftUpdate?.patch as { media_asset_ids: string[] }).media_asset_ids).toEqual([
-      ASSET_ID,
-    ]);
+    expect(draftUpdates).toHaveLength(0);
 
     // Final state mark.
     const stateUpdates = calls.filter(
@@ -302,11 +297,14 @@ describe("autoAttachImage — new draft", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Path 3: attach to an existing scheduled draft
+// Path 3: two approvals for the same date → two SEPARATE drafts
 // ---------------------------------------------------------------------------
 
-describe("autoAttachImage — existing draft", () => {
-  test("does NOT create a new draft when one exists for (company, date); appends asset id", async () => {
+describe("autoAttachImage — two approvals same date = two separate drafts", () => {
+  test("second approval creates a new draft regardless of existing drafts for that date", async () => {
+    const SECOND_DRAFT_ID = "77777777-7777-4777-8777-777777777777";
+    const SECOND_ASSET_ID = "88888888-8888-4888-8888-888888888888";
+
     responses.jobLookup = {
       data: {
         id: JOB_ID,
@@ -318,64 +316,36 @@ describe("autoAttachImage — existing draft", () => {
       },
       error: null,
     };
-    responses.draftLookup = { data: { id: EXISTING_DRAFT_ID }, error: null };
-    responses.draftRead = {
-      data: { media_asset_ids: ["existing-asset-a", "existing-asset-b"] },
-      error: null,
-    };
 
-    const result = await autoAttachImage({
-      jobId: JOB_ID,
-      companyId: COMPANY_ID,
-      approvedBy: APPROVER_ID,
+    // First approval.
+    responses.draftInsert = { data: { id: NEW_DRAFT_ID }, error: null };
+    responses.assetInsert = { data: { id: ASSET_ID }, error: null };
+    const result1 = await autoAttachImage({
+      jobId: JOB_ID, companyId: COMPANY_ID, approvedBy: APPROVER_ID,
     });
 
-    expect(result.state).toBe("attached");
-    expect(result.draftId).toBe(EXISTING_DRAFT_ID);
-
-    // No INSERT into social_post_drafts.
-    expect(calls.filter((c) => c.table === "social_post_drafts" && c.op === "insert"))
-      .toHaveLength(0);
-
-    // media_asset_ids should be the union, preserving existing order.
-    const draftUpdate = calls.find(
-      (c) => c.op === "update" && c.table === "social_post_drafts",
-    );
-    expect((draftUpdate?.patch as { media_asset_ids: string[] }).media_asset_ids).toEqual([
-      "existing-asset-a",
-      "existing-asset-b",
-      ASSET_ID,
-    ]);
-  });
-
-  test("idempotent: assetId already present → media_asset_ids unchanged", async () => {
-    responses.jobLookup = {
-      data: {
-        id: JOB_ID,
-        company_id: COMPANY_ID,
-        state: "completed",
-        result_storage_path: STORAGE_PATH,
-        target_publish_date: "2026-06-15",
-        generation_params: { aspectRatio: "1x1" },
-      },
-      error: null,
-    };
-    responses.draftLookup = { data: { id: EXISTING_DRAFT_ID }, error: null };
-    responses.draftRead = { data: { media_asset_ids: [ASSET_ID] }, error: null };
-
-    const result = await autoAttachImage({
-      jobId: JOB_ID,
-      companyId: COMPANY_ID,
-      approvedBy: APPROVER_ID,
+    // Reset for second approval (simulating a second image job for the same date).
+    calls.length = 0;
+    draftSelectCallCount = 0;
+    responses.draftInsert = { data: { id: SECOND_DRAFT_ID }, error: null };
+    responses.assetInsert = { data: { id: SECOND_ASSET_ID }, error: null };
+    const result2 = await autoAttachImage({
+      jobId: JOB_ID, companyId: COMPANY_ID, approvedBy: APPROVER_ID,
     });
 
-    expect(result.state).toBe("attached");
-    const draftUpdate = calls.find(
-      (c) => c.op === "update" && c.table === "social_post_drafts",
-    );
-    expect((draftUpdate?.patch as { media_asset_ids: string[] }).media_asset_ids).toEqual([
-      ASSET_ID,
-    ]);
+    // Both approvals succeed.
+    expect(result1.state).toBe("attached");
+    expect(result1.draftId).toBe(NEW_DRAFT_ID);
+    expect(result2.state).toBe("attached");
+    expect(result2.draftId).toBe(SECOND_DRAFT_ID);
+
+    // Second call creates its own INSERT — no SELECT for existing draft.
+    const draftInserts2 = calls.filter((c) => c.table === "social_post_drafts" && c.op === "insert");
+    expect(draftInserts2).toHaveLength(1);
+
+    // No SELECT on social_post_drafts (no find-existing logic).
+    const draftSelects2 = calls.filter((c) => c.table === "social_post_drafts" && c.op === "select");
+    expect(draftSelects2).toHaveLength(0);
   });
 });
 
@@ -455,7 +425,7 @@ describe("autoAttachImage — failure paths", () => {
     );
   });
 
-  test("draft update error → attach_failed; draftId surfaced in result for diagnostics", async () => {
+  test("draft INSERT error → attach_failed", async () => {
     responses.jobLookup = {
       data: {
         id: JOB_ID,
@@ -467,9 +437,8 @@ describe("autoAttachImage — failure paths", () => {
       },
       error: null,
     };
-    responses.draftLookup = { data: { id: EXISTING_DRAFT_ID }, error: null };
-    responses.draftRead = { data: { media_asset_ids: [] }, error: null };
-    responses.draftUpdate = { error: { message: "deadlock detected" } };
+    // Simulate a DB constraint failure on draft INSERT.
+    responses.draftInsert = { data: null, error: { message: "violates FK constraint" } };
 
     const result = await autoAttachImage({
       jobId: JOB_ID,
@@ -478,9 +447,7 @@ describe("autoAttachImage — failure paths", () => {
     });
 
     expect(result.state).toBe("attach_failed");
-    expect(result.draftId).toBe(EXISTING_DRAFT_ID);
-    expect(result.assetId).toBe(ASSET_ID);
-    expect(result.error).toBe("deadlock detected");
+    expect(result.error).toBe("draft creation failed");
   });
 
   test("job not in 'completed' state → attach_failed (not allowed to attach a pending/failed job)", async () => {
@@ -571,10 +538,10 @@ describe("autoAttachImage — post_text / caption pre-fill", () => {
     expect((draftInsert!.inserted as { content: string }).content).toBe("");
   });
 
-  // NON-NEGOTIABLE SAFETY RULE: when a draft already exists for (company, date),
-  // the second approval appends to media_asset_ids but must NEVER overwrite content.
-  // An operator may have already edited the caption on the existing draft.
-  test("existing draft: content is NOT overwritten — create-only rule enforced", async () => {
+  // Always-create rule: each approval produces its own draft with its own caption.
+  // A second approval for the same date creates a SECOND draft — it never merges
+  // or overwrites the first operator-created draft.
+  test("second approval for same date → creates its own draft with its own caption", async () => {
     responses.jobLookup = {
       data: {
         id: JOB_ID,
@@ -583,17 +550,12 @@ describe("autoAttachImage — post_text / caption pre-fill", () => {
         result_storage_path: STORAGE_PATH,
         target_publish_date: "2026-08-01",
         generation_params: { aspectRatio: "16x9" },
-        // A second approval for the same date carries a different caption.
-        post_text: "A second AI caption that must NOT overwrite the existing draft.",
+        post_text: "Second post caption — goes on its own fresh draft.",
       },
       error: null,
     };
-    // Draft already exists (first approval created it with a different caption).
-    responses.draftLookup = { data: { id: EXISTING_DRAFT_ID }, error: null };
-    responses.draftRead = {
-      data: { media_asset_ids: ["first-asset-uuid"] },
-      error: null,
-    };
+    const SECOND_DRAFT_ID = "99999999-9999-4999-8999-999999999999";
+    responses.draftInsert = { data: { id: SECOND_DRAFT_ID }, error: null };
 
     const result = await autoAttachImage({
       jobId: JOB_ID,
@@ -602,23 +564,19 @@ describe("autoAttachImage — post_text / caption pre-fill", () => {
     });
 
     expect(result.state).toBe("attached");
-    expect(result.draftId).toBe(EXISTING_DRAFT_ID);
+    expect(result.draftId).toBe(SECOND_DRAFT_ID);
 
-    // ASSERT: no INSERT into social_post_drafts — find path, not create path.
+    // ASSERT: always inserts a new draft.
     const draftInserts = calls.filter(
       (c) => c.table === "social_post_drafts" && c.op === "insert",
     );
-    expect(draftInserts).toHaveLength(0);
+    expect(draftInserts).toHaveLength(1);
 
-    // ASSERT: the UPDATE to social_post_drafts only touches media_asset_ids —
-    // never content.
-    const draftUpdate = calls.find(
-      (c) => c.op === "update" && c.table === "social_post_drafts",
-    );
-    expect(draftUpdate).toBeDefined();
-    const patch = draftUpdate!.patch as Record<string, unknown>;
-    expect("content" in patch).toBe(false); // content must not appear in the patch at all
-    expect(patch.media_asset_ids).toContain(ASSET_ID);
-    expect(patch.media_asset_ids).toContain("first-asset-uuid");
+    // ASSERT: new draft carries its own caption (not merged into an existing one).
+    const insertedRow = draftInserts[0]!.inserted as {
+      content: string; media_asset_ids: string[];
+    };
+    expect(insertedRow.content).toBe("Second post caption — goes on its own fresh draft.");
+    expect(insertedRow.media_asset_ids).toEqual([ASSET_ID]);
   });
 });

--- a/lib/image/auto-attach.ts
+++ b/lib/image/auto-attach.ts
@@ -131,65 +131,28 @@ export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttac
 
     const assetId = (asset as { id: string }).id;
 
-    // ─── Step 2: find or create the scheduled draft ──────────────────────
-    // companyTimezone is provided by the caller (select route); it has the
-    // companyId and fetches the timezone before calling autoAttachImage.
-    const draftId = await findOrCreateScheduledDraft(svc, {
+    // ─── Step 2: create a new scheduled draft ────────────────────────────
+    // ALWAYS inserts a new draft — never finds an existing one. Each approved
+    // image creates its own post: separate image, separate caption, separate
+    // channel selection, and scheduled_at anchored to company midnight.
+    // The asset is included directly in the INSERT — one atomic operation.
+    const draftId = await createScheduledDraft(svc, {
       companyId: input.companyId,
       publishDate: j.target_publish_date,
       approvedBy: input.approvedBy,
       postText: j.post_text ?? null,
       targetPlatforms: (j.target_platforms as string[] | null) ?? [],
       companyTimezone: input.companyTimezone ?? "UTC",
+      assetId,
     });
 
     if (!draftId) {
-      const reason = "find/create draft failed";
+      const reason = "draft creation failed";
       await markJobAttachState(svc, input.jobId, "attach_failed", null, reason);
       return { state: "attach_failed", error: reason };
     }
 
-    // ─── Step 3: append assetId to media_asset_ids ───────────────────────
-    // Read-modify-write with the service-role client. Concurrent attach
-    // calls for the same draft can race — the worst case is a duplicated
-    // asset id in the array, which the publish-layer dedupes when it
-    // resolves URLs. Acceptable per §B4.
-    const { data: draft, error: readErr } = await svc
-      .from("social_post_drafts")
-      .select("media_asset_ids")
-      .eq("id", draftId)
-      .maybeSingle();
-
-    if (readErr || !draft) {
-      const reason = readErr?.message ?? "draft disappeared between create and update";
-      logger.warn("image.auto_attach.draft_read_failed", {
-        jobId: input.jobId,
-        draftId,
-        err: reason,
-      });
-      await markJobAttachState(svc, input.jobId, "attach_failed", null, reason);
-      return { state: "attach_failed", error: reason };
-    }
-
-    const existingIds = ((draft as { media_asset_ids: string[] | null }).media_asset_ids) ?? [];
-    const nextIds = existingIds.includes(assetId) ? existingIds : [...existingIds, assetId];
-
-    const { error: updErr } = await svc
-      .from("social_post_drafts")
-      .update({ media_asset_ids: nextIds, updated_at: new Date().toISOString() })
-      .eq("id", draftId);
-
-    if (updErr) {
-      logger.warn("image.auto_attach.draft_update_failed", {
-        jobId: input.jobId,
-        draftId,
-        err: updErr.message,
-      });
-      await markJobAttachState(svc, input.jobId, "attach_failed", draftId, updErr.message);
-      return { state: "attach_failed", error: updErr.message, draftId, assetId };
-    }
-
-    // ─── Step 4: mark attached ───────────────────────────────────────────
+    // ─── Step 3: mark job attached ───────────────────────────────────────
     await markJobAttachState(svc, input.jobId, "attached", draftId, null);
     logger.info("image.auto_attach.attached", {
       jobId: input.jobId,
@@ -351,93 +314,56 @@ async function resolveTargetConnections(
   return resolved;
 }
 
-interface FindOrCreateDraftInput {
+interface CreateDraftInput {
   companyId: string;
   publishDate: string; // YYYY-MM-DD
   approvedBy: string;
-  /**
-   * AI-generated social caption from the source spreadsheet row.
-   * Written to content ONLY when creating a new draft — never overwrites an
-   * existing draft's content. This is the non-negotiable create-only rule:
-   * the operator may have already edited the caption on an existing draft.
-   */
+  /** AI-generated social caption from the source spreadsheet row. */
   postText: string | null;
-  /**
-   * Generic platform codes from the spreadsheet row (e.g. ["linkedin", "facebook"]).
-   * Resolved to the company's actual connected social_connections on new draft
-   * creation only. Empty array or unmatched codes are silently skipped.
-   */
+  /** Generic platform codes — resolved to connected social_connections. */
   targetPlatforms: string[];
   /**
    * IANA timezone for the company (e.g. "Australia/Melbourne").
-   * Used to anchor midnight to the company's local date — a spreadsheet row
-   * saying "June 14" becomes June 14 00:00 in the company timezone, not UTC.
-   * Defaults to "UTC" if unavailable.
+   * Used to anchor midnight to the company's local date — "June 14"
+   * becomes June 14 00:00 in the company timezone, not UTC.
    */
   companyTimezone: string;
+  /** Asset UUID to attach — included directly in the INSERT. */
+  assetId: string;
 }
 
-async function findOrCreateScheduledDraft(
+/**
+ * Always inserts a new social_post_drafts row — never finds an existing one.
+ *
+ * Each approved image creates its own post: its own image, caption, channel
+ * selection, and date. Re-uploading the same spreadsheet row = a separate
+ * post per approval, not an update to an existing one. This eliminates the
+ * stacking problem (multiple aspect-ratio variants collapsing onto one draft)
+ * and the silent-update problem (a second approval silently replacing an
+ * operator-edited draft).
+ *
+ * The asset is included in the INSERT so there is no separate Step 3
+ * read-modify-write — the draft is fully populated in one operation.
+ */
+async function createScheduledDraft(
   svc: ReturnType<typeof getServiceRoleClient>,
-  input: FindOrCreateDraftInput,
+  input: CreateDraftInput,
 ): Promise<string | null> {
   // Normalise publish_date → scheduled_at = midnight in the COMPANY timezone.
-  // A spreadsheet row saying "June 14" means June 14 00:00 in the client's
-  // local timezone, not UTC midnight. fromZonedTime converts local midnight
-  // to the correct UTC equivalent (e.g. June 14 00:00 AEST = June 13 14:00 UTC).
+  // "June 14" means June 14 00:00 in the company timezone, not UTC midnight.
   const scheduledAtIso = fromZonedTime(
     `${input.publishDate}T00:00:00`,
     input.companyTimezone,
   ).toISOString();
 
-  // Look for an existing scheduled draft for (company, publish_date).
-  // Match by scheduled_at exact equality + state='scheduled' + not archived.
-  // IMPORTANT: if found, we return only the id. We do NOT update content —
-  // the operator may have already edited the caption on this draft.
-  const { data: existing, error: lookupErr } = await svc
-    .from("social_post_drafts")
-    .select("id")
-    .eq("company_id", input.companyId)
-    .eq("scheduled_at", scheduledAtIso)
-    .eq("state", "scheduled")
-    .is("archived_at", null)
-    .limit(1)
-    .maybeSingle();
-
-  if (lookupErr) {
-    logger.warn("image.auto_attach.draft_lookup_failed", {
-      companyId: input.companyId,
-      publishDate: input.publishDate,
-      err: lookupErr.message,
-    });
-    return null;
-  }
-
-  if (existing) {
-    // Draft exists — do NOT touch content. Only the caller (Step 3) will
-    // append the new asset id to media_asset_ids.
-    return (existing as { id: string }).id;
-  }
-
-  // No existing draft — create one.
-  //
-  // Resolve target platforms → connected social accounts (fail-soft: returns []
-  // on error or when no matching connections exist, so the draft is still created).
   const resolvedConnections = await resolveTargetConnections(
     svc,
     input.companyId,
     input.targetPlatforms,
   );
 
-  // target_profiles stores the full connection shape for the Composer display layer.
-  // draft_data.target_connection_ids stores the UUIDs for the V2 save/publish path.
-  // Both must be written — mapV1ToV2Draft reads target_connection_ids first (§draft_data
-  // mirroring convention), falling back to target_profiles. Writing both is safe.
   const connectionIds = resolvedConnections.map((c) => c.profile_id);
 
-  // Pre-fill content from the AI-generated caption if available; fall back to
-  // empty string. This is the ONLY place content is set; never overwritten after
-  // creation (create-only rule — same as target_profiles and content).
   const { data: created, error: createErr } = await svc
     .from("social_post_drafts")
     .insert({
@@ -447,12 +373,11 @@ async function findOrCreateScheduledDraft(
       state: "scheduled",
       content: input.postText ?? "",
       media_urls: [],
-      media_asset_ids: [],
+      media_asset_ids: [input.assetId],
       target_profiles: resolvedConnections,
       platform_variants: {},
       scheduled_at: scheduledAtIso,
       approval_required: false,
-      // Mirror connection IDs into draft_data for the V2 Composer save path.
       draft_data: connectionIds.length > 0
         ? { target_connection_ids: connectionIds }
         : {},


### PR DESCRIPTION
## Summary

Fixes the stacking problem: two aspect-ratio variants of the same spreadsheet row approved → previously one draft with two stacked images; now two separate posts each with one image, one caption, one channel set.

**Directive (no exemptions):** every approved image creates its own `social_post_drafts` row. No date-collapse, no append-to-existing.

## Investigation findings (pre-code)

1. **What stacked the image:** `findOrCreateScheduledDraft` queried `social_post_drafts` by `(company_id, scheduled_at, state='scheduled')`. When a second variant (16:9) for the same spreadsheet row was approved, it found the draft the first variant (1:1) created and appended to `media_asset_ids` — producing one draft with two images.

2. **Is the path shared with any other flow?** `findOrCreateScheduledDraft` is a private function with exactly one caller (`autoAttachImage`), which has exactly one caller (`POST /api/platform/image/jobs/[id]/select`). No recurring posts, no CAP, no manual scheduler. Safe to change with zero risk to other flows.

## Change

`findOrCreateScheduledDraft` → `createScheduledDraft`:
- Removes the `SELECT` lookup entirely — no find-existing branch
- Always `INSERT`s a new `social_post_drafts` row
- Asset UUID included directly in the `INSERT` (`media_asset_ids: [assetId]`) — no separate Step 3 read-modify-write; one atomic operation
- `content = post_text`, `target_profiles` + `draft_data.target_connection_ids` = resolved connections (unchanged from the create path)

**No migration needed** — `social_post_drafts` INSERT uses only existing columns.

## Tests (3068 pass)

- Path 2: asset in the INSERT row (not a subsequent UPDATE); no `social_post_drafts` UPDATE at all
- Path 3 (replaced): "two approvals same date = two separate INSERTs, no SELECT on social_post_drafts"
- Failure path updated: "draft INSERT error → attach_failed" (Step 3 UPDATE gone)
- `image-auto-attach-target-profiles.unit.test.ts`: find-path test replaced with "always-create: every approval INSERTs"