### PR TITLE
feat(workflow): gate config library + CRUD routes (Phase 1 Step 2)

### DIFF
--- a/app/api/platform/companies/[id]/workflow-gates/route.ts
+++ b/app/api/platform/companies/[id]/workflow-gates/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { internalError, parseBodyWith, readJsonBody, validateUuidParam, validationError } from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getGates, upsertGates, type UpsertGateInput } from "@/lib/platform/workflow";
+
+// ---------------------------------------------------------------------------
+// GET  /api/platform/companies/[id]/workflow-gates
+// PUT  /api/platform/companies/[id]/workflow-gates
+//
+// Manage the three workflow gate configs for a company.
+// Gate: manage_users (admin role) — mirrors the settings surface that owns gates.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const GATE_TYPES = ["copy_review", "image_review", "final_signoff"] as const;
+const PASS_RULES = ["all_must", "any_one"] as const;
+
+const ApproverSchema = z.object({
+  platformUserId: z.string().uuid().optional(),
+  externalEmail: z.string().email().optional(),
+}).refine(
+  (v) => v.platformUserId !== undefined || v.externalEmail !== undefined,
+  { message: "Each approver must have either platformUserId or externalEmail." },
+);
+
+const GateInputSchema = z.object({
+  gateType: z.enum(GATE_TYPES),
+  enabled: z.boolean(),
+  passRule: z.enum(PASS_RULES),
+  timeoutDays: z.number().int().min(1).max(365),
+  autoSchedule: z.boolean(),
+  approvers: z.array(ApproverSchema).max(50),
+});
+
+const PutBodySchema = z
+  .array(GateInputSchema)
+  .min(1)
+  .max(3)
+  .refine(
+    (gates) => {
+      const types = gates.map((g) => g.gateType);
+      return new Set(types).size === types.length;
+    },
+    { message: "Each gate_type may appear at most once." },
+  );
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  const uuidResult = validateUuidParam(id, "id");
+  if (!uuidResult.ok) return uuidResult.response;
+  const companyId = uuidResult.value;
+
+  const gate = await requireCanDoForApi(companyId, "manage_users");
+  if (gate.kind === "deny") return gate.response;
+
+  try {
+    const gates = await getGates(companyId);
+    return NextResponse.json(
+      { ok: true, data: { gates }, timestamp: new Date().toISOString() },
+      { status: 200 },
+    );
+  } catch (err) {
+    logger.error("workflow.gates.route.get.failed", {
+      company_id: companyId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return internalError("Failed to load workflow gates.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PUT
+// ---------------------------------------------------------------------------
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  const uuidResult = validateUuidParam(id, "id");
+  if (!uuidResult.ok) return uuidResult.response;
+  const companyId = uuidResult.value;
+
+  const gate = await requireCanDoForApi(companyId, "manage_users");
+  if (gate.kind === "deny") return gate.response;
+
+  const body = await readJsonBody(req);
+  const parsed = parseBodyWith(PutBodySchema, body);
+  if (!parsed.ok) return parsed.response;
+
+  const gatesInput: UpsertGateInput[] = parsed.data;
+
+  try {
+    await upsertGates(companyId, gatesInput, gate.userId);
+  } catch (err) {
+    logger.error("workflow.gates.route.put.failed", {
+      company_id: companyId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return internalError("Failed to save workflow gates.");
+  }
+
+  try {
+    const gates = await getGates(companyId);
+    return NextResponse.json(
+      { ok: true, data: { gates }, timestamp: new Date().toISOString() },
+      { status: 200 },
+    );
+  } catch (err) {
+    logger.error("workflow.gates.route.put.refetch_failed", {
+      company_id: companyId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    // Write succeeded; return a minimal success if refetch fails.
+    return NextResponse.json(
+      { ok: true, data: { gates: [] }, timestamp: new Date().toISOString() },
+      { status: 200 },
+    );
+  }
+}

--- a/lib/__tests__/workflow-gates.unit.test.ts
+++ b/lib/__tests__/workflow-gates.unit.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Unit tests for lib/platform/workflow/index.ts
+//
+// All Supabase calls are mocked. We test:
+//   - getGates: returns 3 disabled defaults for a company with no DB rows
+//   - getEnabledGate: returns null when the gate is disabled (not found)
+//   - upsertGates: calls the DB in the correct order (upsert → delete → insert)
+// ---------------------------------------------------------------------------
+
+vi.mock("server-only", () => ({}));
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { getGates, getEnabledGate, upsertGates } from "@/lib/platform/workflow";
+
+const COMPANY_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+
+// ---------------------------------------------------------------------------
+// Helper: build a chainable Supabase builder mock.
+// ---------------------------------------------------------------------------
+
+function makeSelectChain(finalResult: { data: unknown; error: null | { message: string } }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  const terminal = { ...finalResult };
+  const resolved = Promise.resolve(terminal);
+
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  // .in() is the last call in the approver query — must return a thenable.
+  chain.in = vi.fn().mockReturnValue(resolved);
+  chain.order = vi.fn().mockReturnValue(terminal);
+  chain.maybeSingle = vi.fn().mockResolvedValue(terminal);
+  chain.single = vi.fn().mockResolvedValue(terminal);
+  return chain;
+}
+
+function makeUpsertChain(finalResult: { data: unknown; error: null | { message: string } }) {
+  const selectResult = finalResult;
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.upsert = vi.fn().mockReturnValue(chain);
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.single = vi.fn().mockResolvedValue(selectResult);
+  return chain;
+}
+
+function makeDeleteChain(finalResult: { error: null | { message: string } }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.delete = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockResolvedValue(finalResult);
+  return chain;
+}
+
+function makeInsertChain(finalResult: { error: null | { message: string } }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.insert = vi.fn().mockResolvedValue(finalResult);
+  return chain;
+}
+
+// ---------------------------------------------------------------------------
+// getGates — 3 disabled defaults when no DB rows exist
+// ---------------------------------------------------------------------------
+
+describe("getGates", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns three disabled defaults when company has no gate rows", async () => {
+    // First from() call → company_workflow_gates (returns empty array)
+    const gateChain = makeSelectChain({ data: [], error: null });
+
+    mockFrom.mockReturnValue(gateChain);
+
+    const result = await getGates(COMPANY_ID);
+
+    expect(result).toHaveLength(3);
+    for (const gate of result) {
+      expect(gate.enabled).toBe(false);
+      expect(gate.approvers).toEqual([]);
+      expect(gate.companyId).toBe(COMPANY_ID);
+    }
+
+    const types = result.map((g) => g.gateType).sort();
+    expect(types).toEqual(["copy_review", "final_signoff", "image_review"]);
+  });
+
+  it("returns three disabled defaults on a DB error", async () => {
+    const errorChain = makeSelectChain({ data: null, error: { message: "connection refused" } });
+    mockFrom.mockReturnValue(errorChain);
+
+    const result = await getGates(COMPANY_ID);
+
+    expect(result).toHaveLength(3);
+    expect(result.every((g) => !g.enabled)).toBe(true);
+  });
+
+  it("maps DB rows to camelCase domain types", async () => {
+    const gateRow = {
+      id: "gate-uuid-1",
+      company_id: COMPANY_ID,
+      gate_type: "copy_review",
+      enabled: true,
+      pass_rule: "all_must",
+      timeout_days: 7,
+      auto_schedule: false,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const approverRow = {
+      id: "approver-uuid-1",
+      gate_id: "gate-uuid-1",
+      platform_user_id: "user-uuid-1",
+      external_email: null,
+      created_at: "2026-01-01T00:00:00Z",
+    };
+
+    // call 1: company_workflow_gates select
+    const gateSelectChain = makeSelectChain({ data: [gateRow], error: null });
+    // call 2: company_workflow_gate_approvers select
+    const approverSelectChain = makeSelectChain({ data: [approverRow], error: null });
+
+    mockFrom
+      .mockReturnValueOnce(gateSelectChain)
+      .mockReturnValueOnce(approverSelectChain);
+
+    const result = await getGates(COMPANY_ID);
+
+    const copyGate = result.find((g) => g.gateType === "copy_review");
+    expect(copyGate).toBeDefined();
+    expect(copyGate?.enabled).toBe(true);
+    expect(copyGate?.passRule).toBe("all_must");
+    expect(copyGate?.timeoutDays).toBe(7);
+    expect(copyGate?.autoSchedule).toBe(false);
+    expect(copyGate?.approvers).toHaveLength(1);
+    expect(copyGate?.approvers[0].platformUserId).toBe("user-uuid-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEnabledGate — returns null when gate is not found or disabled
+// ---------------------------------------------------------------------------
+
+describe("getEnabledGate", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns null when no enabled gate exists", async () => {
+    const chain = makeSelectChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const result = await getEnabledGate(COMPANY_ID, "copy_review");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on DB error", async () => {
+    const chain = makeSelectChain({ data: null, error: { message: "timeout" } });
+    mockFrom.mockReturnValue(chain);
+
+    const result = await getEnabledGate(COMPANY_ID, "image_review");
+    expect(result).toBeNull();
+  });
+
+  it("returns the gate with approvers when found and enabled", async () => {
+    const gateRow = {
+      id: "gate-uuid-2",
+      company_id: COMPANY_ID,
+      gate_type: "final_signoff",
+      enabled: true,
+      pass_rule: "any_one",
+      timeout_days: 14,
+      auto_schedule: true,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+
+    const gateChain = makeSelectChain({ data: gateRow, error: null });
+    const approverChain = makeSelectChain({ data: [], error: null });
+
+    mockFrom
+      .mockReturnValueOnce(gateChain)
+      .mockReturnValueOnce(approverChain);
+
+    const result = await getEnabledGate(COMPANY_ID, "final_signoff");
+
+    expect(result).not.toBeNull();
+    expect(result?.gateType).toBe("final_signoff");
+    expect(result?.enabled).toBe(true);
+    expect(result?.approvers).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertGates — verifies correct query sequence: upsert → delete → insert
+// ---------------------------------------------------------------------------
+
+describe("upsertGates", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls upsert, delete, and insert in order for each gate", async () => {
+    const upsertedGate = { id: "gate-uuid-3" };
+
+    const upsertChain = makeUpsertChain({ data: upsertedGate, error: null });
+    const deleteChain = makeDeleteChain({ error: null });
+    const insertChain = makeInsertChain({ error: null });
+
+    mockFrom
+      .mockReturnValueOnce(upsertChain)  // company_workflow_gates upsert
+      .mockReturnValueOnce(deleteChain)  // company_workflow_gate_approvers delete
+      .mockReturnValueOnce(insertChain); // company_workflow_gate_approvers insert
+
+    await expect(
+      upsertGates(
+        COMPANY_ID,
+        [
+          {
+            gateType: "copy_review",
+            enabled: true,
+            passRule: "any_one",
+            timeoutDays: 7,
+            autoSchedule: true,
+            approvers: [{ externalEmail: "reviewer@example.com" }],
+          },
+        ],
+        "user-uuid-actor",
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(upsertChain.upsert).toHaveBeenCalledOnce();
+    expect(deleteChain.delete).toHaveBeenCalledOnce();
+    expect(insertChain.insert).toHaveBeenCalledOnce();
+  });
+
+  it("skips the insert step when no approvers are supplied", async () => {
+    const upsertedGate = { id: "gate-uuid-4" };
+
+    const upsertChain = makeUpsertChain({ data: upsertedGate, error: null });
+    const deleteChain = makeDeleteChain({ error: null });
+    const insertChain = makeInsertChain({ error: null });
+
+    mockFrom
+      .mockReturnValueOnce(upsertChain)
+      .mockReturnValueOnce(deleteChain);
+    // insert should NOT be called — we don't even set up a third mock.
+
+    await expect(
+      upsertGates(
+        COMPANY_ID,
+        [
+          {
+            gateType: "image_review",
+            enabled: false,
+            passRule: "all_must",
+            timeoutDays: 14,
+            autoSchedule: false,
+            approvers: [],
+          },
+        ],
+        "user-uuid-actor",
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(upsertChain.upsert).toHaveBeenCalledOnce();
+    expect(deleteChain.delete).toHaveBeenCalledOnce();
+    expect(insertChain.insert).not.toHaveBeenCalled();
+  });
+
+  it("throws when upsert returns an error", async () => {
+    const upsertChain = makeUpsertChain({ data: null, error: { message: "unique violation" } });
+    mockFrom.mockReturnValueOnce(upsertChain);
+
+    await expect(
+      upsertGates(
+        COMPANY_ID,
+        [
+          {
+            gateType: "final_signoff",
+            enabled: true,
+            passRule: "any_one",
+            timeoutDays: 14,
+            autoSchedule: true,
+            approvers: [],
+          },
+        ],
+        "user-uuid-actor",
+      ),
+    ).rejects.toThrow("Failed to upsert gate final_signoff");
+  });
+
+  it("throws on duplicate gate_types in input", async () => {
+    await expect(
+      upsertGates(
+        COMPANY_ID,
+        [
+          { gateType: "copy_review", enabled: true, passRule: "any_one", timeoutDays: 7, autoSchedule: true, approvers: [] },
+          { gateType: "copy_review", enabled: false, passRule: "all_must", timeoutDays: 14, autoSchedule: false, approvers: [] },
+        ],
+        "user-uuid-actor",
+      ),
+    ).rejects.toThrow("Duplicate gate_type");
+  });
+});

--- a/lib/platform/workflow/index.ts
+++ b/lib/platform/workflow/index.ts
@@ -1,0 +1,308 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import type {
+  GateType,
+  PassRule,
+  WorkflowGateApprover,
+  WorkflowGateWithApprovers,
+} from "./types";
+
+export type { ApprovalStatus, GateType, PassRule, WorkflowGate, WorkflowGateApprover, WorkflowGateWithApprovers } from "./types";
+
+// ---------------------------------------------------------------------------
+// Input type for upserting gates.
+// ---------------------------------------------------------------------------
+
+export interface UpsertGateInput {
+  gateType: GateType;
+  enabled: boolean;
+  passRule: PassRule;
+  timeoutDays: number;
+  autoSchedule: boolean;
+  approvers: Array<{ platformUserId?: string; externalEmail?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// DB row shapes (from migration 0172). We don't rely on generated types
+// so the code compiles before supabase types are regenerated.
+// ---------------------------------------------------------------------------
+
+interface GateRow {
+  id: string;
+  company_id: string;
+  gate_type: string;
+  enabled: boolean;
+  pass_rule: string;
+  timeout_days: number;
+  auto_schedule: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ApproverRow {
+  id: string;
+  gate_id: string;
+  platform_user_id: string | null;
+  external_email: string | null;
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults — three disabled gates returned when a company has no config yet.
+// ---------------------------------------------------------------------------
+
+const ALL_GATE_TYPES: GateType[] = ["copy_review", "image_review", "final_signoff"];
+
+function defaultGates(companyId: string): WorkflowGateWithApprovers[] {
+  return ALL_GATE_TYPES.map((gateType) => ({
+    id: "",
+    companyId,
+    gateType,
+    enabled: false,
+    passRule: "any_one" as PassRule,
+    timeoutDays: 14,
+    autoSchedule: true,
+    approvers: [],
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Map DB rows → domain types.
+// ---------------------------------------------------------------------------
+
+function mapGateRow(row: GateRow, approvers: ApproverRow[]): WorkflowGateWithApprovers {
+  return {
+    id: row.id,
+    companyId: row.company_id,
+    gateType: row.gate_type as GateType,
+    enabled: row.enabled,
+    passRule: row.pass_rule as PassRule,
+    timeoutDays: row.timeout_days,
+    autoSchedule: row.auto_schedule,
+    approvers: approvers.map(
+      (a): WorkflowGateApprover => ({
+        id: a.id,
+        gateId: a.gate_id,
+        platformUserId: a.platform_user_id,
+        externalEmail: a.external_email,
+      }),
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getGates — returns all three gate configs for a company. If no DB rows
+// exist yet, returns three disabled defaults so callers always see all gates.
+// ---------------------------------------------------------------------------
+
+export async function getGates(companyId: string): Promise<WorkflowGateWithApprovers[]> {
+  const svc = getServiceRoleClient();
+
+  const { data: gateRows, error: gateErr } = await svc
+    .from("company_workflow_gates")
+    .select("id, company_id, gate_type, enabled, pass_rule, timeout_days, auto_schedule, created_at, updated_at")
+    .eq("company_id", companyId)
+    .order("gate_type", { ascending: true });
+
+  if (gateErr) {
+    logger.error("workflow.gates.get.failed", { company_id: companyId, err: gateErr.message });
+    // Return defaults on error so the caller always gets a usable structure.
+    return defaultGates(companyId);
+  }
+
+  if (!gateRows || gateRows.length === 0) {
+    return defaultGates(companyId);
+  }
+
+  const gateIds = (gateRows as GateRow[]).map((r) => r.id);
+
+  const { data: approverRows, error: approverErr } = await svc
+    .from("company_workflow_gate_approvers")
+    .select("id, gate_id, platform_user_id, external_email, created_at")
+    .in("gate_id", gateIds);
+
+  if (approverErr) {
+    logger.error("workflow.gates.approvers.get.failed", {
+      company_id: companyId,
+      err: approverErr.message,
+    });
+    // Return gates without approvers rather than failing entirely.
+    return (gateRows as GateRow[]).map((r) => mapGateRow(r, []));
+  }
+
+  const approversByGate = new Map<string, ApproverRow[]>();
+  for (const a of (approverRows ?? []) as ApproverRow[]) {
+    const list = approversByGate.get(a.gate_id) ?? [];
+    list.push(a);
+    approversByGate.set(a.gate_id, list);
+  }
+
+  const result: WorkflowGateWithApprovers[] = (gateRows as GateRow[]).map((r) =>
+    mapGateRow(r, approversByGate.get(r.id) ?? []),
+  );
+
+  // Fill in any missing gate types with disabled defaults.
+  const existingTypes = new Set(result.map((g) => g.gateType));
+  for (const gateType of ALL_GATE_TYPES) {
+    if (!existingTypes.has(gateType)) {
+      result.push({
+        id: "",
+        companyId,
+        gateType,
+        enabled: false,
+        passRule: "any_one",
+        timeoutDays: 14,
+        autoSchedule: true,
+        approvers: [],
+      });
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// getEnabledGate — returns a single gate by type if it exists and is enabled,
+// or null if absent or disabled.
+// ---------------------------------------------------------------------------
+
+export async function getEnabledGate(
+  companyId: string,
+  type: GateType,
+): Promise<WorkflowGateWithApprovers | null> {
+  const svc = getServiceRoleClient();
+
+  const { data: gateRow, error: gateErr } = await svc
+    .from("company_workflow_gates")
+    .select("id, company_id, gate_type, enabled, pass_rule, timeout_days, auto_schedule, created_at, updated_at")
+    .eq("company_id", companyId)
+    .eq("gate_type", type)
+    .eq("enabled", true)
+    .maybeSingle();
+
+  if (gateErr) {
+    logger.error("workflow.gate.get_enabled.failed", {
+      company_id: companyId,
+      gate_type: type,
+      err: gateErr.message,
+    });
+    return null;
+  }
+
+  if (!gateRow) return null;
+
+  const row = gateRow as GateRow;
+
+  const { data: approverRows, error: approverErr } = await svc
+    .from("company_workflow_gate_approvers")
+    .select("id, gate_id, platform_user_id, external_email, created_at")
+    .eq("gate_id", row.id);
+
+  if (approverErr) {
+    logger.error("workflow.gate.approvers.get_enabled.failed", {
+      gate_id: row.id,
+      err: approverErr.message,
+    });
+    return mapGateRow(row, []);
+  }
+
+  return mapGateRow(row, (approverRows ?? []) as ApproverRow[]);
+}
+
+// ---------------------------------------------------------------------------
+// upsertGates — write (or overwrite) all gate configs for a company.
+//
+// For each gate:
+//   1. Upsert the gate row (ON CONFLICT company_id, gate_type DO UPDATE).
+//   2. Delete all existing approver rows for that gate.
+//   3. Insert the new approver rows.
+//
+// The caller is responsible for validating no duplicate gate_types in the input.
+// ---------------------------------------------------------------------------
+
+export async function upsertGates(
+  companyId: string,
+  gates: UpsertGateInput[],
+  _updatedBy: string,
+): Promise<void> {
+  // Guard: no duplicate gate_types.
+  const typesSeen = new Set<GateType>();
+  for (const g of gates) {
+    if (typesSeen.has(g.gateType)) {
+      throw new Error(`Duplicate gate_type in input: ${g.gateType}`);
+    }
+    typesSeen.add(g.gateType);
+  }
+
+  const svc = getServiceRoleClient();
+  const now = new Date().toISOString();
+
+  for (const gate of gates) {
+    // 1. Upsert the gate row.
+    const { data: upserted, error: upsertErr } = await svc
+      .from("company_workflow_gates")
+      .upsert(
+        {
+          company_id: companyId,
+          gate_type: gate.gateType,
+          enabled: gate.enabled,
+          pass_rule: gate.passRule,
+          timeout_days: gate.timeoutDays,
+          auto_schedule: gate.autoSchedule,
+          updated_at: now,
+        },
+        { onConflict: "company_id,gate_type" },
+      )
+      .select("id")
+      .single();
+
+    if (upsertErr || !upserted) {
+      logger.error("workflow.gates.upsert.gate_failed", {
+        company_id: companyId,
+        gate_type: gate.gateType,
+        err: upsertErr?.message ?? "no row returned",
+      });
+      throw new Error(`Failed to upsert gate ${gate.gateType}: ${upsertErr?.message ?? "no row returned"}`);
+    }
+
+    const gateId = (upserted as { id: string }).id;
+
+    // 2. Delete existing approvers for this gate.
+    const { error: deleteErr } = await svc
+      .from("company_workflow_gate_approvers")
+      .delete()
+      .eq("gate_id", gateId);
+
+    if (deleteErr) {
+      logger.error("workflow.gates.upsert.approvers_delete_failed", {
+        gate_id: gateId,
+        err: deleteErr.message,
+      });
+      throw new Error(`Failed to clear approvers for gate ${gateId}: ${deleteErr.message}`);
+    }
+
+    // 3. Insert new approvers (skip if none supplied).
+    if (gate.approvers.length > 0) {
+      const rows = gate.approvers.map((a) => ({
+        gate_id: gateId,
+        platform_user_id: a.platformUserId ?? null,
+        external_email: a.externalEmail ?? null,
+      }));
+
+      const { error: insertErr } = await svc
+        .from("company_workflow_gate_approvers")
+        .insert(rows);
+
+      if (insertErr) {
+        logger.error("workflow.gates.upsert.approvers_insert_failed", {
+          gate_id: gateId,
+          err: insertErr.message,
+        });
+        throw new Error(`Failed to insert approvers for gate ${gateId}: ${insertErr.message}`);
+      }
+    }
+  }
+}

--- a/lib/platform/workflow/types.ts
+++ b/lib/platform/workflow/types.ts
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------
+// Workflow gate types — Phase 1 Step 2
+//
+// company_workflow_gates + company_workflow_gate_approvers schema (migration 0172).
+// ---------------------------------------------------------------------------
+
+export type GateType = "copy_review" | "image_review" | "final_signoff";
+export type PassRule = "all_must" | "any_one";
+export type ApprovalStatus =
+  | "none"
+  | "pending_review"
+  | "approved"
+  | "rejected"
+  | "escalated_to_admin";
+
+export interface WorkflowGate {
+  id: string;
+  companyId: string;
+  gateType: GateType;
+  enabled: boolean;
+  passRule: PassRule;
+  timeoutDays: number;
+  autoSchedule: boolean;
+}
+
+export interface WorkflowGateApprover {
+  id: string;
+  gateId: string;
+  platformUserId: string | null;
+  externalEmail: string | null;
+}
+
+export interface WorkflowGateWithApprovers extends WorkflowGate {
+  approvers: WorkflowGateApprover[];
+}


### PR DESCRIPTION
## Summary

- Adds `lib/platform/workflow/types.ts` — `GateType`, `PassRule`, `ApprovalStatus`, `WorkflowGate`, `WorkflowGateApprover`, `WorkflowGateWithApprovers` types.
- Adds `lib/platform/workflow/index.ts` — `getGates`, `getEnabledGate`, `upsertGates` library functions. `getGates` always returns all three gate types (filling missing types with disabled defaults). `upsertGates` runs upsert → delete-approvers → insert-approvers per gate.
- Adds `app/api/platform/companies/[id]/workflow-gates/route.ts` — `GET` returns current gate configs; `PUT` validates (Zod, max 3 gates, no duplicate gate_types) and writes, returning the updated gates.
- Adds `lib/__tests__/workflow-gates.unit.test.ts` — 10 unit tests (all mocked): defaults for empty company, disabled gate returns null, correct upsert/delete/insert query order.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` — 177 files / 3161 tests pass (+ 10 new)
- [ ] Contract snapshots — no external SDK calls touched
- [ ] Cross-tenant test — route gates on `company_id` from URL param via `requireCanDoForApi`; cross-tenant integration coverage deferred
- [x] Risks identified and mitigated section below

## Working analog

**Working analog**: `app/api/platform/social/posts/[id]/route.ts:1-103` — same `validateUuidParam` + `requireCanDoForApi` gate + `readJsonBody` + `parseBodyWith` + `NextResponse.json({ ok: true, data, timestamp })` pattern.
**Diff**: new route is under `/companies/[id]/` rather than `/social/`; lib layer uses upsert+replace-children rather than create/update.
**Fix**: route mirrors the pattern exactly.

## Risks identified and mitigated

- **No DB tables until migration 0172 merges** — safe to merge before the migration; any request will get a Supabase error (caught, logged, 500). No data corruption possible.
- **Approver replace (delete-then-insert) is not atomic** — acceptable for Phase 1 (config surface, low traffic). Add a transaction wrapper in a follow-up if needed.
- **Auth gate uses `manage_users`** — admin-only, matching the spec. Opollo staff bypass via `canDo` staff override.

> **Depends on migration PR #1242 being applied in prod before this route is exercised.** Safe to merge independently.

---
Generated with [Claude Code](https://claude.com/claude-code)