### PR TITLE
feat(image-gen): slice E — download set + Download all (D6, D7, D20, D24, D25)

### DIFF
--- a/app/api/platform/image/batch/[id]/download/route.ts
+++ b/app/api/platform/image/batch/[id]/download/route.ts
@@ -1,0 +1,287 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { Zip, ZipPassThrough } from "fflate";
+
+import { internalError, notFound, validateUuidParam, validationError } from "@/lib/http";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// GET /api/platform/image/batch/[id]/download?company_id=UUID
+//
+// Streams a ZIP of approved assets for a download-mode batch (D6, D7, E).
+//
+// For destination='download' batches: only jobs with image_selections.selected=true
+// are included. For destination='publish' batches: all completed jobs (same
+// as the original PR-1219 behaviour).
+//
+// Uses fflate ZipPassThrough (level=0, PNGs already compressed) + 10-concurrent
+// Supabase Storage fetches. maxDuration=300.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const IMAGE_GEN_BUCKET = process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
+const SIGNED_URL_TTL = 900;
+const FETCH_CONCURRENCY = 10;
+const HARD_CAP = 500;
+const SOFT_WARNING = 100;
+const IMAGE_FETCH_TIMEOUT_MS = 20_000;
+
+interface JobRow {
+  id: string;
+  result_storage_path: string;
+  parent_post_index: number | null;
+  generation_params: Record<string, unknown> | null;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const idCheck = validateUuidParam(id, "id");
+  if (!idCheck.ok) return idCheck.response;
+  const batchId = idCheck.value;
+
+  const companyId = new URL(req.url).searchParams.get("company_id");
+  if (!companyId) return validationError("company_id query param is required.");
+
+  const svc = getServiceRoleClient();
+
+  // Auth + company-scope guard.
+  const { data: batch, error: batchErr } = await svc
+    .from("image_generation_batches")
+    .select("id, company_id, state, total_jobs, destination")
+    .eq("id", batchId)
+    .single();
+
+  if (batchErr || !batch) {
+    if (batchErr?.code === "PGRST116") return notFound(`Batch ${batchId} not found.`);
+    return internalError("Failed to fetch batch.");
+  }
+
+  if ((batch.company_id as string) !== companyId) return notFound(`Batch ${batchId} not found.`);
+
+  const gate = await requireCanDoForApi(companyId, "create_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const isDownloadMode = (batch.destination as string | null) === "download";
+
+  // For download mode: only approved (selected=true) items.
+  // For publish mode: all completed jobs (original behaviour).
+  let jobs: JobRow[];
+
+  if (isDownloadMode) {
+    // JOIN image_generation_jobs → image_selections WHERE selected=true.
+    const { data: selRows, error: selErr } = await svc
+      .from("image_selections")
+      .select("job_id")
+      .eq("selected", true)
+      .in(
+        "job_id",
+        // sub-select job IDs for this batch
+        (await svc
+          .from("image_generation_jobs")
+          .select("id")
+          .eq("batch_id", batchId)
+          .eq("state", "completed")
+          .not("result_storage_path", "is", null)
+          .then(({ data }) => (data ?? []).map((j: { id: string }) => j.id))),
+      );
+
+    if (selErr) {
+      logger.error("image.batch.download.sel_failed", { batchId, err: selErr.message });
+      return internalError("Failed to fetch approved set.");
+    }
+
+    const approvedJobIds = new Set((selRows ?? []).map((r: { job_id: string }) => r.job_id));
+    if (approvedJobIds.size === 0) {
+      return NextResponse.json(
+        { ok: false, error: { code: "NO_APPROVED_IMAGES", message: "No approved images in download set." } },
+        { status: 422 },
+      );
+    }
+
+    const { data: jobRows, error: jobErr } = await svc
+      .from("image_generation_jobs")
+      .select("id, result_storage_path, parent_post_index, generation_params")
+      .eq("batch_id", batchId)
+      .eq("state", "completed")
+      .not("result_storage_path", "is", null)
+      .in("id", [...approvedJobIds]);
+
+    if (jobErr) return internalError("Failed to fetch jobs.");
+    jobs = (jobRows ?? []) as JobRow[];
+  } else {
+    // Publish mode or no destination: all completed jobs (original behaviour).
+    const { data: jobRows, error: jobErr } = await svc
+      .from("image_generation_jobs")
+      .select("id, result_storage_path, parent_post_index, generation_params")
+      .eq("batch_id", batchId)
+      .eq("state", "completed")
+      .not("result_storage_path", "is", null)
+      .order("parent_post_index", { ascending: true, nullsFirst: true })
+      .order("created_at", { ascending: true });
+
+    if (jobErr) return internalError("Failed to fetch jobs.");
+    jobs = (jobRows ?? []) as JobRow[];
+  }
+
+  if (jobs.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: { code: "NO_COMPLETED_IMAGES", message: "No completed images to download." } },
+      { status: 422 },
+    );
+  }
+
+  if (jobs.length > HARD_CAP) {
+    return NextResponse.json(
+      { ok: false, error: { code: "BATCH_TOO_LARGE", message: `${jobs.length} images exceeds hard cap of ${HARD_CAP}.` } },
+      { status: 413 },
+    );
+  }
+
+  // Batch-sign storage paths.
+  const paths = jobs.map((j) => j.result_storage_path);
+  const { data: signed, error: signErr } = await svc.storage
+    .from(IMAGE_GEN_BUCKET)
+    .createSignedUrls(paths, SIGNED_URL_TTL);
+
+  if (signErr || !signed) {
+    logger.error("image.batch.download.sign_failed", { batchId, err: signErr?.message });
+    return internalError("Failed to generate download URLs.");
+  }
+
+  const signedByPath = new Map<string, string>();
+  for (const s of signed) {
+    if (s.signedUrl && s.path) signedByPath.set(s.path, s.signedUrl);
+  }
+
+  // Stream ZIP.
+  const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+  const writer = writable.getWriter();
+  const skipped: Array<{ entryName: string; reason: string }> = [];
+
+  void buildZip({ jobs, signedByPath, writer, skipped, batchId });
+
+  const filename = `batch-${batchId.slice(0, 8)}.zip`;
+  const headers = new Headers({
+    "Content-Type": "application/zip",
+    "Content-Disposition": `attachment; filename="${filename}"`,
+    "Cache-Control": "no-store",
+  });
+  if (jobs.length > SOFT_WARNING) {
+    headers.set("X-Download-Warning", `large-batch: ${jobs.length} images`);
+  }
+
+  logger.info("image.batch.download.started", { batchId, companyId, count: jobs.length, isDownloadMode });
+  return new NextResponse(readable, { headers });
+}
+
+// ─── ZIP builder ──────────────────────────────────────────────────────────────
+
+async function buildZip({
+  jobs,
+  signedByPath,
+  writer,
+  skipped,
+  batchId,
+}: {
+  jobs: JobRow[];
+  signedByPath: Map<string, string>;
+  writer: WritableStreamDefaultWriter<Uint8Array>;
+  skipped: Array<{ entryName: string; reason: string }>;
+  batchId: string;
+}): Promise<void> {
+  const chunkQueue: Uint8Array[] = [];
+  let zipError: Error | null = null;
+
+  const zip = new Zip((err, chunk, final) => {
+    if (err) { zipError = err; return; }
+    chunkQueue.push(chunk);
+    if (final) void drain();
+  });
+
+  async function drain(): Promise<void> {
+    while (chunkQueue.length > 0) {
+      await writer.write(chunkQueue.shift()!);
+    }
+  }
+
+  let inFlight = 0;
+  const queue: Array<() => void> = [];
+
+  function acquireSlot(): Promise<void> {
+    if (inFlight < FETCH_CONCURRENCY) { inFlight++; return Promise.resolve(); }
+    return new Promise((r) => queue.push(r));
+  }
+
+  function releaseSlot(): void {
+    inFlight--;
+    const next = queue.shift();
+    if (next) { inFlight++; next(); }
+  }
+
+  try {
+    await Promise.all(
+      jobs.map(async (job) => {
+        const entryName = buildEntryName(job);
+        await acquireSlot();
+        try {
+          const signedUrl = signedByPath.get(job.result_storage_path);
+          if (!signedUrl) { skipped.push({ entryName, reason: "no_signed_url" }); return; }
+
+          let imgBuf: Buffer;
+          try {
+            const resp = await fetch(signedUrl, { signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS) });
+            if (!resp.ok) {
+              skipped.push({ entryName, reason: `http_${resp.status}` });
+              logger.warn("image.batch.download.fetch_failed", { batchId, jobId: job.id, status: resp.status });
+              return;
+            }
+            imgBuf = Buffer.from(await resp.arrayBuffer());
+          } catch (err) {
+            skipped.push({ entryName, reason: err instanceof Error && err.name === "TimeoutError" ? "timeout" : "fetch_error" });
+            logger.warn("image.batch.download.fetch_error", { batchId, jobId: job.id });
+            return;
+          }
+
+          const entry = new ZipPassThrough(entryName);
+          zip.add(entry);
+          entry.push(imgBuf, true);
+          await drain();
+        } finally {
+          releaseSlot();
+        }
+      }),
+    );
+
+    if (skipped.length > 0) {
+      const lines = [`manifest.txt — skipped images in batch ${batchId}`, "", ...skipped.map((s) => `SKIPPED  ${s.entryName}  reason: ${s.reason}`), "", `Total skipped: ${skipped.length} / ${jobs.length}`];
+      const manifestEntry = new ZipPassThrough("manifest.txt");
+      zip.add(manifestEntry);
+      manifestEntry.push(Buffer.from(lines.join("\n"), "utf-8"), true);
+      await drain();
+    }
+
+    zip.end();
+    if (zipError) throw zipError;
+    await drain();
+    logger.info("image.batch.download.complete", { batchId, total: jobs.length, skipped: skipped.length });
+  } catch (err) {
+    logger.error("image.batch.download.zip_error", { batchId, err: err instanceof Error ? err.message : String(err) });
+    await writer.abort(err instanceof Error ? err : new Error(String(err)));
+    return;
+  }
+  await writer.close();
+}
+
+function buildEntryName(job: JobRow): string {
+  const row = job.parent_post_index !== null ? `row-${job.parent_post_index}` : "row-unknown";
+  const params = job.generation_params;
+  const variant = params && typeof params.variantKey === "string" ? params.variantKey : "base";
+  return `${row}/${variant}-${job.id.slice(0, 8)}.png`;
+}

--- a/app/api/platform/image/jobs/[id]/select/route.ts
+++ b/app/api/platform/image/jobs/[id]/select/route.ts
@@ -33,15 +33,18 @@ export const dynamic = "force-dynamic";
 const ApproveBodySchema = z.object({ reason: z.string().max(500).optional() });
 const RejectBodySchema = z.object({ reason: z.string().min(1).max(500) });
 
-async function loadJobOwner(jobId: string): Promise<{ companyId: string } | null> {
+async function loadJobOwner(jobId: string): Promise<{ companyId: string; batchId: string | null } | null> {
   const svc = getServiceRoleClient();
   const { data, error } = await svc
     .from("image_generation_jobs")
-    .select("company_id")
+    .select("company_id, batch_id")
     .eq("id", jobId)
     .maybeSingle();
   if (error || !data) return null;
-  return { companyId: (data as { company_id: string }).company_id };
+  return {
+    companyId: (data as { company_id: string }).company_id,
+    batchId: (data as { batch_id: string | null }).batch_id,
+  };
 }
 
 export async function POST(
@@ -79,53 +82,90 @@ async function handleSelection(
 
   const svc = getServiceRoleClient();
 
-  // Insert the selection row. Both approve and reject paths write here.
+  // D25: idempotency guard — if a selection already exists in the target state,
+  // return it without writing a duplicate row.
+  const { data: existing } = await svc
+    .from("image_selections")
+    .select("id, selected")
+    .eq("job_id", jobId)
+    .order("selected_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const existingData = existing as { id: string; selected: boolean } | null;
+  if (existingData && existingData.selected === approve) {
+    // Already in target state — idempotent no-op.
+    logger.info("image.select.idempotent", { jobId, approve });
+    // Fall through to return the existing state with destination-aware response.
+  }
+
+  // Fetch batch destination to route approve action correctly (D6, D20).
+  let batchDestination: "publish" | "download" = "publish";
+  if (owner.batchId) {
+    const { data: batchRow } = await svc
+      .from("image_generation_batches")
+      .select("destination")
+      .eq("id", owner.batchId)
+      .maybeSingle();
+    const dest = (batchRow as { destination?: string } | null)?.destination;
+    if (dest === "download") batchDestination = "download";
+  }
+
   const reason = approve
     ? (parsed.data as { reason?: string }).reason ?? null
     : (parsed.data as { reason: string }).reason;
 
-  const { data: selection, error: selErr } = await svc
-    .from("image_selections")
-    .insert({
-      job_id: jobId,
-      selected: approve,
-      selected_by: gate.userId,
-      rejection_reason: approve ? null : reason,
-    })
-    .select("id")
-    .single();
+  // Only insert if no matching existing row (D25: don't duplicate).
+  let selectionId: string;
+  if (existingData && existingData.selected === approve) {
+    selectionId = existingData.id;
+  } else {
+    const { data: selection, error: selErr } = await svc
+      .from("image_selections")
+      .insert({
+        job_id: jobId,
+        selected: approve,
+        selected_by: gate.userId,
+        rejection_reason: approve ? null : reason,
+      })
+      .select("id")
+      .single();
 
-  if (selErr || !selection) {
-    logger.error("image.select.insert_failed", {
-      jobId,
-      approve,
-      err: selErr?.message,
-    });
-    return internalError("Failed to record selection.");
+    if (selErr || !selection) {
+      logger.error("image.select.insert_failed", { jobId, approve, err: selErr?.message });
+      return internalError("Failed to record selection.");
+    }
+    selectionId = (selection as { id: string }).id;
   }
 
-  // Reject: done. No attach side-effect.
+  // Reject: done. No attach side-effect regardless of destination.
   if (!approve) {
     logger.info("image.select.rejected", { jobId, reason });
     return NextResponse.json({
       ok: true,
+      data: { jobId, selected: false, selectionId, rejectionReason: reason },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  // Approve — destination-aware (D6, D20):
+  //   download → item added to download set; no draft created
+  //   publish  → existing auto-attach behaviour
+  if (batchDestination === "download") {
+    logger.info("image.select.approved_download", { jobId, companyId: owner.companyId });
+    return NextResponse.json({
+      ok: true,
       data: {
         jobId,
-        selected: false,
-        selectionId: (selection as { id: string }).id,
-        rejectionReason: reason,
+        selected: true,
+        selectionId,
+        destination: "download",
+        addedToDownloadSet: true,
       },
       timestamp: new Date().toISOString(),
     });
   }
 
-  // Approve: fire auto-attach. Result is reflected in the response so the
-  // UI can render an "attached to draft on YYYY-MM-DD" affordance. The
-  // attach is fail-soft — selection has already been recorded.
-
-  // Fetch company timezone here (the caller owns companyId; this is the
-  // correct place per the locked model). Reuses the svc already open above.
-  // Fail-soft: "UTC" if absent.
+  // Publish path: fire auto-attach.
   let companyTimezone = "UTC";
   const { data: co } = await svc
     .from("platform_companies")
@@ -143,8 +183,6 @@ async function handleSelection(
       companyTimezone,
     });
   } catch (err) {
-    // autoAttachImage is designed not to throw; this is a defence-in-depth
-    // log for the impossible case.
     logger.warn("image.select.auto_attach_threw", {
       jobId,
       err: err instanceof Error ? err.message : String(err),
@@ -163,7 +201,8 @@ async function handleSelection(
     data: {
       jobId,
       selected: true,
-      selectionId: (selection as { id: string }).id,
+      selectionId,
+      destination: "publish",
       autoAttach: attachResult,
     },
     timestamp: new Date().toISOString(),

--- a/lib/__tests__/image-select-route.unit.test.ts
+++ b/lib/__tests__/image-select-route.unit.test.ts
@@ -35,7 +35,9 @@ function configureFrom(opts: {
   jobOwner?: { company_id: string } | null;
   selectionInsertError?: string | null;
 } = {}): void {
-  const jobOwner = opts.jobOwner === undefined ? { company_id: COMPANY_ID } : opts.jobOwner;
+  const jobOwner = opts.jobOwner === undefined
+    ? { company_id: COMPANY_ID, batch_id: "batch-1" }
+    : opts.jobOwner;
   mockFrom.mockImplementation((table: string) => {
     if (table === "image_generation_jobs") {
       return {
@@ -47,12 +49,34 @@ function configureFrom(opts: {
       };
     }
     if (table === "image_selections") {
+      // Support BOTH the idempotency check (select) and the insert.
+      const selectChain: Record<string, unknown> = {};
+      selectChain["select"] = () => selectChain;
+      selectChain["eq"] = () => selectChain;
+      selectChain["order"] = () => selectChain;
+      selectChain["limit"] = () => selectChain;
+      selectChain["in"] = () => selectChain;
+      // Idempotency check returns null (no existing selection) by default.
+      selectChain["maybeSingle"] = vi.fn().mockResolvedValue({ data: null, error: null });
       return {
+        select: vi.fn().mockReturnValue(selectChain),
         insert: vi.fn().mockReturnValue({
           select: vi.fn().mockReturnValue({
             single: vi.fn().mockResolvedValue({
               data: opts.selectionInsertError ? null : { id: SELECTION_ID },
               error: opts.selectionInsertError ? { message: opts.selectionInsertError } : null,
+            }),
+          }),
+        }),
+      };
+    }
+    if (table === "image_generation_batches") {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { destination: "publish" },
+              error: null,
             }),
           }),
         }),

--- a/lib/__tests__/image-slice-e-download-set.unit.test.ts
+++ b/lib/__tests__/image-slice-e-download-set.unit.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Slice E — Download set + Download all (D6, D20, D24, D25)
+ *
+ * Tests:
+ *  - download-mode batch: approve adds to download set (no autoAttach called)
+ *  - D25 idempotency: double-click Approve returns existing selection, no duplicate insert
+ *  - publish-mode batch: approve still fires autoAttach (unaffected)
+ *  - reject path: unaffected by destination
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+const mockGate = vi.fn().mockResolvedValue({ kind: "allow", userId: "user-1" });
+vi.mock("@/lib/platform/auth/api-gate", () => ({ requireCanDoForApi: (...a: unknown[]) => mockGate(...a) }));
+
+const mockAutoAttach = vi.fn().mockResolvedValue({ state: "attached", draftId: "d1", assetId: "a1" });
+vi.mock("@/lib/image/auto-attach", () => ({ autoAttachImage: (...a: unknown[]) => mockAutoAttach(...a) }));
+
+const COMPANY_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const JOB_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const SEL_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+let existingSelection: { id: string; selected: boolean } | null = null;
+let batchDestination: "publish" | "download" = "publish";
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "image_generation_jobs") {
+    return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: { company_id: COMPANY_ID, batch_id: "batch-1" }, error: null }) }) };
+  }
+  if (table === "image_selections") {
+    const c: Record<string, unknown> = {};
+    c["select"] = () => c; c["eq"] = () => c; c["order"] = () => c; c["limit"] = () => c; c["in"] = () => c;
+    c["maybeSingle"] = vi.fn().mockResolvedValue({ data: existingSelection, error: null });
+    c["insert"] = vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: SEL_ID }, error: null }) }) });
+    return c;
+  }
+  if (table === "image_generation_batches") {
+    return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: { destination: batchDestination }, error: null }) }) };
+  }
+  if (table === "platform_companies") {
+    return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: { timezone: "UTC" }, error: null }) }) };
+  }
+  return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
+});
+
+vi.mock("@/lib/supabase", () => ({ getServiceRoleClient: vi.fn(() => ({ from: mockFrom })) }));
+
+import { POST } from "@/app/api/platform/image/jobs/[id]/select/route";
+
+function makeApproveReq() {
+  return new NextRequest(`http://localhost/api/platform/image/jobs/${JOB_ID}/select`, { method: "POST", body: JSON.stringify({}), headers: { "Content-Type": "application/json" } });
+}
+
+describe("Slice E — download set (D6, D20, D25)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    existingSelection = null;
+    batchDestination = "publish";
+    mockGate.mockResolvedValue({ kind: "allow", userId: "user-1" });
+    mockAutoAttach.mockResolvedValue({ state: "attached", draftId: "d1", assetId: "a1" });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "image_generation_jobs") return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: { company_id: COMPANY_ID, batch_id: "batch-1" }, error: null }) }) };
+      if (table === "image_selections") { const c: Record<string, unknown> = {}; c["select"] = () => c; c["eq"] = () => c; c["order"] = () => c; c["limit"] = () => c; c["in"] = () => c; c["maybeSingle"] = vi.fn().mockResolvedValue({ data: existingSelection, error: null }); c["insert"] = vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: SEL_ID }, error: null }) }) }); return c; }
+      if (table === "image_generation_batches") return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: { destination: batchDestination }, error: null }) }) };
+      if (table === "platform_companies") return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: { timezone: "UTC" }, error: null }) }) };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
+    });
+  });
+
+  it("download mode: approve adds to download set (no autoAttach)", async () => {
+    batchDestination = "download";
+    const res = await POST(makeApproveReq(), { params: Promise.resolve({ id: JOB_ID }) });
+    const body = await res.json() as { ok: boolean; data: Record<string, unknown> };
+    expect(body.ok).toBe(true);
+    expect(body.data.addedToDownloadSet).toBe(true);
+    expect(body.data.destination).toBe("download");
+    expect(mockAutoAttach).not.toHaveBeenCalled();
+  });
+
+  it("D25: idempotent approve — returns existing selection without inserting duplicate", async () => {
+    existingSelection = { id: SEL_ID, selected: true };
+    batchDestination = "publish";
+    const res = await POST(makeApproveReq(), { params: Promise.resolve({ id: JOB_ID }) });
+    const body = await res.json() as { ok: boolean; data: { selectionId: string } };
+    expect(body.ok).toBe(true);
+    expect(body.data.selectionId).toBe(SEL_ID);
+    // autoAttach still called for publish idempotent case
+    expect(mockAutoAttach).toHaveBeenCalledOnce();
+  });
+
+  it("publish mode: approve fires autoAttach (unaffected by Slice E)", async () => {
+    batchDestination = "publish";
+    const res = await POST(makeApproveReq(), { params: Promise.resolve({ id: JOB_ID }) });
+    const body = await res.json() as { ok: boolean; data: Record<string, unknown> };
+    expect(body.ok).toBe(true);
+    expect(body.data.destination).toBe("publish");
+    expect(mockAutoAttach).toHaveBeenCalledOnce();
+  });
+});

--- a/lib/__tests__/image-slice-e-download-set.unit.test.ts
+++ b/lib/__tests__/image-slice-e-download-set.unit.test.ts
@@ -72,7 +72,7 @@ describe("Slice E — download set (D6, D20, D25)", () => {
 
   it("download mode: approve adds to download set (no autoAttach)", async () => {
     batchDestination = "download";
-    const res = await POST(makeApproveReq(), { params: Promise.resolve({ id: JOB_ID }) });
+    const res = await POST(makeApproveReq(), { params: { id: JOB_ID } });
     const body = await res.json() as { ok: boolean; data: Record<string, unknown> };
     expect(body.ok).toBe(true);
     expect(body.data.addedToDownloadSet).toBe(true);
@@ -83,7 +83,7 @@ describe("Slice E — download set (D6, D20, D25)", () => {
   it("D25: idempotent approve — returns existing selection without inserting duplicate", async () => {
     existingSelection = { id: SEL_ID, selected: true };
     batchDestination = "publish";
-    const res = await POST(makeApproveReq(), { params: Promise.resolve({ id: JOB_ID }) });
+    const res = await POST(makeApproveReq(), { params: { id: JOB_ID } });
     const body = await res.json() as { ok: boolean; data: { selectionId: string } };
     expect(body.ok).toBe(true);
     expect(body.data.selectionId).toBe(SEL_ID);
@@ -93,7 +93,7 @@ describe("Slice E — download set (D6, D20, D25)", () => {
 
   it("publish mode: approve fires autoAttach (unaffected by Slice E)", async () => {
     batchDestination = "publish";
-    const res = await POST(makeApproveReq(), { params: Promise.resolve({ id: JOB_ID }) });
+    const res = await POST(makeApproveReq(), { params: { id: JOB_ID } });
     const body = await res.json() as { ok: boolean; data: Record<string, unknown> };
     expect(body.ok).toBe(true);
     expect(body.data.destination).toBe("publish");


### PR DESCRIPTION
## Slice E — Download set + Download all

### D20 — Server-persisted download set (no migration)
PRIMARY approach: reuse  as the download-set membership indicator. Combined with , this provides the complete status without any new schema.

### D6 — Download mode approve
Approve on download batches: records  but skips . Response: .

### D25 — Idempotency
Select route checks for existing selection before inserting. If already in target state (), returns existing  without duplicate.

### D7 — Download all endpoint
:
- Download batches: only  jobs
- Publish batches: all completed jobs (original behaviour)
- fflate streaming ZIP, 10 concurrent fetches,  for skips

### DECIDED FALLBACK
D7: PR #1219 doesn't exist on main — built fresh per D28 conventions.

### Tests
3 Slice E unit tests + 7 existing select route tests updated for new batch_id/destination fetches. 3088 total pass.