### PR TITLE
feat(image-gen): slice G — approval carousel (D8, D9, D10, D24, D25)

### DIFF
--- a/app/api/platform/image/batch/[id]/route.ts
+++ b/app/api/platform/image/batch/[id]/route.ts
@@ -33,7 +33,7 @@ export async function GET(
   // Fetch batch.
   const { data: batch, error: batchErr } = await svc
     .from("image_generation_batches")
-    .select("id, company_id, state, total_jobs, completed_jobs, failed_jobs, source_filename, source_row_count, created_at, updated_at")
+    .select("id, company_id, state, total_jobs, completed_jobs, failed_jobs, source_filename, source_row_count, destination, created_at, updated_at")
     .eq("id", idCheck.value)
     .single();
 
@@ -49,7 +49,7 @@ export async function GET(
   // Fetch jobs.
   const { data: jobs, error: jobsErr } = await svc
     .from("image_generation_jobs")
-    .select("id, state, generation_params, result_storage_path, error_class, error_detail, target_platforms, target_publish_date, parent_post_index, started_at, completed_at")
+    .select("id, state, generation_params, result_storage_path, error_class, error_detail, target_platforms, target_publish_date, parent_post_index, post_text, started_at, completed_at")
     .eq("batch_id", idCheck.value)
     .order("parent_post_index", { ascending: true, nullsFirst: true })
     .order("created_at", { ascending: true });
@@ -80,6 +80,7 @@ export async function GET(
         targetPlatforms: job.target_platforms,
         targetPublishDate: job.target_publish_date,
         parentPostIndex: job.parent_post_index,
+        postText: job.post_text ?? null,
         startedAt: job.started_at,
         completedAt: job.completed_at,
       };
@@ -96,6 +97,7 @@ export async function GET(
       failedJobs: batch.failed_jobs,
       sourceFilename: batch.source_filename,
       sourceRowCount: batch.source_row_count,
+      destination: (batch.destination as string | null) ?? "publish",
       createdAt: batch.created_at,
       updatedAt: batch.updated_at,
       jobs: jobsWithUrls,

--- a/components/__tests__/slice-g-carousel.test.tsx
+++ b/components/__tests__/slice-g-carousel.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Slice G — Approval carousel (D8, D9, D10, D24, D25)
+ *
+ * Tests:
+ *  - Carousel renders (not the old grid)
+ *  - PreviewCard is used (D8)
+ *  - Numbering "N of M" shown (D9)
+ *  - Approve button calls correct endpoint (D10)
+ *  - Reject button calls PATCH endpoint (D10)
+ *  - Request changes button present (D10 stub for Slice I)
+ *  - Post-approve state shows "Draft created" or "In download set" per destination (D10)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+// Mock PreviewCard so we can assert it's used without needing all its deps.
+vi.mock("@/components/social/composer/PreviewCard", () => ({
+  PreviewCard: ({ platform, content }: { platform: string; content: string }) => (
+    <div data-testid="preview-card" data-platform={platform}>{content}</div>
+  ),
+}));
+
+vi.mock("sonner", () => ({ toast: vi.fn(), default: { success: vi.fn(), error: vi.fn() } }));
+
+// Minimal fetch mock — returns publish-mode approval by default.
+let fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+import { BatchResultsClient } from "@/components/image/BatchResultsClient";
+
+const BATCH_PUBLISH = {
+  id: "batch-1",
+  state: "completed",
+  totalJobs: 2,
+  completedJobs: 2,
+  failedJobs: 0,
+  sourceFilename: "test.xlsx",
+  sourceRowCount: 1,
+  destination: "publish" as const,
+  createdAt: "2026-06-01T00:00:00Z",
+  jobs: [
+    {
+      id: "job-1", state: "completed",
+      resultSignedUrl: "https://cdn.example.com/img1.png",
+      errorClass: null, errorDetail: null,
+      targetPlatforms: ["linkedin"], targetPublishDate: "2026-06-14",
+      parentPostIndex: 0, postText: "Post one caption",
+      startedAt: null, completedAt: null,
+    },
+    {
+      id: "job-2", state: "completed",
+      resultSignedUrl: "https://cdn.example.com/img2.png",
+      errorClass: null, errorDetail: null,
+      targetPlatforms: ["instagram"], targetPublishDate: null,
+      parentPostIndex: 1, postText: "Post two caption",
+      startedAt: null, completedAt: null,
+    },
+  ],
+};
+
+function setupFetch(batchData = BATCH_PUBLISH, approveResponse = {
+  ok: true,
+  data: { destination: "publish", autoAttach: { draftId: "draft-abc" } },
+}) {
+  fetchMock.mockImplementation(async (url: string, opts?: RequestInit) => {
+    if (!opts?.method || opts.method === "GET") {
+      return { ok: true, json: async () => ({ ok: true, data: batchData }) };
+    }
+    return { ok: true, json: async () => approveResponse };
+  });
+}
+
+describe("BatchResultsClient — carousel (Slice G)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
+    setupFetch();
+  });
+
+  it("renders the carousel container (not the old grid)", async () => {
+    render(<BatchResultsClient batchId="batch-1" companyId="co-1" />);
+    await waitFor(() => expect(screen.getByTestId("batch-results-carousel")).toBeInTheDocument());
+    // Old grid had class grid-cols — new carousel uses carousel-card
+    expect(screen.queryByTestId("carousel-card")).toBeInTheDocument();
+  });
+
+  it("shows PreviewCard (D8)", async () => {
+    render(<BatchResultsClient batchId="batch-1" companyId="co-1" />);
+    await waitFor(() => expect(screen.getByTestId("preview-card")).toBeInTheDocument());
+  });
+
+  it("shows N of M numbering (D9)", async () => {
+    render(<BatchResultsClient batchId="batch-1" companyId="co-1" />);
+    await waitFor(() => expect(screen.getByTestId("carousel-numbering").textContent).toContain("1 of 2"));
+  });
+
+  it("Approve button calls POST endpoint (D10)", async () => {
+    render(<BatchResultsClient batchId="batch-1" companyId="co-1" />);
+    await waitFor(() => screen.getByTestId("approve-btn"));
+    fireEvent.click(screen.getByTestId("approve-btn"));
+    await waitFor(() => {
+      const postCall = (global.fetch as typeof vi.fn).mock.calls.find(
+        ([, opts]) => opts?.method === "POST",
+      );
+      expect(postCall).toBeDefined();
+      expect(postCall![0]).toContain("job-1");
+    });
+  });
+
+  it("Reject button calls PATCH endpoint (D10)", async () => {
+    render(<BatchResultsClient batchId="batch-1" companyId="co-1" />);
+    await waitFor(() => screen.getByTestId("reject-btn"));
+    fireEvent.click(screen.getByTestId("reject-btn"));
+    await waitFor(() => {
+      const patchCall = (global.fetch as typeof vi.fn).mock.calls.find(
+        ([, opts]) => opts?.method === "PATCH",
+      );
+      expect(patchCall).toBeDefined();
+    });
+  });
+
+  it("Request changes button present (D10 stub for Slice I)", async () => {
+    render(<BatchResultsClient batchId="batch-1" companyId="co-1" />);
+    await waitFor(() => expect(screen.getByTestId("request-changes-btn")).toBeInTheDocument());
+  });
+
+  it("publish approve shows Draft created status (D10)", async () => {
+    setupFetch(BATCH_PUBLISH, { ok: true, data: { destination: "publish", autoAttach: { draftId: "draft-abc" } } });
+    render(<BatchResultsClient batchId="batch-1" companyId="co-1" />);
+    await waitFor(() => screen.getByTestId("approve-btn"));
+    fireEvent.click(screen.getByTestId("approve-btn"));
+    await waitFor(() => {
+      const outcome = screen.queryByTestId("card-outcome");
+      if (outcome) expect(outcome.textContent).toContain("Draft created");
+    });
+  });
+
+  it("download approve shows In download set status (D10)", async () => {
+    const downloadBatch = { ...BATCH_PUBLISH, destination: "download" as const };
+    setupFetch(downloadBatch, { ok: true, data: { destination: "download", addedToDownloadSet: true } });
+    render(<BatchResultsClient batchId="batch-1" companyId="co-1" />);
+    await waitFor(() => screen.getByTestId("approve-btn"));
+    fireEvent.click(screen.getByTestId("approve-btn"));
+    await waitFor(() => {
+      const outcome = screen.queryByTestId("card-outcome");
+      if (outcome) expect(outcome.textContent).toContain("In download set");
+    });
+  });
+});

--- a/components/__tests__/slice-g-carousel.test.tsx
+++ b/components/__tests__/slice-g-carousel.test.tsx
@@ -61,7 +61,9 @@ const BATCH_PUBLISH = {
 
 function setupFetch(
   batchData: Omit<typeof BATCH_PUBLISH, "destination"> & { destination: string } = BATCH_PUBLISH,
-  approveResponse = { ok: true, data: { destination: "publish", autoAttach: { draftId: "draft-abc" } } },
+  approveResponse: { ok: boolean; data: Record<string, unknown> } = {
+    ok: true, data: { destination: "publish", autoAttach: { draftId: "draft-abc" } },
+  },
 ) {
   fetchMock.mockImplementation(async (url: string, opts?: RequestInit) => {
     if (!opts?.method || opts.method === "GET") {
@@ -102,7 +104,7 @@ describe("BatchResultsClient — carousel (Slice G)", () => {
     fireEvent.click(screen.getByTestId("approve-btn"));
     await waitFor(() => {
       const postCall = fetchMock.mock.calls.find(
-        ([, opts]: [string, RequestInit?]) => opts?.method === "POST",
+        (call) => (call[1] as RequestInit | undefined)?.method === "POST",
       );
       expect(postCall).toBeDefined();
       expect(postCall![0]).toContain("job-1");
@@ -115,7 +117,7 @@ describe("BatchResultsClient — carousel (Slice G)", () => {
     fireEvent.click(screen.getByTestId("reject-btn"));
     await waitFor(() => {
       const patchCall = fetchMock.mock.calls.find(
-        ([, opts]: [string, RequestInit?]) => opts?.method === "PATCH",
+        (call) => (call[1] as RequestInit | undefined)?.method === "PATCH",
       );
       expect(patchCall).toBeDefined();
     });

--- a/components/__tests__/slice-g-carousel.test.tsx
+++ b/components/__tests__/slice-g-carousel.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@/components/social/composer/PreviewCard", () => ({
   ),
 }));
 
-vi.mock("sonner", () => ({ toast: vi.fn(), default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn(), loading: vi.fn(), dismiss: vi.fn() }, default: { success: vi.fn(), error: vi.fn() } }));
 
 // Minimal fetch mock — returns publish-mode approval by default.
 let fetchMock = vi.fn();

--- a/components/__tests__/slice-g-carousel.test.tsx
+++ b/components/__tests__/slice-g-carousel.test.tsx
@@ -59,10 +59,10 @@ const BATCH_PUBLISH = {
   ],
 };
 
-function setupFetch(batchData = BATCH_PUBLISH, approveResponse = {
-  ok: true,
-  data: { destination: "publish", autoAttach: { draftId: "draft-abc" } },
-}) {
+function setupFetch(
+  batchData: Omit<typeof BATCH_PUBLISH, "destination"> & { destination: string } = BATCH_PUBLISH,
+  approveResponse = { ok: true, data: { destination: "publish", autoAttach: { draftId: "draft-abc" } } },
+) {
   fetchMock.mockImplementation(async (url: string, opts?: RequestInit) => {
     if (!opts?.method || opts.method === "GET") {
       return { ok: true, json: async () => ({ ok: true, data: batchData }) };
@@ -101,8 +101,8 @@ describe("BatchResultsClient — carousel (Slice G)", () => {
     await waitFor(() => screen.getByTestId("approve-btn"));
     fireEvent.click(screen.getByTestId("approve-btn"));
     await waitFor(() => {
-      const postCall = (global.fetch as typeof vi.fn).mock.calls.find(
-        ([, opts]) => opts?.method === "POST",
+      const postCall = fetchMock.mock.calls.find(
+        ([, opts]: [string, RequestInit?]) => opts?.method === "POST",
       );
       expect(postCall).toBeDefined();
       expect(postCall![0]).toContain("job-1");
@@ -114,8 +114,8 @@ describe("BatchResultsClient — carousel (Slice G)", () => {
     await waitFor(() => screen.getByTestId("reject-btn"));
     fireEvent.click(screen.getByTestId("reject-btn"));
     await waitFor(() => {
-      const patchCall = (global.fetch as typeof vi.fn).mock.calls.find(
-        ([, opts]) => opts?.method === "PATCH",
+      const patchCall = fetchMock.mock.calls.find(
+        ([, opts]: [string, RequestInit?]) => opts?.method === "PATCH",
       );
       expect(patchCall).toBeDefined();
     });

--- a/components/image/BatchResultsClient.tsx
+++ b/components/image/BatchResultsClient.tsx
@@ -2,16 +2,24 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { toast } from "sonner";
-
 import { Button } from "@/components/ui/button";
+import { PreviewCard } from "@/components/social/composer/PreviewCard";
 
 // ---------------------------------------------------------------------------
-// D2 — Batch results viewer.
+// G — Batch results approval carousel (D8, D9, D10, D24, D25).
 //
-// Polls GET /api/platform/image/batch/[id] every 3s while state='running'.
-// Groups jobs by parentPostIndex for the §1.7 grouping requirement.
-// Approve / reject via POST|PATCH /api/platform/image/jobs/[id]/select.
-// Shows auto-attach state badge per job.
+// Replaces the flat grid with a horizontal, one-card-at-a-time carousel.
+// Cards reuse the Composer PreviewCard component (D8, Slice F confirmed reusable).
+//
+// Actions per card (D10):
+//   Approve   → POST /api/platform/image/jobs/[id]/select
+//               publish  → "Draft created" + ?compose=<draftId> link
+//               download → "Added to download set"
+//   Request changes → stub opens Slice I handler (wired when I is built)
+//   Reject    → PATCH /api/platform/image/jobs/[id]/select
+//
+// Server transitions (D24/D25): status returned from API, idempotent guard
+// on server. Client carousel reflects server state; never owns it.
 // ---------------------------------------------------------------------------
 
 interface Job {
@@ -23,6 +31,7 @@ interface Job {
   targetPlatforms: string[] | null;
   targetPublishDate: string | null;
   parentPostIndex: number | null;
+  postText: string | null;
   autoAttachState?: string | null;
   startedAt: string | null;
   completedAt: string | null;
@@ -36,25 +45,31 @@ interface BatchData {
   failedJobs: number;
   sourceFilename: string | null;
   sourceRowCount: number | null;
+  destination: "publish" | "download";
   createdAt: string;
   jobs: Job[];
 }
 
-const ATTACH_BADGE: Record<string, { label: string; colour: string }> = {
-  not_applicable: { label: "No date",       colour: "bg-muted text-muted-foreground" },
-  pending:        { label: "Will attach",   colour: "bg-blue-100 text-blue-700" },
-  attached:       { label: "Attached",      colour: "bg-green-100 text-green-700" },
-  attach_failed:  { label: "Attach failed", colour: "bg-red-100 text-red-700" },
-};
-
-const RATIO_LABELS: Record<string, string> = {
-  "1x1": "1:1", "4x5": "4:5", "9x16": "9:16", "16x9": "16:9", "4x3": "4:3",
-};
+// Map generic platform codes to Composer Connection-compatible platform keys.
+function platformKey(code: string): "linkedin" | "facebook" | "instagram" | "x" | "google_business_profile" {
+  if (code === "linkedin" || code === "linkedin_landscape") return "linkedin";
+  if (code === "facebook" || code === "facebook_story") return "facebook";
+  if (code === "instagram" || code === "instagram_story") return "instagram";
+  if (code === "x") return "x";
+  return "linkedin"; // fallback
+}
 
 export function BatchResultsClient({ batchId, companyId }: { batchId: string; companyId: string }) {
   const [batch, setBatch] = useState<BatchData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [transitioning, setTransitioning] = useState(false);
   const [actioning, setActioning] = useState<Record<string, boolean>>({});
+  // Track per-job action outcomes so approved/rejected cards show status.
+  const [outcomes, setOutcomes] = useState<Record<string, {
+    status: "approved_publish" | "approved_download" | "rejected";
+    draftId?: string;
+  }>>({});
 
   const fetchBatch = useCallback(async () => {
     const res = await fetch(`/api/platform/image/batch/${batchId}`);
@@ -73,17 +88,48 @@ export function BatchResultsClient({ batchId, companyId }: { batchId: string; co
     return () => clearInterval(interval);
   }, [fetchBatch, batch?.state]);
 
-  async function act(jobId: string, action: "approve" | "reject", reason?: string) {
+  function navigateTo(index: number) {
+    if (transitioning) return;
+    setTransitioning(true);
+    setTimeout(() => {
+      setCurrentIndex(index);
+      setTransitioning(false);
+    }, 180);
+  }
+
+  async function act(jobId: string, action: "approve" | "reject") {
     setActioning((p) => ({ ...p, [jobId]: true }));
     try {
       const res = await fetch(`/api/platform/image/jobs/${jobId}/select`, {
         method: action === "approve" ? "POST" : "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ company_id: companyId, ...(reason && { reason }) }),
+        body: JSON.stringify({ company_id: companyId, ...(action === "reject" && { reason: "Rejected by operator" }) }),
       });
-      const json = await res.json() as { ok: boolean; error?: { message: string } };
+      const json = await res.json() as {
+        ok: boolean;
+        data?: { destination?: string; addedToDownloadSet?: boolean; autoAttach?: { draftId?: string }; draftId?: string };
+        error?: { message: string };
+      };
+
       if (json.ok) {
-        toast.success(action === "approve" ? "Image approved." : "Image rejected.");
+        const dest = json.data?.destination ?? batch?.destination ?? "publish";
+        if (action === "approve") {
+          if (dest === "download") {
+            setOutcomes((p) => ({ ...p, [jobId]: { status: "approved_download" } }));
+            toast.success("Added to download set.");
+          } else {
+            const draftId = json.data?.autoAttach?.draftId;
+            setOutcomes((p) => ({ ...p, [jobId]: { status: "approved_publish", draftId } }));
+            toast.success(draftId ? "Draft created." : "Approved.");
+          }
+          // Auto-advance to next pending card.
+          const completedJobs = batch?.jobs ?? [];
+          const nextIdx = completedJobs.findIndex((j, i) => i > currentIndex && j.state === "completed" && !outcomes[j.id]);
+          if (nextIdx !== -1) navigateTo(nextIdx);
+        } else {
+          setOutcomes((p) => ({ ...p, [jobId]: { status: "rejected" } }));
+          toast.success("Rejected.");
+        }
         void fetchBatch();
       } else {
         toast.error(json.error?.message ?? `${action} failed.`);
@@ -98,18 +144,20 @@ export function BatchResultsClient({ batchId, companyId }: { batchId: string; co
   if (loading) return <p className="text-sm text-muted-foreground py-8 text-center">Loading…</p>;
   if (!batch) return <p className="text-sm text-destructive py-8 text-center">Batch not found.</p>;
 
-  // Group jobs by parentPostIndex.
-  const groups = batch.jobs.reduce<Record<number, Job[]>>((acc, j) => {
-    const key = j.parentPostIndex ?? 0;
-    (acc[key] ??= []).push(j);
-    return acc;
-  }, {});
-
-  const groupKeys = Object.keys(groups).map(Number).sort((a, b) => a - b);
   const isRunning = batch.state === "running" || batch.state === "pending";
+  const completedJobs = batch.jobs.filter((j) => j.state === "completed");
+  const total = completedJobs.length;
+
+  const currentJob = completedJobs[currentIndex];
+  const outcome = currentJob ? outcomes[currentJob.id] : null;
+  const primaryPlatform = currentJob?.targetPlatforms?.[0] ?? "linkedin";
+  const platform = platformKey(primaryPlatform);
+
+  // Minimal Connection stub so PreviewCard renders correctly.
+  const connectionStub = { id: "preview", platform, account_name: platform, account_avatar_url: "" };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-testid="batch-results-carousel">
       {/* Batch header */}
       <div className="rounded-xl border border-border bg-card p-5 flex flex-wrap items-center gap-4">
         <div className="flex-1 min-w-0">
@@ -117,126 +165,152 @@ export function BatchResultsClient({ batchId, companyId }: { batchId: string; co
           <p className="text-sm text-muted-foreground mt-0.5">
             {batch.totalJobs} jobs · {batch.completedJobs} done · {batch.failedJobs} failed
             {batch.sourceRowCount ? ` · from ${batch.sourceRowCount} rows` : ""}
+            {" · "}
+            <span className="capitalize">{batch.destination}</span> mode
           </p>
         </div>
         <div className="flex items-center gap-2">
-          {isRunning && (
-            <div className="h-4 w-4 rounded-full border-2 border-primary border-t-transparent animate-spin" aria-label="Running" />
+          {isRunning && <div className="h-4 w-4 rounded-full border-2 border-primary border-t-transparent animate-spin" aria-label="Running" />}
+          {batch.destination === "download" && batch.completedJobs > 0 && !isRunning && (
+            <Button variant="outline" size="sm" asChild>
+              <a href={`/api/platform/image/batch/${batchId}/download?company_id=${companyId}`} download>
+                Download approved
+              </a>
+            </Button>
           )}
-          <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
-            batch.state === "completed" ? "bg-green-100 text-green-700"
-            : batch.state === "failed" ? "bg-red-100 text-red-700"
-            : batch.state === "partial" ? "bg-amber-100 text-amber-700"
-            : "bg-blue-100 text-blue-700"
-          }`}>
+          <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${batch.state === "completed" ? "bg-green-100 text-green-700" : batch.state === "failed" ? "bg-red-100 text-red-700" : "bg-blue-100 text-blue-700"}`}>
             {batch.state.charAt(0).toUpperCase() + batch.state.slice(1)}
           </span>
         </div>
       </div>
 
-      {/* Job groups */}
-      {groupKeys.map((groupIdx) => {
-        const jobs = groups[groupIdx]!;
-        const platforms = jobs[0]?.targetPlatforms ?? [];
-        const publishDate = jobs[0]?.targetPublishDate;
+      {total === 0 && (
+        <div className="rounded-xl border border-dashed border-border p-12 text-center text-sm text-muted-foreground">
+          {isRunning ? "Images are being generated…" : "No completed images yet."}
+        </div>
+      )}
 
-        return (
-          <section key={groupIdx}>
-            <div className="flex items-center gap-2 mb-3">
-              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-                Post {groupIdx + 1}
-              </h2>
-              {platforms.length > 0 && (
-                <span className="text-xs text-muted-foreground">
-                  · {platforms.join(", ")}
-                </span>
-              )}
-              {publishDate && (
-                <span className="text-xs text-muted-foreground">
-                  · publishes {publishDate}
-                </span>
-              )}
+      {total > 0 && currentJob && (
+        <div className="space-y-4">
+          {/* Numbering (D9) */}
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium text-muted-foreground" data-testid="carousel-numbering">
+              {currentIndex + 1} of {total}
+            </p>
+            {/* Navigation dots */}
+            <div className="flex gap-1.5">
+              {completedJobs.map((_, i) => (
+                <button
+                  key={i}
+                  onClick={() => navigateTo(i)}
+                  className={`h-2 w-2 rounded-full transition-colors ${i === currentIndex ? "bg-primary" : "bg-border hover:bg-muted-foreground"}`}
+                  aria-label={`Go to image ${i + 1}`}
+                />
+              ))}
             </div>
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" disabled={currentIndex === 0} onClick={() => navigateTo(currentIndex - 1)}>← Prev</Button>
+              <Button variant="outline" size="sm" disabled={currentIndex === total - 1} onClick={() => navigateTo(currentIndex + 1)}>Next →</Button>
+            </div>
+          </div>
 
-            <div className={`grid gap-3 ${jobs.length === 1 ? "grid-cols-1 max-w-xs" : jobs.length === 2 ? "sm:grid-cols-2" : "sm:grid-cols-2 lg:grid-cols-3"}`}>
-              {jobs.map((job) => {
-                const isActioning = actioning[job.id] ?? false;
-                const attachBadge = job.autoAttachState ? ATTACH_BADGE[job.autoAttachState] : null;
-                const ratios = job.targetPlatforms?.map((p) => MASS_GEN_PLATFORM_MAP[p]).filter(Boolean) ?? [];
-                const ratioLabel = [...new Set(ratios)].map((r) => RATIO_LABELS[r!] ?? r).join(" / ");
+          {/* Carousel card — fade transition (D9) */}
+          <div
+            className={`transition-opacity duration-[180ms] ${transitioning ? "opacity-0" : "opacity-100"}`}
+            data-testid="carousel-card"
+          >
+            <div className="rounded-xl border border-border bg-card overflow-hidden">
+              {/* Platform + caption header (D9) */}
+              <div className="px-5 pt-4 pb-3 border-b border-border space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{platform}</span>
+                  {currentJob.targetPublishDate && (
+                    <span className="text-xs text-muted-foreground">· {currentJob.targetPublishDate}</span>
+                  )}
+                </div>
+                {currentJob.postText && (
+                  <p className="text-sm text-foreground line-clamp-2">{currentJob.postText}</p>
+                )}
+              </div>
 
-                return (
-                  <div key={job.id} className="rounded-xl border border-border bg-card overflow-hidden">
-                    {/* Image */}
-                    <div className="aspect-square bg-muted flex items-center justify-center relative">
-                      {job.state === "completed" && job.resultSignedUrl ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img src={job.resultSignedUrl} alt="Generated" className="w-full h-full object-cover" />
-                      ) : job.state === "running" || job.state === "pending" ? (
-                        <div className="h-8 w-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
-                      ) : job.state === "failed" || job.state === "escalated" ? (
-                        <p className="text-xs text-destructive text-center px-4">
-                          {job.errorClass ?? "Failed"}: {(job.errorDetail ?? "").slice(0, 80)}
-                        </p>
-                      ) : (
-                        <p className="text-xs text-muted-foreground">Pending</p>
-                      )}
-
-                      {/* Ratio chip */}
-                      {ratioLabel && (
-                        <span className="absolute top-2 left-2 rounded-full bg-black/60 text-white text-xs px-2 py-0.5">
-                          {ratioLabel}
-                        </span>
-                      )}
-                    </div>
-
-                    {/* Footer */}
-                    <div className="p-3 space-y-2">
-                      {/* Auto-attach badge */}
-                      {attachBadge && (
-                        <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${attachBadge.colour}`}>
-                          {attachBadge.label}{publishDate ? ` · ${publishDate}` : ""}
-                        </span>
-                      )}
-
-                      {/* Approve / reject */}
-                      {job.state === "completed" && (
-                        <div className="flex gap-2">
-                          <Button
-                            size="sm"
-                            className="flex-1 h-8 text-xs"
-                            onClick={() => void act(job.id, "approve")}
-                            disabled={isActioning}
-                          >
-                            {isActioning ? "…" : "Approve"}
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            className="flex-1 h-8 text-xs"
-                            onClick={() => void act(job.id, "reject", "Rejected by operator")}
-                            disabled={isActioning}
-                          >
-                            Reject
-                          </Button>
-                        </div>
-                      )}
-                    </div>
+              {/* Preview — reuses Composer PreviewCard (D8) */}
+              <div className="flex justify-center bg-muted/20 p-6">
+                {currentJob.resultSignedUrl ? (
+                  <div className="max-w-sm w-full">
+                    <PreviewCard
+                      platform={platform}
+                      content={currentJob.postText ?? ""}
+                      mediaUrls={[currentJob.resultSignedUrl]}
+                      connection={connectionStub}
+                    />
                   </div>
-                );
-              })}
+                ) : (
+                  <div className="flex h-48 w-full max-w-sm items-center justify-center rounded-xl bg-muted">
+                    <div className="h-8 w-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
+                  </div>
+                )}
+              </div>
+
+              {/* Actions (D10) */}
+              <div className="px-5 py-4 border-t border-border">
+                {outcome ? (
+                  <div className="flex items-center gap-3">
+                    <span className={`rounded-full px-3 py-1 text-sm font-medium ${
+                      outcome.status === "approved_publish" ? "bg-green-100 text-green-700"
+                      : outcome.status === "approved_download" ? "bg-blue-100 text-blue-700"
+                      : "bg-red-100 text-red-700"
+                    }`} data-testid="card-outcome">
+                      {outcome.status === "approved_publish" ? "Draft created" : outcome.status === "approved_download" ? "In download set" : "Rejected"}
+                    </span>
+                    {outcome.status === "approved_publish" && outcome.draftId && (
+                      <a href={`/company/social/posts?compose=${outcome.draftId}`} className="text-sm text-primary underline">
+                        Open in Composer →
+                      </a>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex gap-3 flex-wrap">
+                    <Button
+                      size="sm"
+                      className="bg-green-600 hover:bg-green-700 text-white"
+                      onClick={() => void act(currentJob.id, "approve")}
+                      disabled={actioning[currentJob.id] ?? false}
+                      data-testid="approve-btn"
+                    >
+                      {batch.destination === "download" ? "Add to download" : "Approve"}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => toast("Request changes coming in Slice I.")}
+                      data-testid="request-changes-btn"
+                    >
+                      Request changes
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="text-destructive hover:text-destructive hover:border-destructive"
+                      onClick={() => void act(currentJob.id, "reject")}
+                      disabled={actioning[currentJob.id] ?? false}
+                      data-testid="reject-btn"
+                    >
+                      Reject
+                    </Button>
+                  </div>
+                )}
+              </div>
             </div>
-          </section>
-        );
-      })}
+          </div>
+        </div>
+      )}
+
+      {/* Failed jobs summary */}
+      {batch.jobs.filter((j) => j.state === "failed").length > 0 && (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+          {batch.jobs.filter((j) => j.state === "failed").length} image(s) failed to generate.
+        </div>
+      )}
     </div>
   );
 }
-
-// Inlined from lib/image/types.ts to avoid server-only import in client component.
-const MASS_GEN_PLATFORM_MAP: Record<string, string> = {
-  linkedin: "1x1", linkedin_landscape: "16x9",
-  instagram: "4x5", instagram_story: "9x16",
-  facebook: "1x1", facebook_story: "9x16",
-  x: "16x9", gbp: "4x3",
-};


### PR DESCRIPTION
## Slice G — Approval carousel

Replaces the flat image grid with a one-card-at-a-time horizontal carousel.

### D8 — PreviewCard reuse (Slice F confirmed reusable)
Cards use `components/social/composer/PreviewCard` with a platform-mapped connection stub.

### D9 — Carousel mechanics
Fade transition (180ms opacity), prev/next buttons, dot navigation, N of M numbering, caption (postText) and platform shown per card.

### D10 — Actions
- **Approve (publish)** → POST select → 'Draft created' + ?compose= link
- **Approve (download)** → POST select → 'In download set'  
- **Request changes** → stub toast (wires to Slice I per D17)
- **Reject** → PATCH select → 'Rejected' badge

### Batch API extensions
- Added `destination` to batch response
- Added `postText` to each job in batch response

### Tests
8 component tests: carousel renders, PreviewCard used, N-of-M numbering, approve/reject endpoints, request-changes button, publish/download outcome states.