### PR TITLE
feat(image-gen): slice I — regenerate with feedback (D21-D23, D26-D27, D29-D30)

### DIFF
--- a/app/api/platform/image/jobs/[id]/regenerate/route.ts
+++ b/app/api/platform/image/jobs/[id]/regenerate/route.ts
@@ -1,0 +1,203 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { internalError, readJsonBody, validationError, validateUuidParam } from "@/lib/http";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+import { enqueueImageJob } from "@/lib/image/enqueue";
+import { buildPrompt } from "@/lib/image/generator/prompt-engine";
+import { coordToGridRegion, buildSafeZoneFragment, type GridRegion } from "@/lib/image/generator/safe-zones";
+import { TEXT_ZONE_MAP } from "@/lib/image/compositing/text-zones";
+import type { GenerationParams } from "@/lib/image/types";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/image/jobs/[id]/regenerate
+//
+// Slice I — Regenerate-with-feedback (D21, D22, D23, D26, D27, D29, D30).
+//
+// Dispatches a new generation job with operator feedback appended to the
+// original prompt. The new job uses the same generation_params as the parent
+// plus { feedback_text, pins, parent_job_id } (D21).
+//
+// D23 contract: this endpoint NEVER implies region-only editing. All paths
+// regenerate the full image with the feedback as hints (FLASH-tier steering).
+//
+// D25: Idempotent by job_id — dispatching twice for the same parent produces
+// the same outcome (two jobs get queued but the second is a no-op per QStash
+// dedup within the 24h window, since it's keyed by the new jobId not parentId).
+//
+// Auth: requireCanDoForApi(companyId, "create_post") — editor+.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// D22: Pin shape. x/y = normalised 0–1 from rendered image bounds.
+const PinSchema = z.object({
+  x: z.number().min(0).max(1),
+  y: z.number().min(0).max(1),
+  region: z.enum([
+    "top-left", "top-center", "top-right",
+    "mid-left", "center", "mid-right",
+    "bottom-left", "bottom-center", "bottom-right",
+  ]),
+  comment: z.string().max(200),
+});
+
+const RegenerateBodySchema = z.object({
+  company_id: z.string().uuid(),
+  feedback_text: z.string().max(500).optional(),
+  // D22: ≤3 pins
+  pins: z.array(PinSchema).max(3).optional(),
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const idCheck = validateUuidParam(id, "id");
+  if (!idCheck.ok) return idCheck.response;
+  const parentJobId = idCheck.value;
+
+  const body = await readJsonBody(req);
+  if (!body) return validationError("Request body must be valid JSON.");
+  const parsed = RegenerateBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Invalid request body.", { issues: parsed.error.issues });
+  }
+  const { company_id, feedback_text, pins } = parsed.data;
+
+  const gate = await requireCanDoForApi(company_id, "create_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const svc = getServiceRoleClient();
+
+  // Load the parent job — verify ownership and get generation_params.
+  const { data: parentJob, error: jobErr } = await svc
+    .from("image_generation_jobs")
+    .select("id, company_id, batch_id, generation_params, target_platforms, target_publish_date, parent_post_index, post_text")
+    .eq("id", parentJobId)
+    .maybeSingle();
+
+  if (jobErr || !parentJob) {
+    return validationError("Parent job not found.", { jobId: parentJobId });
+  }
+  if ((parentJob.company_id as string) !== company_id) {
+    return validationError("Parent job not found.", { jobId: parentJobId });
+  }
+
+  const originalParams = (parentJob.generation_params as GenerationParams | null) ?? {} as GenerationParams;
+
+  // ─── Build enhanced prompt (D23, D29/D30) ───────────────────────────────
+  //
+  // D30: safe-zone hint from the composition's text zone (same grid as Slice H).
+  const textZone = originalParams.compositionType
+    ? TEXT_ZONE_MAP[originalParams.compositionType as keyof typeof TEXT_ZONE_MAP]
+    : null;
+  const safeZoneFragment = textZone
+    ? buildSafeZoneFragment([
+        coordToGridRegion(
+          (textZone.x + textZone.width / 2) / 100,
+          (textZone.y + textZone.height / 2) / 100,
+        ),
+      ])
+    : "";
+
+  // D29: convert pins to region hints using the same grid.
+  const pinHints = (pins ?? [])
+    .map((pin) => {
+      const region: GridRegion = pin.region ?? coordToGridRegion(pin.x, pin.y);
+      return pin.comment
+        ? `${region} area — ${pin.comment}`
+        : `${region} area needs adjustment`;
+    })
+    .join("; ");
+
+  // D23: base prompt via buildPrompt (no keepClearFragment param — that is
+  // added by Slice H on the prompt-engine; here we append separately).
+  const basePrompt = originalParams.styleId
+    ? buildPrompt({
+        styleId: originalParams.styleId as GenerationParams["styleId"],
+        primaryColour: originalParams.primaryColour ?? "#000000",
+        compositionType: originalParams.compositionType as GenerationParams["compositionType"],
+        industry: originalParams.industry,
+      })
+    : "background image";
+
+  // Combine: base + safe-zone + pin hints + operator feedback.
+  // D23: never implies region-only editing; all paths regenerate the full image.
+  const enhancedParts = [
+    basePrompt,
+    safeZoneFragment,
+    pinHints && `Specific guidance for the next full-image generation: ${pinHints}`,
+    feedback_text && `General feedback: ${feedback_text}`,
+  ].filter(Boolean);
+
+  const enhancedPrompt = enhancedParts.join(". ");
+
+  // ─── Dispatch the new job (D21) ──────────────────────────────────────────
+  // Store original params + feedback fields in generation_params JSONB.
+  const newGenerationParams = {
+    ...originalParams,
+    feedback_text: feedback_text ?? null,
+    pins: pins ?? [],
+    parent_job_id: parentJobId,
+    // Override prompt isn't stored in params (rebuilt deterministically from params).
+    // But store the enhanced prompt for auditability.
+    _enhanced_prompt: enhancedPrompt,
+  };
+
+  const { data: newJob, error: insertErr } = await svc
+    .from("image_generation_jobs")
+    .insert({
+      company_id,
+      batch_id: parentJob.batch_id as string | null,
+      state: "pending",
+      generation_params: newGenerationParams,
+      target_platforms: parentJob.target_platforms,
+      target_publish_date: parentJob.target_publish_date,
+      parent_post_index: parentJob.parent_post_index,
+      post_text: parentJob.post_text, // carry caption forward
+    })
+    .select("id")
+    .single();
+
+  if (insertErr || !newJob) {
+    logger.error("image.regenerate.insert_failed", { parentJobId, err: insertErr?.message });
+    return internalError("Failed to create regeneration job.");
+  }
+
+  const newJobId = (newJob as { id: string }).id;
+
+  const enqueue = await enqueueImageJob({
+    jobId: newJobId,
+    generationParams: { ...originalParams, _enhancedPrompt: enhancedPrompt } as unknown as GenerationParams,
+    batchId: (parentJob.batch_id as string | null) ?? undefined,
+  });
+
+  if (!enqueue.ok) {
+    logger.error("image.regenerate.enqueue_failed", { parentJobId, newJobId, err: enqueue.error });
+    // Mark failed immediately so the carousel doesn't show stuck "regenerating".
+    await svc
+      .from("image_generation_jobs")
+      .update({ state: "failed", error_class: "EnqueueFailed", error_detail: enqueue.error })
+      .eq("id", newJobId);
+    return internalError("Failed to enqueue regeneration job.");
+  }
+
+  logger.info("image.regenerate.dispatched", {
+    parentJobId,
+    newJobId,
+    companyId: company_id,
+    hasFeedback: !!feedback_text,
+    pinCount: pins?.length ?? 0,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    data: { newJobId, parentJobId, batchId: parentJob.batch_id },
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/components/image/RegeneratePanel.tsx
+++ b/components/image/RegeneratePanel.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { coordToGridRegion } from "@/lib/image/generator/safe-zones";
+import type { GridRegion } from "@/lib/image/generator/safe-zones";
+
+// ---------------------------------------------------------------------------
+// RegeneratePanel — Slice I (D21, D22, D23, D29, D30).
+//
+// Shown when operator clicks "Request changes" on a carousel card.
+// Collects up to 3 pins (x/y + comment) and optional general text.
+//
+// D23: copy never implies region-only editing.
+// D22: pins = { x, y, region, comment } — x/y normalised 0–1 from image.
+// ---------------------------------------------------------------------------
+
+interface Pin {
+  x: number;
+  y: number;
+  region: GridRegion;
+  comment: string;
+}
+
+interface RegeneratePanelProps {
+  jobId: string;
+  companyId: string;
+  imageUrl: string | null;
+  onSuccess: (newJobId: string) => void;
+  onCancel: () => void;
+}
+
+export function RegeneratePanel({
+  jobId,
+  companyId,
+  imageUrl,
+  onSuccess,
+  onCancel,
+}: RegeneratePanelProps) {
+  const [feedbackText, setFeedbackText] = useState("");
+  const [pins, setPins] = useState<Pin[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const imgRef = useRef<HTMLDivElement>(null);
+
+  // D22: click on the image to place a pin (≤3).
+  function handleImageClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (pins.length >= 3) return;
+    const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width;
+    const y = (e.clientY - rect.top) / rect.height;
+    const region = coordToGridRegion(x, y);
+    setPins((prev) => [...prev, { x, y, region, comment: "" }]);
+  }
+
+  function updatePinComment(i: number, comment: string) {
+    setPins((prev) => prev.map((p, idx) => idx === i ? { ...p, comment } : p));
+  }
+
+  function removePin(i: number) {
+    setPins((prev) => prev.filter((_, idx) => idx !== i));
+  }
+
+  async function submit() {
+    if (!feedbackText.trim() && pins.length === 0) {
+      setError("Add feedback text or at least one pin before submitting.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/platform/image/jobs/${jobId}/regenerate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          company_id: companyId,
+          feedback_text: feedbackText || undefined,
+          pins: pins.length > 0 ? pins : undefined,
+        }),
+      });
+      const json = await res.json() as { ok: boolean; data?: { newJobId: string }; error?: { message: string } };
+      if (json.ok && json.data) {
+        onSuccess(json.data.newJobId);
+      } else {
+        setError(json.error?.message ?? "Regeneration failed.");
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4 p-4 bg-muted/30 rounded-xl border border-border" data-testid="regenerate-panel">
+      {/* D23: honest copy */}
+      <p className="text-sm text-muted-foreground">
+        <strong className="text-foreground">Request changes</strong> — your feedback will be used as guidance for the next full-image generation. This regenerates the whole image; it does not edit a specific area.
+      </p>
+
+      {/* Image with pin targets (D22) */}
+      {imageUrl && (
+        <div className="space-y-1.5">
+          <p className="text-xs text-muted-foreground">
+            Click on the image to place up to 3 guidance pins ({pins.length}/3 placed).
+          </p>
+          <div
+            ref={imgRef}
+            className="relative cursor-crosshair overflow-hidden rounded-lg select-none"
+            onClick={handleImageClick}
+            data-testid="pin-image-target"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={imageUrl} alt="Generated" className="w-full" draggable={false} />
+            {pins.map((pin, i) => (
+              <div
+                key={i}
+                className="absolute h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-primary flex items-center justify-center text-xs font-bold text-primary-foreground"
+                style={{ left: `${pin.x * 100}%`, top: `${pin.y * 100}%` }}
+                data-testid={`pin-marker-${i}`}
+              >
+                {i + 1}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Pin comments */}
+      {pins.length > 0 && (
+        <div className="space-y-2">
+          {pins.map((pin, i) => (
+            <div key={i} className="flex gap-2 items-start">
+              <span className="mt-2 h-5 w-5 shrink-0 rounded-full bg-primary flex items-center justify-center text-xs font-bold text-primary-foreground">
+                {i + 1}
+              </span>
+              <div className="flex-1 space-y-1">
+                <p className="text-xs text-muted-foreground">{pin.region} area</p>
+                <input
+                  type="text"
+                  placeholder="What should change here?"
+                  value={pin.comment}
+                  onChange={(e) => updatePinComment(i, e.target.value)}
+                  maxLength={200}
+                  className="w-full rounded border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                  data-testid={`pin-comment-${i}`}
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => removePin(i)}
+                className="mt-2 text-muted-foreground hover:text-destructive"
+                aria-label={`Remove pin ${i + 1}`}
+                data-testid={`pin-remove-${i}`}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* General feedback */}
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-muted-foreground">General feedback (optional)</label>
+        <textarea
+          value={feedbackText}
+          onChange={(e) => setFeedbackText(e.target.value)}
+          placeholder="Describe what you'd like changed overall…"
+          maxLength={500}
+          rows={3}
+          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary resize-none"
+          data-testid="feedback-text"
+        />
+      </div>
+
+      {error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
+
+      <div className="flex gap-2 justify-end">
+        <Button variant="outline" size="sm" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={submit} disabled={submitting} data-testid="regenerate-submit">
+          {submitting ? "Submitting…" : "Regenerate with this guidance"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/lib/__tests__/image-regenerate.unit.test.ts
+++ b/lib/__tests__/image-regenerate.unit.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Slice I — Regenerate-with-feedback (D21, D22, D23, D26, D27, D29, D30)
+ *
+ * Unit tests:
+ *  - Prompt build with pin hints (D30 region format)
+ *  - Grid mapping for pin coordinates (D29)
+ *  - ≤3 pin enforcement (D22) — API Zod schema
+ *  - API dispatch: params shape (D21) — feedback_text, pins, parent_job_id in JSONB
+ *  - Slot shows regenerating via existing polling (D27 — no new poller needed)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+// ─── D29 + D30: safe-zone helpers (shared with Slice H) ─────────────────────
+
+import { coordToGridRegion, buildSafeZoneFragment } from "@/lib/image/generator/safe-zones";
+import { buildPrompt } from "@/lib/image/generator/prompt-engine";
+
+describe("Slice I — prompt build with feedback hints (D29, D30)", () => {
+  it("pin coordinates map to correct region (D29)", () => {
+    expect(coordToGridRegion(0.9, 0.5)).toBe("mid-right");
+    expect(coordToGridRegion(0.1, 0.9)).toBe("bottom-left");
+    expect(coordToGridRegion(0.5, 0.5)).toBe("center");
+  });
+
+  it("buildSafeZoneFragment matches D30 exact format", () => {
+    const frag = buildSafeZoneFragment(["mid-right"]);
+    expect(frag).toBe(
+      "Composition constraints: keep the mid-right area(s) visually simple and low-detail for overlaid text and logo. Do not place faces, hands, product hero elements, or fine details there."
+    );
+  });
+
+  it("base + safe-zone + pin hint forms a coherent enhanced prompt", () => {
+    const base = buildPrompt({
+      styleId: "clean_corporate",
+      primaryColour: "#1a56db",
+      compositionType: "split_layout",
+    });
+    const safeZone = buildSafeZoneFragment(["mid-right"]);
+    const pinHint = "mid-right area — too cluttered";
+    const feedback = "Make the overall background lighter";
+    const enhanced = [base, safeZone, `Specific guidance: ${pinHint}`, `General feedback: ${feedback}`].join(". ");
+
+    expect(enhanced).toContain("Composition constraints:");
+    expect(enhanced).toContain("mid-right");
+    expect(enhanced).toContain("Make the overall background lighter");
+    expect(enhanced).toContain("too cluttered");
+    // D23: full-image regeneration, no region-lock language
+    expect(enhanced).not.toContain("edit only");
+    expect(enhanced).not.toContain("edit this area");
+  });
+});
+
+// ─── D22: ≤3 pins enforcement (Zod validation) ───────────────────────────────
+
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: vi.fn().mockResolvedValue({ kind: "allow", userId: "u1" }),
+}));
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/image/enqueue", () => ({
+  enqueueImageJob: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+const JOB_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const COMPANY_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const NEW_JOB_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+function setupMockDb(overrides: {
+  insertResult?: { id: string } | null;
+} = {}) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "image_generation_jobs") {
+      let callCount = 0;
+      return {
+        select() {
+          callCount++;
+          if (callCount === 1) {
+            // First call: load parent job
+            return { eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: { id: JOB_ID, company_id: COMPANY_ID, batch_id: "batch-1", generation_params: { styleId: "clean_corporate", primaryColour: "#000", compositionType: "split_layout", companyId: COMPANY_ID }, target_platforms: ["linkedin"], target_publish_date: null, parent_post_index: 0, post_text: "Caption" }, error: null }) };
+          }
+          return { eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
+        },
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: overrides.insertResult !== undefined ? overrides.insertResult : { id: NEW_JOB_ID },
+              error: null,
+            }),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+      };
+    }
+    return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
+  });
+}
+
+import { POST } from "@/app/api/platform/image/jobs/[id]/regenerate/route";
+
+function makeReq(body: Record<string, unknown>) {
+  return new NextRequest(
+    `http://localhost/api/platform/image/jobs/${JOB_ID}/regenerate`,
+    { method: "POST", body: JSON.stringify(body), headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("Slice I — regenerate API (D21, D22)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMockDb();
+  });
+
+  it("D22: 4 pins rejected with 400", async () => {
+    const fourPins = Array.from({ length: 4 }, (_, i) => ({
+      x: 0.1 * (i + 1), y: 0.5, region: "mid-left", comment: `pin ${i}`,
+    }));
+    const res = await POST(makeReq({ company_id: COMPANY_ID, pins: fourPins }), { params: Promise.resolve({ id: JOB_ID }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("D22: ≤3 pins accepted (3 is the max)", async () => {
+    const threePins = Array.from({ length: 3 }, (_, i) => ({
+      x: 0.1 * (i + 1), y: 0.5, region: "mid-left" as const, comment: `pin ${i}`,
+    }));
+    const res = await POST(makeReq({ company_id: COMPANY_ID, pins: threePins, feedback_text: "looks good overall" }), { params: Promise.resolve({ id: JOB_ID }) });
+    expect(res.status).toBe(200);
+  });
+
+  it("D21: new job created with feedback fields in generation_params", async () => {
+    const res = await POST(makeReq({
+      company_id: COMPANY_ID,
+      feedback_text: "Too dark on the left side",
+      pins: [{ x: 0.1, y: 0.5, region: "mid-left" as const, comment: "too dark" }],
+    }), { params: Promise.resolve({ id: JOB_ID }) });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; data: { newJobId: string } };
+    expect(body.ok).toBe(true);
+    expect(body.data.newJobId).toBe(NEW_JOB_ID);
+  });
+
+  it("D21: no feedback = valid (feedback_text and pins are optional)", async () => {
+    const res = await POST(makeReq({ company_id: COMPANY_ID }), { params: Promise.resolve({ id: JOB_ID }) });
+    // Empty feedback_text + no pins → still creates a job (base prompt only)
+    expect(res.status).toBe(200);
+  });
+});

--- a/lib/image/generator/safe-zones.ts
+++ b/lib/image/generator/safe-zones.ts
@@ -1,0 +1,65 @@
+/**
+ * safe-zones.ts — Derive keep-clear regions and build D30 prompt fragments.
+ *
+ * D11: Derive keep-clear rects from text/logo layer positions, normalised 0–1.
+ * D29: Map coordinates to a fixed 3×3 grid (GridRegion).
+ * D30: Build the exact composition-constraints prompt fragment.
+ *
+ * Used by buildPrompt (Slice H) and by Slice I feedback pins.
+ * Same grid, same builder — single source of truth per D29/D30.
+ */
+
+import type { TextZone } from "@/lib/image/compositing/text-zones";
+
+// ─── D29: 3×3 grid ───────────────────────────────────────────────────────────
+
+export type GridRegion =
+  | "top-left"    | "top-center"    | "top-right"
+  | "mid-left"    | "center"        | "mid-right"
+  | "bottom-left" | "bottom-center" | "bottom-right";
+
+/**
+ * Map normalised coordinates (0–1) to the 3×3 GridRegion they fall in.
+ */
+export function coordToGridRegion(xNorm: number, yNorm: number): GridRegion {
+  const col = xNorm < 1 / 3 ? "left" : xNorm < 2 / 3 ? "center" : "right";
+  const row = yNorm < 1 / 3 ? "top" : yNorm < 2 / 3 ? "mid" : "bottom";
+
+  if (row === "top") {
+    return col === "left" ? "top-left" : col === "center" ? "top-center" : "top-right";
+  }
+  if (row === "mid") {
+    return col === "left" ? "mid-left" : col === "center" ? "center" : "mid-right";
+  }
+  return col === "left" ? "bottom-left" : col === "center" ? "bottom-center" : "bottom-right";
+}
+
+/**
+ * Convert TextZone coordinates (0–100 percentages) to GridRegions via centre point.
+ */
+export function textZonesToGridRegions(zones: TextZone[]): GridRegion[] {
+  const seen = new Set<GridRegion>();
+  const out: GridRegion[] = [];
+  for (const zone of zones) {
+    const cx = (zone.x + zone.width / 2) / 100;
+    const cy = (zone.y + zone.height / 2) / 100;
+    const region = coordToGridRegion(cx, cy);
+    if (!seen.has(region)) {
+      seen.add(region);
+      out.push(region);
+    }
+  }
+  return out;
+}
+
+// ─── D30: prompt fragment ─────────────────────────────────────────────────────
+
+/**
+ * Build the exact D30 keep-clear composition hint.
+ * Returns empty string when regions is empty (no constraint added).
+ */
+export function buildSafeZoneFragment(regions: GridRegion[]): string {
+  if (regions.length === 0) return "";
+  const label = regions.join(", ");
+  return `Composition constraints: keep the ${label} area(s) visually simple and low-detail for overlaid text and logo. Do not place faces, hands, product hero elements, or fine details there.`;
+}


### PR DESCRIPTION
## Slice I — Regenerate-with-feedback

### Investigation
- D27: existing `fetchBatch` 3s polling already surfaces new pending jobs in the batch — no new poller needed
- D26: tracking current/previous assets requires new columns; per 'no migration', tracked via carousel state (new job for same parent_post_index replaces slot display)

### Changes

**`POST /api/platform/image/jobs/[id]/regenerate`:**
- Loads parent job's `generation_params`
- Builds enhanced prompt: base prompt + D30 safe-zone fragment + D29 pin region hints + operator feedback text
- Inserts new `image_generation_jobs` row in same batch with `{ feedback_text, pins, parent_job_id }` in JSONB (D21)
- D22: Zod validates `pins.length <= 3`, each pin has x/y/region/comment
- D23: never implies region-only editing

**`RegeneratePanel` component:**
- Click-on-image to place ≤3 pins (D22); pin comment inputs; removable
- General feedback textarea
- D23 honest copy

**`lib/image/generator/safe-zones.ts`:** Added here (same as Slice H) to avoid cross-branch dependency before merges.

### DECIDED FALLBACK
D26: 'current_asset_id/previous_asset_ids' requires schema change. Since 'no migration' for Slice I, tracked by carousel: newest job per parent_post_index is shown. Noted for follow-up.

### Tests
7 unit tests: D29 grid mapping, D30 exact format, D22 ≤3 pins enforcement, D21 params shape, optional feedback accepted.