### PR TITLE
feat(migration): 0173 — approval reminder tracking columns (Phase 2)

### DIFF
--- a/supabase/migrations/0173_approval_reminders.sql
+++ b/supabase/migrations/0173_approval_reminders.sql
@@ -1,0 +1,32 @@
+-- Migration 0173 — Approval Workflow Engine, Phase 2: reminder tracking
+--
+-- Adds four timestamptz columns to social_approval_requests for exactly-once
+-- QStash reminder/escalation tracking (the IS NULL guard pattern used by the
+-- invitation callback system).
+--
+-- Each column serves as an idempotency anchor for its handler:
+--   reminder_day3_sent_at  — day-3 nudge sent; handler no-ops if not null
+--   reminder_day7_sent_at  — day-7 nudge sent
+--   reminder_day14_sent_at — day-14 final notice sent to approver(s)
+--   admin_alerted_at       — Opollo-admin dark-client alert sent (day 14)
+--
+-- All nullable (null = not yet sent). All default null. Safe to apply on live
+-- production — additive only, no data changes.
+--
+-- Also: reminder_day0_sent_at for the initial magic-link invite email that
+-- should be sent the moment the approval request is created. Without this,
+-- the day-0 send can fire twice if createBatchApprovalRequest is retried.
+--
+-- Rollback: ALTER TABLE social_approval_requests
+--   DROP COLUMN IF EXISTS reminder_day0_sent_at,
+--   DROP COLUMN IF EXISTS reminder_day3_sent_at,
+--   DROP COLUMN IF EXISTS reminder_day7_sent_at,
+--   DROP COLUMN IF EXISTS reminder_day14_sent_at,
+--   DROP COLUMN IF EXISTS admin_alerted_at;
+
+ALTER TABLE social_approval_requests
+  ADD COLUMN IF NOT EXISTS reminder_day0_sent_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS reminder_day3_sent_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS reminder_day7_sent_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS reminder_day14_sent_at timestamptz,
+  ADD COLUMN IF NOT EXISTS admin_alerted_at       timestamptz;


### PR DESCRIPTION
## Migration 0173 — Phase 2 reminder tracking

Migration-first per build brief. Apply and verify in production before merging any Phase 2 code PRs.

### Changes (additive — safe on live prod)

Adds 5 nullable `timestamptz` columns to `social_approval_requests`:

| Column | Purpose |
|---|---|
| `reminder_day0_sent_at` | Idempotency anchor for the initial magic-link invite email |
| `reminder_day3_sent_at` | Day-3 nudge sent guard |
| `reminder_day7_sent_at` | Day-7 nudge sent guard |
| `reminder_day14_sent_at` | Day-14 final notice sent guard |
| `admin_alerted_at` | Opollo-admin dark-client alert sent guard |

All use the `IS NULL` guard pattern from the invitation callbacks blueprint — each QStash handler atomically claims its slot via `UPDATE ... WHERE reminder_dayN_sent_at IS NULL`, ensuring exactly-once fire across concurrent QStash retries.

### Production verification checklist
After merge and deploy:
- [ ] `SELECT reminder_day3_sent_at FROM social_approval_requests LIMIT 1` — column exists, value NULL
- [ ] `SELECT admin_alerted_at FROM social_approval_requests LIMIT 1` — column exists, value NULL

### Rollback
```sql
ALTER TABLE social_approval_requests
  DROP COLUMN IF EXISTS reminder_day0_sent_at,
  DROP COLUMN IF EXISTS reminder_day3_sent_at,
  DROP COLUMN IF EXISTS reminder_day7_sent_at,
  DROP COLUMN IF EXISTS reminder_day14_sent_at,
  DROP COLUMN IF EXISTS admin_alerted_at;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)