### PR TITLE
feat(calendar): slice A — side-pane editing + hover (D1, D2)

### DIFF
--- a/components/__tests__/slice-a-calendar-sidepane.test.tsx
+++ b/components/__tests__/slice-a-calendar-sidepane.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Slice A — Calendar side-pane editing + hover (D1, D2)
+ *
+ * D1: In-cell click = select day only (no Composer). Side-pane post item = opens Composer.
+ * D2: Muted at rest; hover reveals Open + Delete buttons. Delete uses confirm dialog.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({ attributes: {}, listeners: {}, setNodeRef: () => {}, transform: null, isDragging: false }),
+}));
+vi.mock("@dnd-kit/utilities", () => ({ CSS: { Translate: { toString: () => "" } } }));
+vi.mock("@/components/ui/SocialPlatformIcon", () => ({
+  SocialPlatformIcon: () => <span data-testid="platform-icon" />,
+}));
+
+import { DayDetailPostCard } from "@/components/social/dashboard/DayDetailPostCard";
+import { DayDetail } from "@/components/social/dashboard/DayDetail";
+import type { CalendarPost } from "@/lib/social/types";
+
+const POST: CalendarPost = {
+  id: "post-1",
+  state: "scheduled",
+  scheduled_at: "2026-06-14T09:00:00Z",
+  published_at: null,
+  planned_for_at: null,
+  content_excerpt: "Test post content",
+  primary_media_url: null,
+  link_url: null,
+  target_profiles: [],
+  is_recurring_child: false,
+};
+
+// ─── DayDetailPostCard ────────────────────────────────────────────────────────
+
+describe("DayDetailPostCard — D2 hover", () => {
+  it("renders hover-actions container (hidden at rest via CSS, present in DOM)", () => {
+    const onClick = vi.fn();
+    const onDelete = vi.fn();
+    render(<DayDetailPostCard post={POST} onClick={onClick} onDelete={onDelete} />);
+    // Hover actions exist in DOM (CSS hides them; group-hover reveals)
+    expect(screen.getByTestId("hover-actions")).toBeInTheDocument();
+  });
+
+  it("hover Open button calls onClick with the post — opens Composer", () => {
+    const onClick = vi.fn();
+    const onDelete = vi.fn();
+    render(<DayDetailPostCard post={POST} onClick={onClick} onDelete={onDelete} />);
+    fireEvent.click(screen.getByTestId("hover-open-btn"));
+    expect(onClick).toHaveBeenCalledWith(POST);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("hover Delete button calls onDelete with the post id — not onClick", () => {
+    const onClick = vi.fn();
+    const onDelete = vi.fn();
+    render(<DayDetailPostCard post={POST} onClick={onClick} onDelete={onDelete} />);
+    fireEvent.click(screen.getByTestId("hover-delete-btn"));
+    expect(onDelete).toHaveBeenCalledWith("post-1");
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("card body click calls onClick — opens Composer from side pane (D1)", () => {
+    const onClick = vi.fn();
+    const onDelete = vi.fn();
+    render(<DayDetailPostCard post={POST} onClick={onClick} onDelete={onDelete} />);
+    // The flex-1 div wrapping content has the onClick
+    fireEvent.click(screen.getByText("Test post content"));
+    expect(onClick).toHaveBeenCalledWith(POST);
+  });
+
+  it("card has muted-at-rest opacity class", () => {
+    render(<DayDetailPostCard post={POST} onClick={vi.fn()} onDelete={vi.fn()} />);
+    const card = screen.getByTestId("day-detail-post-card");
+    expect(card.className).toContain("opacity-80");
+  });
+
+  it("card has hover-shadow lift class (hover:shadow-md)", () => {
+    render(<DayDetailPostCard post={POST} onClick={vi.fn()} onDelete={vi.fn()} />);
+    const card = screen.getByTestId("day-detail-post-card");
+    expect(card.className).toContain("hover:shadow-md");
+  });
+});
+
+// ─── DayDetail ────────────────────────────────────────────────────────────────
+
+describe("DayDetail — D1 side-pane opens Composer", () => {
+  const date = new Date("2026-06-14T09:00:00Z");
+
+  it("renders a card per post", () => {
+    const onPostClick = vi.fn();
+    render(
+      <DayDetail
+        date={date}
+        posts={[POST]}
+        onPostClick={onPostClick}
+        onDelete={vi.fn()}
+        onAddPost={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("day-detail-post-card")).toBeInTheDocument();
+    expect(screen.getByTestId("day-detail-list")).toBeInTheDocument();
+  });
+
+  it("clicking a card body calls onPostClick (opens Composer)", () => {
+    const onPostClick = vi.fn();
+    render(
+      <DayDetail
+        date={date}
+        posts={[POST]}
+        onPostClick={onPostClick}
+        onDelete={vi.fn()}
+        onAddPost={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("Test post content"));
+    expect(onPostClick).toHaveBeenCalledWith(POST);
+  });
+
+  it("shows empty state when no posts", () => {
+    render(
+      <DayDetail
+        date={date}
+        posts={[]}
+        onPostClick={vi.fn()}
+        onDelete={vi.fn()}
+        onAddPost={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("No posts scheduled.")).toBeInTheDocument();
+  });
+});

--- a/components/social/dashboard/CalendarShell.tsx
+++ b/components/social/dashboard/CalendarShell.tsx
@@ -306,7 +306,6 @@ export function CalendarShell({ companyId, hasConnections, availableConnections,
                 profileFilter={profileFilter}
                 selectedDate={selectedDate}
                 onDateSelect={(d) => setSelectedDate(d)}
-                onClickPost={handleClickPost}
                 renderDay={(date, dayPosts, meta) => (
                   <DnDCell
                     date={date}
@@ -316,7 +315,9 @@ export function CalendarShell({ companyId, hasConnections, availableConnections,
                     isOtherMonth={meta.isOtherMonth}
                     isToday={meta.isToday}
                     onClick={() => setSelectedDate(date)}
-                    onClickPost={handleClickPost}
+                    // D1: in-cell click = select day only. No onClickPost here —
+                    // PostChip clicks bubble up to the cell and select the date.
+                    // Opening Composer happens only from the side-pane (DayDetail).
                   />
                 )}
               />
@@ -328,7 +329,6 @@ export function CalendarShell({ companyId, hasConnections, availableConnections,
               posts={selectedDayPosts}
               onPostClick={handleClickPost}
               onDelete={handleDelete}
-              onReschedule={handleReschedule}
               onAddPost={() => openComposer({ prefilledDate: selectedDate })}
               className="w-72 shrink-0"
             />

--- a/components/social/dashboard/DayDetail.tsx
+++ b/components/social/dashboard/DayDetail.tsx
@@ -10,7 +10,6 @@ interface DayDetailProps {
   posts: CalendarPost[];
   onPostClick: (post: CalendarPost) => void;
   onDelete: (id: string) => void;
-  onReschedule: (id: string) => void;
   onAddPost: () => void;
   className?: string;
 }
@@ -20,7 +19,6 @@ export function DayDetail({
   posts,
   onPostClick,
   onDelete,
-  onReschedule,
   onAddPost,
   className,
 }: DayDetailProps) {
@@ -77,7 +75,6 @@ export function DayDetail({
               key={post.id}
               post={post}
               onDelete={onDelete}
-              onReschedule={onReschedule}
               onClick={onPostClick}
             />
           ))}

--- a/components/social/dashboard/DayDetailPostCard.tsx
+++ b/components/social/dashboard/DayDetailPostCard.tsx
@@ -10,7 +10,6 @@ import type { CalendarPost } from "@/lib/social/types";
 interface DayDetailPostCardProps {
   post: CalendarPost;
   onDelete: (id: string) => void;
-  onReschedule: (id: string) => void;
   onClick: (post: CalendarPost) => void;
 }
 
@@ -67,7 +66,7 @@ function StateIcon({ state }: { state: CalendarPost["state"] }) {
   return null;
 }
 
-export function DayDetailPostCard({ post, onDelete, onReschedule, onClick }: DayDetailPostCardProps) {
+export function DayDetailPostCard({ post, onDelete, onClick }: DayDetailPostCardProps) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: post.id,
     data: { postId: post.id, scheduledAt: post.scheduled_at },
@@ -86,7 +85,8 @@ export function DayDetailPostCard({ post, onDelete, onReschedule, onClick }: Day
       ref={setNodeRef}
       style={style}
       className={cn(
-        "group relative flex cursor-pointer items-start gap-3 rounded-lg border border-border bg-card p-3 transition-shadow hover:shadow-sm",
+        // D2: muted at rest → full opacity + lift on hover.
+        "group relative flex cursor-pointer items-start gap-3 rounded-lg border border-border bg-card p-3 transition-all opacity-80 hover:opacity-100 hover:shadow-md",
         isDragging && "opacity-50 shadow-lg z-50",
       )}
       data-testid="day-detail-post-card"
@@ -129,26 +129,29 @@ export function DayDetailPostCard({ post, onDelete, onReschedule, onClick }: Day
         </div>
       )}
 
-      {/* Hover action buttons */}
+      {/* Hover action buttons — D2: Open (edit) + Delete */}
       <div className="absolute right-2 top-2 hidden gap-1 group-hover:flex" data-testid="hover-actions">
         <button
           type="button"
-          aria-label="Delete"
-          onClick={(e) => { e.stopPropagation(); onDelete(post.id); }}
-          className="flex h-7 w-7 items-center justify-center rounded border border-border bg-background text-muted-foreground hover:text-destructive hover:border-destructive transition-colors"
+          aria-label="Open post"
+          onClick={(e) => { e.stopPropagation(); onClick(post); }}
+          data-testid="hover-open-btn"
+          className="flex h-7 w-7 items-center justify-center rounded border border-border bg-background text-muted-foreground hover:text-primary hover:border-primary transition-colors"
         >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-            <path d="M3 6h18" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" /><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
           </svg>
         </button>
         <button
           type="button"
-          aria-label="Reschedule"
-          onClick={(e) => { e.stopPropagation(); onReschedule(post.id); }}
-          className="flex h-7 w-7 items-center justify-center rounded border border-border bg-background text-muted-foreground hover:text-primary hover:border-primary transition-colors"
+          aria-label="Delete post"
+          onClick={(e) => { e.stopPropagation(); onDelete(post.id); }}
+          data-testid="hover-delete-btn"
+          className="flex h-7 w-7 items-center justify-center rounded border border-border bg-background text-muted-foreground hover:text-destructive hover:border-destructive transition-colors"
         >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-            <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" /><path d="M21 3v5h-5" />
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="M3 6h18" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" /><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
           </svg>
         </button>
       </div>

--- a/e2e/composer-d3-edit-mode.spec.ts
+++ b/e2e/composer-d3-edit-mode.spec.ts
@@ -148,12 +148,16 @@ test.describe("PR-D3 edit-mode parity", () => {
     const post = makeCalendarPost("d3-scheduled", "scheduled");
     await setupCalendarWithPost(page, context, post, "scheduled");
 
-    // Click the post chip
+    // D1: chip click selects the day, showing the side-pane post card
     const chip = page.locator('[data-testid="post-chip"]').first();
     await expect(chip).toBeVisible({ timeout: 10_000 });
     await chip.click();
 
-    // Composer overlay should open (not analytics modal)
+    // Side-pane card appears; clicking it opens Composer (not analytics modal)
+    const card = page.getByTestId("day-detail-post-card").first();
+    await expect(card).toBeVisible({ timeout: 5_000 });
+    await card.click();
+
     await expect(page.getByTestId("composer-overlay")).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId("post-analytics-modal")).not.toBeVisible();
   });
@@ -189,6 +193,11 @@ test.describe("PR-D3 edit-mode parity", () => {
     const chip = page.locator('[data-testid="post-chip"]').first();
     await expect(chip).toBeVisible({ timeout: 10_000 });
     await chip.click();
+
+    // D1: chip click selects the day, showing the side-pane post card
+    const card = page.getByTestId("day-detail-post-card").first();
+    await expect(card).toBeVisible({ timeout: 5_000 });
+    await card.click();
 
     // Analytics modal should open; composer overlay should NOT open
     await expect(page.getByTestId("post-analytics-modal")).toBeVisible({ timeout: 5_000 });

--- a/e2e/composer-v3.2-full-flow.spec.ts
+++ b/e2e/composer-v3.2-full-flow.spec.ts
@@ -421,6 +421,11 @@ test.describe("Item 15 — click routing by post status", () => {
     await expect(chip).toBeVisible({ timeout: 10_000 });
     await chip.click();
 
+    // D1: chip click selects the day; side-pane card click opens Composer
+    const card = page.getByTestId("day-detail-post-card").first();
+    await expect(card).toBeVisible({ timeout: 5_000 });
+    await card.click();
+
     await expect(page.getByTestId("composer-overlay")).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId("post-analytics-modal")).not.toBeVisible();
   });
@@ -450,6 +455,11 @@ test.describe("Item 15 — click routing by post status", () => {
     const chip = page.getByTestId("post-chip").first();
     await expect(chip).toBeVisible({ timeout: 10_000 });
     await chip.click();
+
+    // D1: chip click selects the day; side-pane card click opens analytics modal
+    const card = page.getByTestId("day-detail-post-card").first();
+    await expect(card).toBeVisible({ timeout: 5_000 });
+    await card.click();
 
     await expect(page.getByTestId("post-analytics-modal")).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId("composer-overlay")).not.toBeVisible();


### PR DESCRIPTION
## Slice A — Calendar side-pane editing + hover

**Brief ref:** IMAGE_TO_POST_FULL_BUILD_BRIEF.md §3 Slice A, decisions D1+D2.

### Investigation findings
- `CalendarShell` was passing `onClickPost={handleClickPost}` to both `SocialCalendarGrid` and `DnDCell`, causing in-cell PostChip clicks to navigate `?compose=<id>` (opening Composer). D1 requires in-cell clicks to select day only.
- `DayDetailPostCard` had Delete + Reschedule buttons in hover state. D2 requires Open (edit) + Delete.

### Changes

**D1 — In-cell click = select day only:**
- Removed `onClickPost` from DnDCell render in `CalendarShell`. PostChip clicks now bubble to the cell's `onClick` → `setSelectedDate` (no Composer).
- Removed `onClickPost` from `SocialCalendarGrid` in the DnD path (renderDay overrides; the `onClickPost` prop there was redundant when renderDay is active).
- `DayDetail` side-pane card click still calls `onPostClick=handleClickPost` → opens Composer. ✓

**D2 — Hover: Open + Delete; muted at rest:**
- Replaced Reschedule button with Open (pencil) button that calls `onClick(post)`.
- Removed `onReschedule` prop from `DayDetailPostCard`, `DayDetail`, and CalendarShell pass-through.
- Card: `opacity-80` at rest → `opacity-100` on hover; `hover:shadow-md` lift; `transition-all`.
- `stopPropagation` on both hover buttons.

### DECIDED FALLBACK
None — D1+D2 were fully specified.

### Migration status
None required.

### Tests
9 component tests — all pass. Full unit suite 3083/3083 green.