### PR TITLE
feat(migration): slice C — destination column on image_generation_batches (0171)

### DIFF
--- a/supabase/migrations/0171_image_generation_batches_destination.sql
+++ b/supabase/migrations/0171_image_generation_batches_destination.sql
@@ -1,0 +1,24 @@
+-- Migration 0171: Add destination column to image_generation_batches
+--
+-- D5 (IMAGE_TO_POST_FULL_BUILD_BRIEF §2): operators choose Download vs Publish
+-- before generating. The choice is persisted on the batch so the approval
+-- carousel (Slice G) and download endpoint (Slice E) can behave accordingly.
+--
+-- Discovery: image_generation_batches owns the batch lifecycle and is already
+-- joined to per-job rows — the correct table per D5 discovery rule.
+--
+-- Values:
+--   'publish'  (DEFAULT) — existing behaviour; approval auto-creates a draft
+--   'download' — approval adds to a download set; no draft created
+--
+-- Online-safe: ADD COLUMN with a NOT NULL DEFAULT acquires no row-level lock.
+-- Existing batches get DEFAULT 'publish' (backwards-compatible).
+
+ALTER TABLE image_generation_batches
+  ADD COLUMN IF NOT EXISTS destination TEXT NOT NULL DEFAULT 'publish'
+    CONSTRAINT image_generation_batches_destination_check
+      CHECK (destination IN ('download', 'publish'));
+
+COMMENT ON COLUMN image_generation_batches.destination IS
+  'Operator-chosen output path: ''publish'' creates social drafts on approval '
+  '(default, backwards-compatible); ''download'' adds assets to a download set.';


### PR DESCRIPTION
## Slice C — Destination column migration (D5)

**§0.5 migration ritual — migration-only PR.**

### Investigation (D5 discovery rule)
- `image_generation_batches` owns batch lifecycle state and is read by the batch-results page.
- It is already joined to `image_generation_jobs` (via `batch_id` FK).
- No `destination` column exists today.
- Per D5: do NOT add to per-asset rows — batch-level is correct.

### Migration 0171
```sql
ALTER TABLE image_generation_batches
  ADD COLUMN IF NOT EXISTS destination TEXT NOT NULL DEFAULT 'publish'
  CONSTRAINT image_generation_batches_destination_check
    CHECK (destination IN ('download', 'publish'));
```

**Online-safe** (ADD COLUMN with NOT NULL DEFAULT, no row lock).  
**Backwards-compatible** (DEFAULT 'publish' = existing behaviour for all current batches).

### Migration ritual
1. ✅ Migration PR (this PR)
2. ⏳ Trigger `deploy-migrations.yml` + verify column exists in prod (done after merge)
3. ⏳ Regenerate DB types in Slice D PR
4. ⏳ Slice D (code) merges only after column confirmed

### Tests
Migration applies cleanly; no code using the column in this PR.