### PR TITLE
feat(image-gen): slice H — safe-zone keep-clear injection (D11, D29, D30)

### DIFF
--- a/lib/__tests__/image-safe-zones.unit.test.ts
+++ b/lib/__tests__/image-safe-zones.unit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Slice H — Safe-zone keep-clear injection (D11, D29, D30)
+ *
+ * Tests:
+ *  - Safe-zone derivation from TextZone coordinates → GridRegion (D29)
+ *  - 3×3 grid mapping correct for all 9 cells (D29)
+ *  - Prompt fragment matches D30 exact format
+ *  - buildPrompt includes fragment when provided
+ *  - buildPrompt unchanged when no fragment (images without templates unaffected)
+ *  - buildSafeZoneFragment returns "" for empty regions (no constraint)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  coordToGridRegion,
+  textZonesToGridRegions,
+  buildSafeZoneFragment,
+  type GridRegion,
+} from "@/lib/image/generator/safe-zones";
+import { buildPrompt } from "@/lib/image/generator/prompt-engine";
+import type { TextZone } from "@/lib/image/compositing/text-zones";
+
+// ─── D29: 3×3 grid mapping ────────────────────────────────────────────────────
+
+describe("coordToGridRegion — D29 3×3 grid", () => {
+  // Each third of each axis maps to the correct label.
+  const cases: [number, number, GridRegion][] = [
+    [0.1, 0.1, "top-left"],
+    [0.5, 0.1, "top-center"],
+    [0.9, 0.1, "top-right"],
+    [0.1, 0.5, "mid-left"],
+    [0.5, 0.5, "center"],
+    [0.9, 0.5, "mid-right"],
+    [0.1, 0.9, "bottom-left"],
+    [0.5, 0.9, "bottom-center"],
+    [0.9, 0.9, "bottom-right"],
+  ];
+
+  it.each(cases)("coord (%s, %s) → '%s'", (x, y, expected) => {
+    expect(coordToGridRegion(x, y)).toBe(expected);
+  });
+
+  it("boundary at exactly 1/3 maps to center column", () => {
+    expect(coordToGridRegion(1 / 3, 0.5)).toBe("center");
+  });
+
+  it("boundary at exactly 2/3 maps to right column", () => {
+    expect(coordToGridRegion(2 / 3, 0.5)).toBe("mid-right");
+  });
+});
+
+// ─── textZonesToGridRegions ────────────────────────────────────────────────────
+
+describe("textZonesToGridRegions", () => {
+  it("converts TEXT_ZONE_MAP split_layout zone to the correct region", () => {
+    // split_layout: x:58, y:15, w:37, h:70 → center = (58+18.5)/100, (15+35)/100 = (0.765, 0.50)
+    // → right column, mid row → "mid-right"
+    const zone: TextZone = { x: 58, y: 15, width: 37, height: 70, alignment: "left" };
+    const regions = textZonesToGridRegions([zone]);
+    expect(regions).toEqual(["mid-right"]);
+  });
+
+  it("full_background zone: center near bottom → bottom-center", () => {
+    // full_background: x:5, y:68, w:90, h:24 → center = (5+45)/100, (68+12)/100 = (0.50, 0.80)
+    // → center column, bottom row → "bottom-center"
+    const zone: TextZone = { x: 5, y: 68, width: 90, height: 24, alignment: "center" };
+    const regions = textZonesToGridRegions([zone]);
+    expect(regions).toEqual(["bottom-center"]);
+  });
+
+  it("deduplicates regions from multiple zones in same cell", () => {
+    const zone1: TextZone = { x: 5, y: 5, width: 10, height: 10, alignment: "left" };
+    const zone2: TextZone = { x: 8, y: 8, width: 5, height: 5, alignment: "left" };
+    // Both centres in top-left cell
+    const regions = textZonesToGridRegions([zone1, zone2]);
+    expect(regions).toHaveLength(1);
+    expect(regions[0]).toBe("top-left");
+  });
+});
+
+// ─── D30: exact prompt fragment format ───────────────────────────────────────
+
+describe("buildSafeZoneFragment — D30 exact format", () => {
+  it("single region: exact D30 format", () => {
+    const result = buildSafeZoneFragment(["mid-right"]);
+    expect(result).toBe(
+      "Composition constraints: keep the mid-right area(s) visually simple and low-detail for overlaid text and logo. Do not place faces, hands, product hero elements, or fine details there."
+    );
+  });
+
+  it("multiple regions: comma-joined in the fragment", () => {
+    const result = buildSafeZoneFragment(["top-left", "bottom-center"]);
+    expect(result).toContain("top-left, bottom-center");
+    expect(result).toMatch(/^Composition constraints:/);
+  });
+
+  it("empty regions: returns empty string (no constraint injected)", () => {
+    expect(buildSafeZoneFragment([])).toBe("");
+  });
+});
+
+// ─── buildPrompt integration ──────────────────────────────────────────────────
+
+describe("buildPrompt — safe-zone fragment injection", () => {
+  const BASE = {
+    styleId: "clean_corporate" as const,
+    primaryColour: "#1a56db",
+    compositionType: "split_layout" as const,
+  };
+
+  it("includes the keep-clear fragment when provided", () => {
+    const fragment = buildSafeZoneFragment(["mid-right"]);
+    const prompt = buildPrompt({ ...BASE, keepClearFragment: fragment });
+    expect(prompt).toContain("Composition constraints:");
+    expect(prompt).toContain("mid-right");
+  });
+
+  it("prompt unchanged when keepClearFragment is absent (images without templates)", () => {
+    const withoutFragment = buildPrompt(BASE);
+    const withEmptyFragment = buildPrompt({ ...BASE, keepClearFragment: "" });
+    expect(withoutFragment).toBe(withEmptyFragment);
+    expect(withoutFragment).not.toContain("Composition constraints:");
+  });
+
+  it("fragment placed before negative suffix (no text, no words…)", () => {
+    const fragment = buildSafeZoneFragment(["bottom-center"]);
+    const prompt = buildPrompt({ ...BASE, keepClearFragment: fragment });
+    const fragmentIdx = prompt.indexOf("Composition constraints:");
+    const negativeIdx = prompt.indexOf("no text");
+    expect(fragmentIdx).toBeGreaterThan(-1);
+    expect(fragmentIdx).toBeLessThan(negativeIdx);
+  });
+});

--- a/lib/image/generator/ideogram.ts
+++ b/lib/image/generator/ideogram.ts
@@ -8,6 +8,8 @@ import { getServiceRoleClient } from "@/lib/supabase";
 import type { GeneratedImage, GenerationParams } from "../types";
 import { IdeogramError } from "../types";
 import { buildPrompt } from "./prompt-engine";
+import { textZonesToGridRegions, buildSafeZoneFragment } from "./safe-zones";
+import { TEXT_ZONE_MAP } from "@/lib/image/compositing/text-zones";
 
 const GLOBAL_NEGATIVE_PROMPT = [
   "text",
@@ -57,6 +59,12 @@ export async function generateBackground(
     throw new IdeogramError(0, "IDEOGRAM_API_KEY is not set");
   }
 
+  // D11/H: derive keep-clear regions from the text zone for this composition type.
+  const textZone = TEXT_ZONE_MAP[params.compositionType];
+  const keepClearFragment = textZone
+    ? buildSafeZoneFragment(textZonesToGridRegions([textZone]))
+    : "";
+
   const prompt = buildPrompt({
     styleId: params.styleId,
     primaryColour: params.primaryColour,
@@ -65,6 +73,7 @@ export async function generateBackground(
     mood: params.mood,
     safeMode: false, // safe_mode gates styles in routing.ts; prompt simplification is separate
     simplify: params.simplifyPrompt,
+    keepClearFragment,
   });
 
   const startMs = Date.now();

--- a/lib/image/generator/prompt-engine.ts
+++ b/lib/image/generator/prompt-engine.ts
@@ -11,6 +11,11 @@ interface PromptParams {
   mood?: string;
   safeMode?: boolean;
   simplify?: boolean; // retry pass — strip optional modifiers
+  /**
+   * D30 keep-clear composition fragment derived from text/logo layer positions
+   * (Slice H). Injected before the negative-prompt suffix when present.
+   */
+  keepClearFragment?: string;
 }
 
 export function buildPrompt(params: PromptParams): string {
@@ -31,7 +36,12 @@ export function buildPrompt(params: PromptParams): string {
   const moodMod = params.mood ? `${params.mood} mood, ` : "";
   const industryPart = industryCtx ? `, ${industryCtx}` : "";
 
-  return `${safeMod}${moodMod}${base}, ${composition}, ${colourDesc} colour accent${industryPart}, no text, no words, no letters, no typography`.trim();
+  // D30: append keep-clear fragment before the negative suffix when provided.
+  const keepClearSuffix = params.keepClearFragment
+    ? `. ${params.keepClearFragment}`
+    : "";
+
+  return `${safeMod}${moodMod}${base}, ${composition}, ${colourDesc} colour accent${industryPart}${keepClearSuffix}, no text, no words, no letters, no typography`.trim();
 }
 
 function hexToColourDescription(hex: string): string {

--- a/lib/image/generator/safe-zones.ts
+++ b/lib/image/generator/safe-zones.ts
@@ -1,0 +1,72 @@
+/**
+ * safe-zones.ts — Derive keep-clear regions and build D30 prompt fragments.
+ *
+ * D11: Derive keep-clear rects from text/logo layer positions, normalised 0–1.
+ * D29: Map coordinates to a fixed 3×3 grid (GridRegion).
+ * D30: Build the exact composition-constraints prompt fragment.
+ *
+ * Used by buildPrompt (PRIMARY path) and available for Slice I feedback pins
+ * (same grid, same builder).
+ */
+
+import type { TextZone } from "@/lib/image/compositing/text-zones";
+
+// ─── D29: 3×3 grid ───────────────────────────────────────────────────────────
+
+export type GridRegion =
+  | "top-left"    | "top-center"    | "top-right"
+  | "mid-left"    | "center"        | "mid-right"
+  | "bottom-left" | "bottom-center" | "bottom-right";
+
+/**
+ * Map normalised coordinates (0–1) to the 3×3 GridRegion they fall in.
+ * The grid divides the image into equal thirds on each axis.
+ */
+export function coordToGridRegion(xNorm: number, yNorm: number): GridRegion {
+  const col = xNorm < 1 / 3 ? "left" : xNorm < 2 / 3 ? "center" : "right";
+  const row = yNorm < 1 / 3 ? "top" : yNorm < 2 / 3 ? "mid" : "bottom";
+
+  if (row === "top") {
+    return col === "left" ? "top-left" : col === "center" ? "top-center" : "top-right";
+  }
+  if (row === "mid") {
+    return col === "left" ? "mid-left" : col === "center" ? "center" : "mid-right";
+  }
+  return col === "left" ? "bottom-left" : col === "center" ? "bottom-center" : "bottom-right";
+}
+
+/**
+ * Convert TextZone coordinates (0–100 percentages) to GridRegions via the
+ * zone's centre point.
+ */
+export function textZonesToGridRegions(zones: TextZone[]): GridRegion[] {
+  const seen = new Set<GridRegion>();
+  const out: GridRegion[] = [];
+  for (const zone of zones) {
+    const cx = (zone.x + zone.width / 2) / 100;
+    const cy = (zone.y + zone.height / 2) / 100;
+    const region = coordToGridRegion(cx, cy);
+    if (!seen.has(region)) {
+      seen.add(region);
+      out.push(region);
+    }
+  }
+  return out;
+}
+
+// ─── D30: prompt fragment ─────────────────────────────────────────────────────
+
+/**
+ * Build the exact D30 keep-clear composition hint.
+ * Returns empty string when regions is empty (no constraint added).
+ *
+ * Exact format (authoritative per brief §1.1 D30):
+ *   "Composition constraints: keep the {regions} area(s) visually simple and
+ *    low-detail for overlaid text and logo. Do not place faces, hands, product
+ *    hero elements, or fine details there."
+ */
+export function buildSafeZoneFragment(regions: GridRegion[]): string {
+  if (regions.length === 0) return "";
+  const label = regions.join(", ");
+  return `Composition constraints: keep the ${label} area(s) visually simple and low-detail for overlaid text and logo. Do not place faces, hands, product hero elements, or fine details there.`;
+}


### PR DESCRIPTION
## Slice H — Safe-zone keep-clear injection

**PRIMARY path — no migration (D12).**

### Investigation
`TEXT_ZONE_MAP` in `lib/image/compositing/text-zones.ts` already provides text zone positions (0–100% percentages) for each `CompositionType`. These are the correct source for keep-clear derivation — no layer positions from the template model needed for the Ideogram path.

### Changes

**`lib/image/generator/safe-zones.ts` (new):**
- `coordToGridRegion(x, y)` — maps 0–1 normalised coords to D29 3×3 GridRegion
- `textZonesToGridRegions(zones[])` — converts TEXT_ZONE_MAP zones to GridRegions via centre-point
- `buildSafeZoneFragment(regions[])` — D30 exact format, or '' if no regions

**`prompt-engine.ts`:** Extended `PromptParams` with `keepClearFragment?: string`. Injected before the negative suffix when present. Empty = no change (backwards-compat).

**`ideogram.ts`:** `generateBackground` now derives fragment from `TEXT_ZONE_MAP[compositionType]` and passes to `buildPrompt`. All new Ideogram generations include composition-aware keep-clear guidance.

### Reuse for Slice I
Same `coordToGridRegion` + `buildSafeZoneFragment` used for feedback pin hints in Slice I.

### DECIDED FALLBACK
No fallback needed — TEXT_ZONE_MAP positions were available.

### Tests
20 unit tests: all 9 grid cells, zone→region conversion, D30 exact format, buildPrompt integration, empty-region no-op.