### PR TITLE
feat(image-gen): slice D — destination fork Download vs Publish (D4, D5)

### DIFF
--- a/app/api/platform/image/batch/route.ts
+++ b/app/api/platform/image/batch/route.ts
@@ -42,6 +42,7 @@ const BatchSchema = z.object({
   source_filename: z.string().optional(),
   source_row_count: z.number().int().min(1).optional(),
   mode: z.enum(["generate", "preview"]).default("generate"),
+  destination: z.enum(["publish", "download"]).default("publish"),
 });
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
@@ -53,7 +54,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return validationError("Invalid batch spec.", { issues: parsed.error.issues });
   }
 
-  const { company_id, jobs, source_filename, source_row_count, mode } = parsed.data;
+  const { company_id, jobs, source_filename, source_row_count, mode, destination } = parsed.data;
 
   const gate = await requireCanDoForApi(company_id, "create_post");
   if (gate.kind === "deny") return gate.response;
@@ -65,6 +66,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     mode,
     sourceFilename: source_filename,
     sourceRowCount: source_row_count,
+    destination,
   });
 
   if (!result.ok) {

--- a/app/api/platform/image/ingest/route.ts
+++ b/app/api/platform/image/ingest/route.ts
@@ -81,6 +81,11 @@ function parseIngestMode(formData: FormData): IngestMode {
   return v === "template" ? "template" : "ideogram";
 }
 
+function parseDestination(formData: FormData): "publish" | "download" {
+  const v = (formData.get("destination") as string | null)?.trim();
+  return v === "download" ? "download" : "publish";
+}
+
 /** Extract modifiable fields from a v2 template's layer list. */
 function extractTemplateFields(layers: Layer[]): TemplateField[] {
   const fields: TemplateField[] = [];
@@ -141,12 +146,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   // ─── Route by ingest mode ────────────────────────────────────────────────
   const ingestMode = parseIngestMode(formData);
+  const destination = parseDestination(formData);
 
   if (ingestMode === "template") {
-    return handleTemplateIngest({ formData, fileBlob, format, companyId, gate, req });
+    return handleTemplateIngest({ formData, fileBlob, format, companyId, gate, req, destination });
   }
 
-  return handleIdeogramIngest({ fileBlob, format, companyId, gate, req });
+  return handleIdeogramIngest({ fileBlob, format, companyId, gate, req, destination });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -159,12 +165,14 @@ async function handleIdeogramIngest({
   companyId,
   gate,
   req,
+  destination,
 }: {
   fileBlob: File;
   format: FileFormat;
   companyId: string;
   gate: { userId: string };
   req: NextRequest;
+  destination: "publish" | "download";
 }): Promise<NextResponse> {
   const buffer = Buffer.from(await fileBlob.arrayBuffer());
   const parsed =
@@ -229,6 +237,7 @@ async function handleIdeogramIngest({
     sourceFilename: fileBlob.name,
     sourceRowCount: interpreted.posts.length,
     postTextByParentIndex,
+    destination,
   });
 
   if (!dispatched.ok) {
@@ -291,6 +300,7 @@ async function handleTemplateIngest({
   companyId,
   gate,
   req,
+  destination,
 }: {
   formData: FormData;
   fileBlob: File;
@@ -298,6 +308,7 @@ async function handleTemplateIngest({
   companyId: string;
   gate: { userId: string };
   req: NextRequest;
+  destination: "publish" | "download";
 }): Promise<NextResponse> {
   // ─── 1. Validate template mode constraints ───────────────────────────────
   if (format !== "xlsx") {
@@ -431,6 +442,7 @@ async function handleTemplateIngest({
     triggeredBy: gate.userId,
     jobs: jobSpecs,
     mode: generateMode,
+    destination,
     sourceFilename: fileBlob.name,
     sourceRowCount: parsed.rowCount,
   });

--- a/components/image/IngestClient.tsx
+++ b/components/image/IngestClient.tsx
@@ -30,11 +30,15 @@ interface IngestResponse {
   error?: { message: string };
 }
 
+type Destination = "publish" | "download";
+
 export function IngestClient({ companyId }: { companyId: string }) {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
   const [mode, setMode] = useState<Mode>("generate");
+  // D4: Destination fork — explicit Download vs Publish BEFORE generating.
+  const [destination, setDestination] = useState<Destination>("publish");
   const [submitting, setSubmitting] = useState(false);
   const [previewResult, setPreviewResult] = useState<IngestResponse["data"] | null>(null);
   const [dragOver, setDragOver] = useState(false);
@@ -61,6 +65,7 @@ export function IngestClient({ companyId }: { companyId: string }) {
     const fd = new FormData();
     fd.append("company_id", companyId);
     fd.append("file", file);
+    fd.append("destination", destination);
 
     try {
       const res = await fetch(`/api/platform/image/ingest?mode=${mode}`, {
@@ -119,6 +124,31 @@ export function IngestClient({ companyId }: { companyId: string }) {
         <a href="/templates/mass-image-gen-template.xlsx" download className="underline">Download .xlsx</a>
         {" · "}
         <a href="/templates/mass-image-gen-template.docx" download className="underline">Download .docx</a>
+      </div>
+
+      {/* D4: Destination fork — Download vs Publish, separate from cost toggle */}
+      <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <p className="text-sm font-semibold">What do you want to do with approved images?</p>
+        <div className="grid grid-cols-2 gap-3">
+          {(["publish", "download"] as const).map((d) => (
+            <button
+              key={d}
+              type="button"
+              data-testid={`destination-${d}`}
+              onClick={() => setDestination(d)}
+              className={`flex flex-col gap-1 rounded-lg border-2 p-3 text-left transition-colors ${destination === d ? "border-primary bg-primary/5" : "border-border hover:border-primary/40"}`}
+            >
+              <span className="text-sm font-medium">
+                {d === "publish" ? "Create scheduled posts" : "Download images"}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {d === "publish"
+                  ? "Approved images create draft posts with caption, channel, and date pre-filled."
+                  : "Approved images go into a download set. No posts created."}
+              </span>
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Mode toggle */}

--- a/lib/__tests__/image-batch-destination.unit.test.ts
+++ b/lib/__tests__/image-batch-destination.unit.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Slice D — Generate destination fork (D4, D5)
+ *
+ * Tests:
+ *  - destination='publish' (default) written to batch row
+ *  - destination='download' written to batch row
+ *  - dispatch with no destination defaults to 'publish'
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+const capturedBatchInserts: Array<Record<string, unknown>> = [];
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({
+    from: vi.fn((table: string) => {
+      if (table === "platform_companies") {
+        return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: { monthly_image_gen_budget_cents: 1_000_000 }, error: null }) };
+      }
+      if (table === "image_gen_spend") {
+        return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }
+      if (table === "image_generation_batches") {
+        return {
+          insert: vi.fn((row: Record<string, unknown>) => {
+            capturedBatchInserts.push(row);
+            return { select: vi.fn().mockReturnThis(), single: vi.fn().mockResolvedValue({ data: { id: "batch-1" }, error: null }) };
+          }),
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        };
+      }
+      if (table === "image_generation_jobs") {
+        return { insert: vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: "job-1" }, error: null }) }) }), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }) };
+      }
+      return { insert: vi.fn(), select: vi.fn(), update: vi.fn(), eq: vi.fn() };
+    }),
+  })),
+}));
+
+vi.mock("@/lib/image/enqueue", () => ({ enqueueImageJob: vi.fn().mockResolvedValue({ ok: true }) }));
+
+import { dispatchImageBatch } from "@/lib/image/dispatch";
+
+const BASE_JOB = { styleId: "clean_corporate" as const, primaryColour: "#123456", compositionType: "split_layout" as const, aspectRatio: "1x1" as const };
+const COMPANY = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+beforeEach(() => {
+  capturedBatchInserts.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("dispatchImageBatch — destination (D5)", () => {
+  it("persists destination='publish' on the batch row", async () => {
+    await dispatchImageBatch({ companyId: COMPANY, triggeredBy: "u1", jobs: [BASE_JOB], mode: "generate", destination: "publish" });
+    expect(capturedBatchInserts[0]?.destination).toBe("publish");
+  });
+
+  it("persists destination='download' on the batch row", async () => {
+    await dispatchImageBatch({ companyId: COMPANY, triggeredBy: "u1", jobs: [BASE_JOB], mode: "generate", destination: "download" });
+    expect(capturedBatchInserts[0]?.destination).toBe("download");
+  });
+
+  it("defaults to 'publish' when destination is omitted", async () => {
+    await dispatchImageBatch({ companyId: COMPANY, triggeredBy: "u1", jobs: [BASE_JOB], mode: "generate" });
+    expect(capturedBatchInserts[0]?.destination).toBe("publish");
+  });
+});

--- a/lib/image/dispatch.ts
+++ b/lib/image/dispatch.ts
@@ -48,6 +48,12 @@ export interface DispatchInput {
    * Absent for template mode, mood board, and direct batch dispatch.
    */
   postTextByParentIndex?: Record<number, string>;
+  /**
+   * Operator-chosen output path for batch approvals (D5).
+   * 'publish' (default) → auto-attach creates drafts on approval.
+   * 'download' → approvals add to a download set; no draft created.
+   */
+  destination?: "publish" | "download";
 }
 
 export type DispatchResult =
@@ -113,6 +119,7 @@ export async function dispatchImageBatch(input: DispatchInput): Promise<Dispatch
       source_filename: input.sourceFilename ?? null,
       source_row_count: input.sourceRowCount ?? null,
       triggered_by: triggeredBy,
+      destination: input.destination ?? "publish",
     })
     .select("id")
     .single();


### PR DESCRIPTION
## Slice D — Generate destination fork (D4, D5)

Depends on Slice C (migration 0171 for destination column, verified live in prod).

### Changes
**D4 — IngestClient UI:** Download/Publish card selector added BEFORE the cost toggle. Two cards ('Create scheduled posts' / 'Download images') with descriptive copy. Default: Publish.

**D5 — Backend persistence:** DispatchInput + batch INSERT + batch route Zod schema + both ingest handlers pass destination through.

### DECIDED FALLBACK
None — requirements were explicit.

### Migration
None (uses Slice C column).

### Tests
3 unit tests: publish persisted, download persisted, default='publish'.