### PR TITLE
docs(proposals): proofing/DAM/workflow master brief and build briefs 0–4

### DIFF
--- a/docs/proposals/AUDIT_INDEX.md
+++ b/docs/proposals/AUDIT_INDEX.md
@@ -1,0 +1,191 @@
+# Proofing / Workflow / Client-Portal — Full Build Package (Audit Index)
+
+This is the entry point for auditing the full build. It ties together every document,
+states build order and dependencies, records what is already built and live, and flags
+known hazards. An auditor should read THIS first, then the documents in the order below.
+
+> Repo destination: `docs/proposals/AUDIT_INDEX.md`
+
+---
+
+## 0. What this build is
+
+A content **proofing + approval + workflow** subsystem plus a **client portal** for the
+Opollo platform — a "Gain-style front door over a PageProof-style engine." It generalises
+an image-review approval feature (already built + live) into a proofing system across
+content types, adds configurable workflows, and gives external clients self-service access
+(approvals + social-connection reconnect) via magic links.
+
+Strategy and rationale: see the Master Brief (doc M). This index is the build map.
+
+---
+
+## 1. Documents in this package
+
+| # | Document | Role | Status |
+|---|----------|------|--------|
+| M | Master Brief (proofing/DAM/workflow) | Orientation + strategy + wireframes | Written |
+| R1 | docs/recon/PROOFING_RECON.md | Codebase recon (proofing/approval/magic-link) | In repo — INCLUDE from repo |
+| R2 | docs/recon/CONNECTIONS_CLIENT_ACCESS_RECON.md | Codebase recon (connections/client access) | In repo — INCLUDE from repo |
+| B0 | Brief 0 — Proofing UX Contract | Product/UX decisions (non-technical) | Written |
+| B1 | Brief 1 — Magic Link Infrastructure | Build brief | Written |
+| B2 | Brief 2 — Core Proofing V1 | Build brief | Written |
+| B3 | Brief 3 — Workflow Engine + Versioning | Build brief | Written |
+| B4 | Brief 4 — Client Portal (Connections) | Build brief | Written |
+| C | CLAUDE.md addition (durable principles) | Conventions update | PENDING — to be written against existing CLAUDE.md |
+
+AUDITOR NOTE: R1 + R2 are authoritative ground truth — the briefs were written against
+them. Do not audit the briefs without the recons; brief accuracy depends on them. They
+live in the repo (terminal-written); include the actual files.
+
+---
+
+## 2. Read / audit order
+
+1. **M** — understand the vision and why.
+2. **R1, R2** — what the codebase actually is (corrects many reasonable assumptions).
+3. **B0** — the product decisions every technical brief assumes.
+4. **B1 → B2 → B3** — the proofing line, in dependency order.
+5. **B4** — the client portal (parallel branch off B1).
+6. **C** — the conventions update (pending).
+
+---
+
+## 3. Build order & dependency graph
+
+```
+B1 (Magic Link)  ─┬─→  B2 (Core Proofing V1)  ─→  B3 (Workflow Engine)
+                  └─→  B4 (Client Portal)
+B0 (UX Contract) — read by ALL technical briefs as the decision contract
+```
+
+- **B1 first** — everything depends on the magic-link service.
+- After B1, two independent branches: proofing (B2→B3) and connections (B4). They do not
+  depend on each other. **Do not run both branches in parallel against the build agent** —
+  finish one, verify, then the other (both touch the magic-link service + shared surfaces).
+- B3 depends on B2 (versioning chain). B4 depends only on B1.
+- Each brief: build → verify live → update the NEXT brief with any drift the prior one
+  reported, before running it. (This loop has already caught real mismatches.)
+
+---
+
+## 4. Already built & live (do NOT rebuild — extend)
+
+Production as of SHA 11272bd8 (verify current):
+- 3 fixed approval gates (copy_review / image_review / final_signoff), per-company,
+  optional, pass-rules, timeout, auto_schedule. `company_workflow_gates` +
+  `_gate_approvers`.
+- Image-review gate intercepts approval → draft held in `pending_image_review` → approval
+  request → on pass, schedule (V2). Reject → round (cap 3) → round-3 escalate-to-admin.
+- Batch delete / reset / watch with full cascade.
+- Approval backbone reused: `social_approval_requests` (+ `subject_type`/`subject_id`),
+  `_recipients`, `_events`. `record_approval_decision` RPC.
+- Escalation ladder (QStash day-3/7/14 + day-14 admin alert), reminder templates.
+- Gate config UI (company page Workflow tab) + vertical workflow status drawer.
+- Auto-schedule via V2 publish-due cron.
+
+The build EXTENDS this. Briefs B1–B4 must reuse, not fork. (One engine, not two.)
+
+---
+
+## 5. Locked decisions (the spine — auditor should check briefs honour these)
+
+Architecture: V2 pipeline (`social_post_drafts`), not V1 (retiring). Introduce real content
+versioning (`content_group_id`/`version_number`/`supersedes_id`, immutable). Reuse approval
+backbone, extend don't fork. Magic links = core infra, generic by `purpose`. Build on
+existing stubs (`platform_session_grants`, OTP columns) not new tables.
+
+UX (B0): one-time link + same-day session + self-serve re-request. Comments resolvable,
+no threads, close on new version. New version re-enters at requesting step + skips prior
+approvers. Gatekeeper sends back one step only. V1 surfaces = image + carousel (slide
+pins); PDF/video/HTML deferred. Notification matrix per B0 §7. DAM deferred but interfaces
+stable now.
+
+Workflow: round-3 = escalate to admin. all_must/any_one pass rules → evolve to role model
+(reviewer/mandatory/gatekeeper/approver). Lossless gate→step migration bridge.
+
+---
+
+## 5a. Hard constraint — NO new external dependencies (applies to ALL briefs)
+
+This build adds ZERO new external services, APIs, SaaS products, or paid subscriptions. It
+reuses ONLY the existing stack the platform already runs: Supabase (DB/auth/storage),
+Vercel (host), QStash/Upstash (delayed jobs), SendGrid (email via `dispatch()`), and
+bundle.social (social OAuth/publishing). A builder must NOT introduce any new dependency —
+no new email provider, queue, auth service, storage, analytics, or third-party API. If a
+brief seems to require something outside the existing stack, STOP and flag it — do not add
+it. Everything in B1–B4 is achievable on the current stack (verified per brief: B1 token
+primitive+SendGrid+Supabase; B2 approval backbone+SendGrid+Supabase+V2 cron; B3 pure
+Postgres+existing patterns; B4 existing bundle.social OAuth+QStash+SendGrid+
+`platform_session_grants`).
+
+---
+
+## 6. Known hazards (auditor + builder must respect)
+
+1. **Company-context / access hierarchy (security boundary).** Opollo users = global,
+   can/must switch client context. Customers = single-company, self-sign-up, hard-walled
+   from other companies (no switching). Every company-scoped action must resolve + enforce
+   the correct company (admin acting on a client must be switched into that client's
+   company context; a customer can never reach another company). Enforced via
+   `is_company_member` / `is_opollo_staff` RLS helpers + `platform_company_users` roles.
+2. **Unnormalized admin endpoints/URLs.** Admin routing is not fully normalized — actions
+   can land in the wrong place / wrong company context. When building company-scoped
+   features, verify the target company is resolved correctly, not ambient. (Remediation —
+   admin routing + client-switching normalization — is its own backlog item.)
+3. **Cross-tenant binding.** A LinkedIn OAuth cross-tenant leak was previously fixed via
+   the `external_identity_hash` fingerprint. Any connection/OAuth work must honour it. B4
+   in particular: a client must only ever touch their own company's connections.
+4. **V1/V2 split.** Approvals historically wired to V1 master; new work targets V2 drafts.
+   Don't anchor to V1.
+5. **Schema stubs exist ahead of code.** `platform_session_grants`, OTP columns, the
+   expiry index were all scaffolded but unused. Grep for an existing home before adding a
+   migration.
+
+---
+
+## 7. Autonomous-build readiness (per external review)
+
+The technical briefs (B1–B4) + UX contract (B0) scored 8.5/10 pre-B0; B0 closes the
+product-decision gaps (magic-link lifecycle, comments, re-entry, gatekeeper, notifications,
+review-surface scope) that an autonomous agent would otherwise invent. The recons (R1/R2)
+ground the schema/route assumptions. Remaining auditor focus areas:
+- Per-screen UI detail beyond the wireframes (B0 §9 + Master §7a point at wireframes; full
+  empty-state/component specs are light — flag if the auditor wants more before build).
+- The CLAUDE.md conventions update (C) is pending.
+- DAM is deferred by design; B0 §8 requires stable asset-referencing interfaces now to
+  avoid later migration.
+
+---
+
+## 9. Audit resolutions (round 1)
+
+External audit raised these; resolved in this revision:
+- B3 ↔ B0 conflict on version re-entry → B3 now deterministic per B0 §4 (re-enter at
+  requesting step, skip prior approvers; configurable re-entry deferred). FIXED.
+- B3 ↔ B0 conflict on gatekeeper send-back → B3 now one-step-only per B0 §5. FIXED.
+- B3 role-interaction ambiguity → added role-behaviour matrix + resolved interactions. FIXED.
+- B3 custom_count "count of whom" → defined as N of blocking participants only. FIXED.
+- B4 portal recipient unspecified → `portal_contact_email` + fallback defined. FIXED.
+- B4 notification cadence → locked at 7-day / 1-day / on-expiry. FIXED.
+- B4 failure-state contract → added (expired/revoked/deleted/inactive/OAuth-fail/wrong-company). FIXED.
+- Master brief stale assumptions → authority-pointer added (B0–B4 + recon are source of
+  truth; master is strategic context only). FIXED.
+
+Still open (not blocking the build line below, but flagged):
+- DAM architecture/scope — the largest remaining strategic decision (Master §6 Q1). B0 §8
+  requires stable asset-referencing interfaces NOW regardless. Auditor + Steven concur:
+  proofing-core + connected-DAM, not fused. Decide before any DAM work begins.
+- B3 dashboard detail (due dates / stuck / SLA / pending reviewers) — light; expand before
+  building the dashboard portion of B3.
+- B3 step-builder complexity — consider deferring custom_count/advanced thresholding to a
+  "release 4" if real usage is mostly 3 fixed steps (strategic, not blocking).
+- CLAUDE.md addition (doc C) — pending existing-file review.
+
+---
+
+## 10. What is NOT in this build (deferred by design)
+
+DAM (asset library, reuse, search, delivery), advanced markup (DOM selectors, video
+frame-level), SDK/webhooks, SSO/SCIM, AI content generation as a create-source, the client
+onboarding wizard (own backlog brief — approvals is one step within it). Per Master Brief.

--- a/docs/proposals/BUILD_BRIEF_0_PROOFING_UX_CONTRACT.md
+++ b/docs/proposals/BUILD_BRIEF_0_PROOFING_UX_CONTRACT.md
@@ -1,0 +1,132 @@
+# Build Brief 0 — Proofing UX Contract
+
+THE PRODUCT CONTRACT. Non-technical. This document makes every product/UX decision the
+three technical briefs (1 Magic Link, 2 Core Proofing, 3 Workflow Engine) assume but do
+not state. Builders MUST follow these decisions exactly — they are not free to invent
+reviewer UX, comment behaviour, workflow re-entry, magic-link lifecycle, or notification
+rules. Where a builder finds a case not covered here, STOP and ask, do not invent.
+
+Read this BEFORE briefs 1–3. Decisions here override any conflicting assumption in those.
+
+---
+
+## 1. Magic-link lifecycle (was the largest gap)
+
+- **One-time link.** A magic link admits the reviewer ONCE.
+- **Opening the link creates a short same-day session.** So a reviewer who opens on phone
+  then moves to desktop the same day can return WITHOUT a new link, for the life of the
+  session (same-day). The DECISION is what's recorded, not "consumed on first glance" —
+  the session lets them keep working that day.
+- **After the session expires, the reviewer self-serves a fresh link** by entering their
+  email on a re-request page (Gain model). A new one-time link is issued.
+- **The operator can also resend** a reviewer a fresh link.
+- Token itself remains one-time + hashed (per recon); "re-request" = issue a NEW link via
+  the magic-link service `regenerate`/`issue` (Brief 1), never resurrect the old token.
+- Security requirements (make explicit in Brief 1): rate-limit link issuance + re-request
+  (per email + per IP), audit every issue/consume/regenerate as events, no enumerable
+  sequential ids (UUID + hash only), and on email change the old links revoke.
+
+## 2. Reviewer session
+
+- Session is **short and same-day** (e.g. expires end of day or a few hours — builder
+  picks a sane default, ≤24h). It exists only to avoid re-requesting a link mid-task.
+- No persistent account is required for external reviewers (token + session identity).
+- Returning a different day = re-request a link (§1).
+
+## 3. Comment model (V1 — deliberately simple)
+
+- Comments can be **resolved** (mark done). NO threading/replies in V1.
+- Comment types V1: general comment + simple region pin on an image (and per-slide pin on
+  a carousel — see §6).
+- Comment REQUIRED on "request changes" (already L17). Optional on approve.
+- **On a new version, all open comments CLOSE.** They are not carried forward; they remain
+  visible in the prior version's history (immutable record) but the new version starts
+  clean. (Builder: mark them closed/superseded, do not delete — audit preserved.)
+
+## 4. Workflow re-entry on a new version (was "huge")
+
+Workflow example: Internal → Legal → Client.
+- A reviewer requests a change at their step → new version is created.
+- **The new version re-enters at the step that requested the change** (Legal requests →
+  new version re-enters at Legal), NOT from step 1.
+- **Reviewers who already approved the prior version are SKIPPED** on the new version
+  (Internal approved v1 → not re-asked). So the flow becomes Legal → Client.
+- This combination is deliberate and must be implemented together.
+
+## 5. Gatekeeper send-back (was "dangerous if imprecise")
+
+- A gatekeeper can send the proof back **ONE step only** — to the immediately prior step.
+- A gatekeeper CANNOT send back to an arbitrary earlier step, and CANNOT bypass mandatory
+  reviewers.
+- Send-back reopens that one prior step; normal sequencing resumes from there.
+
+## 6. Review surface scope (V1)
+
+- V1 supports **images (single) and carousels** as review surfaces.
+- On a carousel, a reviewer can **pin comments to a specific slide** (pins are
+  slide-scoped).
+- **NOT in V1:** PDF, video (frame-level), HTML/website preview, DOM-selector markup.
+  These are explicitly deferred — a builder must NOT attempt them. If content of an
+  unsupported type reaches a proof, show "preview not supported in this version," not a
+  broken viewer.
+
+## 7. Notification matrix (was missing — now explicit)
+
+Recipient rules per event. "Everyone on the proof" = all reviewers/approvers + owner.
+
+| Event | Notified |
+|-------|----------|
+| Proof created / reviewer invited | The invited reviewer(s) (day-0 invite) |
+| Comment added | Owner + everyone on the proof |
+| Reviewer approves (a step) | Everyone on the proof |
+| Changes requested | Everyone on the proof |
+| New version created | Everyone on the proof (re-review notice to the re-entry step) |
+| Final approval reached | Owner + all approvers across the whole workflow |
+| Reminder ladder (day 3/7/14) | The pending reviewer(s) (Phase 2) |
+| Day-14 escalation | Opollo admin (dark-client alert) |
+
+Channels: email + in-app (existing dispatch() + notification system). Event-driven (emit
+structured event → channel adapters), per the master brief.
+
+## 8. DAM boundary (deferred, but interfaces defined now)
+
+DAM is NOT built in V1. BUT, to avoid a painful migration later (reviewer's warning), the
+build must define stable interfaces now:
+- Asset URLs/refs go through a stable accessor, not hard-coded storage paths, so a future
+  DAM layer can swap the source without touching proofing.
+- Version asset references attach to the content version (the `content_group_id` chain),
+  so assets are already version-addressable when DAM arrives.
+- No asset library / reuse / search UI in V1 — just the stable referencing.
+
+## 9. Screens (the UI layer the reviewer flagged as under-specified)
+
+Builders MUST build to these, not invent. Wireframes in master brief §7a + this session.
+
+1. **Client review queue** (Gain front door): simple list of items awaiting THIS
+   reviewer's decision; item opens the review screen; batch-approve allowed. Client's
+   whole world — no projects/workspaces/workflow internals exposed.
+2. **Review screen**: content (image/carousel) + simple markup (pin/region/comment),
+   resolvable comments, decision controls (Approve / Request changes [comment required]).
+   Fixed always-visible action bar (PageProof-style). Round/version indicator.
+3. **Operator proof setup** (Brief 3): workflow steps + roles + thresholds + per-approver
+   access (login/magic-link). Release-3 depth.
+4. **Operator proof dashboard** (Brief 3): proofs by state/step, role-aware.
+5. **Version comparison** (Brief 3): side-by-side of two versions in a content_group.
+6. **Re-request link page** (§1): enter email → fresh link.
+7. **Workflow status drawer** (BUILT): vertical, per-stage status + responsible party.
+
+## 10. What a builder must NOT invent
+
+If any of these is unclear in a brief, STOP and ask — do not guess: link/session timing
+beyond §1–2; comment richness beyond §3; re-entry rules beyond §4; gatekeeper scope beyond
+§5; review surface types beyond §6; notification recipients beyond §7; any DAM behaviour;
+any screen layout not in §9.
+
+---
+
+## Decision log (locked this session)
+One-time link + same-day session + self-serve re-request (Gain-style). Comments
+resolvable, no threads, close on new version. Re-enter at requesting step, skip prior
+approvers. Gatekeeper sends back one step only. V1 surfaces = image + carousel (slide
+pins). Notifications mostly "everyone on the proof"; final = owner + all approvers. DAM
+deferred but interfaces stable now.

--- a/docs/proposals/BUILD_BRIEF_1_MAGIC_LINK.md
+++ b/docs/proposals/BUILD_BRIEF_1_MAGIC_LINK.md
@@ -1,0 +1,107 @@
+# Build Brief 1/3 — Magic Link Infrastructure
+
+CONTRACT-DRIVEN AUTONOMOUS BUILD. First of three (Magic Link → Core Proofing V1 →
+Workflow Engine). Build this FIRST — the other two depend on it. Execute end-to-end, one
+PR per logical change, migration-first, report at the end. Grounded in
+`docs/recon/PROOFING_RECON.md`.
+
+> START WITH RECON: before writing code, re-read docs/recon/PROOFING_RECON.md and verify
+> the assumptions below against the current codebase. Report any drift before building.
+
+---
+
+## Why this is first
+
+Magic links are core platform infrastructure (login, content approvals, social-connection
+reconnect, reviewer access). The proofing system can't notify or admit external reviewers
+without it. Recon finding 5: the raw token is SHA-256 hashed at creation and discarded —
+there is NO way to recover or resend a link today; resend needs a fresh token. This brief
+builds a general, reusable magic-link service that owns the full token lifecycle.
+
+## Locked context (from recon — verify, don't assume)
+
+- Token generation today: `lib/platform/invitations/tokens.ts` — `generateRawToken()` →
+  64-char hex; only SHA-256 hash stored. Reuse this primitive; do not reinvent hashing.
+- `social_approval_recipients` holds approval tokens: `token_hash`, `platform_user_id`
+  (null = external), `external_email`, `requires_otp`, `otp_code_hash`, `otp_expires_at`
+  (OTP columns present, entirely unwired — finding 6), `revoked_at`.
+- External `/approve/[token]` auth: token-only identity, no account, no OTP.
+- Email: `dispatch()` + SendGrid, templates registered in `lib/email/templates/`,
+  `platform_email_log` + `is_critical` admin-alert path, QStash enqueue w/ dedup.
+- No magic-link reconnect path exists (finding 7) — greenfield.
+- No passwordless magic-login path confirmed — treat login use as additive.
+
+## Goal
+
+A general `lib/platform/magic-link/` service: issue, store, validate, consume, revoke,
+and **re-send/regenerate** links for ANY purpose, identified by a `purpose` discriminator.
+Approvals become its first consumer; login + reconnect are additive consumers.
+
+## Step 1 — Migration (migration-first; apply + verify in prod before code)
+
+New table `magic_links` (the general service — does NOT replace approval recipients, sits
+alongside; approval recipients become a consumer that references a magic link):
+```
+id            uuid pk default gen_random_uuid()
+purpose       text not null check (purpose in ('approval','login','reconnect'))
+token_hash    text not null            -- SHA-256, reuse existing primitive
+subject_type  text                      -- e.g. 'approval_recipient','user','social_connection'
+subject_id    uuid                      -- the row this link acts on
+company_id    uuid references platform_companies(id) on delete cascade
+email         text                      -- recipient
+expires_at    timestamptz not null
+consumed_at   timestamptz               -- one-time-use marker (null = unused)
+revoked_at    timestamptz
+regenerated_from uuid references magic_links(id)  -- chain when resent
+created_at    timestamptz not null default now()
+unique (token_hash)
+index on (subject_type, subject_id) where revoked_at is null and consumed_at is null
+```
+RLS: `is_opollo_staff() OR is_company_member(company_id)`; service-role for validate/consume.
+
+## Step 2 — The service (`lib/platform/magic-link/`)
+
+- `issue({purpose, subjectType, subjectId, companyId, email, ttl})` → returns the RAW
+  token ONCE (caller sends it in the email) + the row. Stores hash only.
+- `validate(rawToken)` → `{valid, link}`; rejects if revoked/consumed/expired.
+- `consume(rawToken)` → atomically sets `consumed_at` if one-time-use for that purpose;
+  idempotent. (Approval links: one-time per Gain's model — issue a fresh one on each send.)
+- `revoke(linkId | subjectRef)` → sets `revoked_at`; used by batch-delete + resend.
+- `regenerate(linkId)` → revokes old, issues new with `regenerated_from` set, returns raw
+  token. THIS is the resend primitive finding 5 said is missing.
+- Configurable TTL per purpose (approval default: Gain-style — one-time or 24h, whichever
+  first; login/reconnect their own).
+
+## Step 3 — Wire approvals as the first consumer
+
+- Refactor approval-recipient token creation to issue via the magic-link service
+  (`purpose='approval'`, `subjectType='approval_recipient'`, `subjectId=recipient.id`).
+  Keep `social_approval_recipients.token_hash` working (back-compat) OR point it at the
+  magic_links row — choose the lower-risk path and state which; do not break the live
+  `/approve/[token]` flow.
+- Provide `regenerateApprovalLink(recipientId)` so Phase-2 external reminders (currently
+  skipped, finding) can send a fresh working link.
+- The `/approve/[token]` route validates + consumes via the service.
+
+## Step 4 — Login + reconnect consumers (additive, minimal)
+
+- `purpose='login'`: a passwordless email-login link issuance + a route that validates,
+  consumes, and establishes the session. (Mirror existing session establishment.)
+- `purpose='reconnect'`: issue a link that lands an operator/client on the social-
+  connection reconnect OAuth start for a specific connection (greenfield, finding 7).
+- Keep these minimal — the point is the service supports them, not a full UX build.
+
+## Step 5 — Tests + verify
+Issue/validate/consume/revoke/regenerate; one-time-use enforcement; expiry; revoke cascade;
+approval link still admits at `/approve/[token]`; regenerate produces a working new link
+and invalidates the old. Typecheck/lint/suite green. L18 Definition of Done.
+
+## Constraints
+Reuse the existing hashing primitive + dispatch() + QStash. One engine, generic by
+`purpose`. Transactional, idempotent, preserve audit, RLS, mirror route conventions
+(`app/api/platform/image/jobs/[id]/select/route.ts` is the canonical shape). No second
+token system.
+
+## Report
+PRs, migration prod-verified, what Steven verifies live (resend a link, log in via link),
+and any drift from the recon assumptions (feeds briefs 2 + 3).

--- a/docs/proposals/BUILD_BRIEF_2_CORE_PROOFING_V1.md
+++ b/docs/proposals/BUILD_BRIEF_2_CORE_PROOFING_V1.md
@@ -1,0 +1,101 @@
+# Build Brief 2/3 — Core Proofing V1
+
+CONTRACT-DRIVEN AUTONOMOUS BUILD. Second of three. DEPENDS ON Brief 1 (magic-link
+service). Build AFTER Brief 1 is merged + verified. Update this brief with any drift
+Brief 1 reported. Execute end-to-end, one PR per logical change, migration-first.
+
+> START WITH RECON: re-read docs/recon/PROOFING_RECON.md + Brief 1's drift report. Verify
+> before building.
+
+---
+
+## Scope discipline (the reviewer's #1 warning)
+
+V1 is the SIMPLE Gain-style loop. Do NOT build roles/thresholds/gatekeepers/DAM/advanced
+markup — those are Brief 3 and later. V1 journey:
+
+**Create proof → invite client (magic link) → client reviews in a queue → approve /
+request changes (simple comments + region pins) → revise = NEW VERSION → re-review →
+approve.**
+
+## Locked architecture decisions (from this session)
+
+- **Pipeline: V2.** Proofing lives on `social_post_drafts` (the active pipeline +
+  publish-due cron), NOT V1 `social_post_master` (retiring). Extend the approval backbone
+  to advance V2 state — the pattern already exists (Phase 1 advances batch
+  `approval_status`/`workflow_state` via `onGatePass`; generalise it).
+- **Versioning: introduce it for real.** No version chain exists today (recon finding 4 —
+  `draft_version` is just a CAS integer). Build a true version chain now.
+- Reuse the approval backbone (`social_approval_requests` etc.) — extend, don't fork
+  (recon: `post_master_id` is nullable; `record_approval_decision` no-ops post state when
+  null and only writes the event — so the proofing layer advances its OWN content state).
+- Magic links via Brief 1's service (`purpose='approval'`).
+
+## Step 1 — Migration: content versioning + proof linkage
+
+On `social_post_drafts` (the content unit), add a version chain:
+```
+content_group_id uuid    -- stable id shared across all versions of one content item
+version_number   int not null default 1
+supersedes_id    uuid references social_post_drafts(id)  -- prev version (null = v1)
+proof_state      text check (proof_state in
+  ('draft','in_review','changes_requested','in_revision','approved','published','archived'))
+```
+- Backfill: each existing draft = its own `content_group_id`, `version_number=1`.
+- "Revise" = create a NEW draft row: same `content_group_id`, `version_number+1`,
+  `supersedes_id` = the rejected version. The old row is archived, never mutated
+  (immutability of reviewed content — the PageProof discipline).
+- A "proof" = the approval request (reuse `social_approval_requests`, `subject_type` gets
+  a new value `'content_proof'`, `subject_id` = `content_group_id`).
+
+## Step 2 — Proof creation + invite
+
+- Create-proof action: takes a content draft (V2), opens a `social_approval_request`
+  (`subject_type='content_proof'`), adds recipients (internal + external), issues magic
+  links via Brief 1 for externals, sends the day-0 invite email (recon: this send is
+  currently MISSING from `createBatchApprovalRequest` — wire it here using the §7.1
+  content shape: version label, due-date-in-company-tz, reviewer role).
+- Content `proof_state` → `in_review`.
+
+## Step 3 — Client review queue (Gain front door — keep SIMPLE)
+
+- A queue screen the magic link lands on: list of items awaiting THIS reviewer's decision,
+  item opens the review screen. Batch-approve supported. This is the client's whole world
+  — do not expose projects/workspaces/workflow internals.
+- Reuse the existing batch-results review screen + carousel components and the
+  WorkflowStatusDrawer where they fit; reuse the existing sheet/drawer primitive.
+
+## Step 4 — Review screen (simple markup only)
+
+- Show the content (the review surface). V1 markup = general comments + simple region
+  pins on images. NO DOM selectors, NO video frame-level (Brief 3+).
+- Decisions: Approve / Request changes (comment REQUIRED on request-changes, per L17,
+  stored as `social_approval_events.comment_text`).
+- Request changes → content `proof_state='changes_requested'` → operator revises →
+  new version (Step 1) → re-review.
+
+## Step 5 — Approve → publish handoff
+
+- On approval (gate passes per the request's `approval_rule`), advance content
+  `proof_state='approved'`, then route to the V2 publish path: set draft
+  `state='scheduled'` with `scheduled_at` (apply the L16 edge cases — null→ready, past→now,
+  exists→no-op, disconnected→ready+alert). The publish-due cron does the rest.
+
+## Step 6 — Notifications (event-driven)
+
+- Emit structured events: proof_created, reviewer_invited, proof_viewed, comment_added,
+  decision_made, changes_requested, new_version, approved. Route via dispatch() + in-app.
+- Reuse Phase-2 reminder ladder; external reminders now work via Brief 1's regenerate.
+
+## Step 7 — Tests + verify
+Version chain (revise = new row, old archived, chain intact); proof create + invite email
+sends; external reviewer admits via magic link; approve→scheduled; request-changes→new
+version→re-review; comment-required. L18 Definition of Done.
+
+## Constraints
+V2 only. Extend approval backbone, don't fork. Immutable versions. Reuse Brief 1 magic
+links + dispatch() + existing UI primitives. Transactional, idempotent, preserve audit,
+RLS, mirror route conventions. Keep V1 SIMPLE — defer all complexity to Brief 3.
+
+## Report
+PRs, migration prod-verified, live verification steps, drift for Brief 3.

--- a/docs/proposals/BUILD_BRIEF_3_WORKFLOW_ENGINE.md
+++ b/docs/proposals/BUILD_BRIEF_3_WORKFLOW_ENGINE.md
@@ -1,0 +1,131 @@
+# Build Brief 3/3 — Workflow Engine + Versioning
+
+CONTRACT-DRIVEN AUTONOMOUS BUILD. Third of three. DEPENDS ON Briefs 1 + 2 (magic-link +
+core proofing). Build LAST, after both merged + verified. Update with their drift reports.
+This is the PageProof-depth engine — the most complex brief; expect it to span several PRs.
+
+> START WITH RECON: re-read docs/recon/PROOFING_RECON.md + Brief 1 & 2 drift reports.
+
+---
+
+## Goal
+
+Evolve the 3 fixed gates (copy_review / image_review / final_signoff) into a configurable
+**workflow engine**: ordered steps, each with reviewer-role semantics and thresholds, plus
+version comparison and exportable audit. Supersedes the fixed gates via a migration bridge
+— does NOT throw away what Briefs 1–2 and Phases 1–2 built.
+
+## Locked context
+
+- Pipeline: V2 (Brief 2). Versioning: the `content_group_id` / `version_number` /
+  `supersedes_id` chain from Brief 2 — extend it, don't duplicate.
+- Approval backbone: `social_approval_requests` (`approval_rule` any_one|all_must already
+  exists), `_recipients`, `_events`. `record_approval_decision` RPC drives it.
+- Roles today: flat approver list with all_must/any_one. This brief adds role semantics.
+
+## Step 1 — Migration: workflow steps + roles + gate bridge
+
+New `workflow_steps` (replaces the implicit 3-gate ordering):
+```
+id uuid pk; company_id uuid fk; workflow_template_id uuid (nullable for ad-hoc)
+step_order int not null
+name text not null              -- e.g. 'Internal review','Client sign-off'
+pass_rule text check (pass_rule in ('any_one','all_must','custom_count'))
+required_count int               -- when pass_rule='custom_count'
+blocking boolean not null default true
+created_at timestamptz default now()
+```
+New `workflow_step_participants`:
+```
+id uuid pk; step_id uuid fk
+platform_user_id uuid            -- null = external
+external_email text
+role text check (role in ('reviewer','mandatory_reviewer','gatekeeper','approver'))
+```
+**Gate → step migration bridge (critical, must be lossless):** for every company with
+`company_workflow_gates`, generate equivalent `workflow_steps` — copy_review/image_review/
+final_signoff become ordered steps, `pass_rule` carried over, approvers become
+participants with `role='approver'`. Keep `company_workflow_gates` readable during
+transition; the engine reads steps. State the cutover plan (dual-read then deprecate).
+
+## Step 2 — Role semantics in the state machine
+
+Extend the approval engine so a step passes per role rules (PageProof model):
+- ordinary `reviewer` — can comment/decide but does NOT block progression.
+- `mandatory_reviewer` — must decide before the step closes.
+- `gatekeeper` — can halt the workflow and send it back **ONE step only** (to the
+  immediately prior step), per B0 §5. CANNOT send to an arbitrary earlier step, CANNOT
+  send to the owner directly, CANNOT bypass mandatory reviewers. (This overrides any
+  broader "send back to a prior step / owner" phrasing.)
+- `approver` — final-step decision.
+- Step threshold: all_must / any_one / custom_count of the blocking participants.
+- Sequencing: step N opens only when N-1 closes; gatekeeper send-back reopens an earlier
+  step. Skipping: owner/inviter can skip a blocked non-mandatory participant.
+- All transitions transactional + idempotent; every transition appends an audit event.
+
+### Role-behaviour matrix (eliminates interaction ambiguity)
+
+| Role | Can comment | Can approve | Blocks step | Can send back |
+|------|-------------|-------------|-------------|---------------|
+| reviewer | yes | yes | NO | no |
+| mandatory_reviewer | yes | yes | yes | no |
+| gatekeeper | yes | yes | yes | yes (one step, B0 §5) |
+| approver | yes | yes | yes (final step) | no |
+
+Resolved interactions (build exactly this):
+- A `reviewer`'s decision is recorded but NEVER blocks step progression.
+- A step closes when its threshold (below) is met across its BLOCKING participants
+  (mandatory_reviewer / gatekeeper / approver). Non-blocking reviewers never hold a step.
+- A gatekeeper counts as a blocking participant AND can send back; both behaviours apply.
+- If a mandatory reviewer has not decided, the step CANNOT close regardless of others.
+
+### custom_count definition (eliminates the "count of whom" gap)
+
+`custom_count` + `required_count` means: **N approvals from the step's BLOCKING participants
+only** (mandatory_reviewer / gatekeeper / approver). Non-blocking reviewers do not count
+toward `required_count`. `required_count` must be ≤ the number of blocking participants
+(validate on config save).
+
+## Step 3 — Versioning depth
+
+- Version comparison: given two versions in a `content_group_id` chain, show what changed
+  (V1 = side-by-side; smart/diff is later).
+- New version re-entry is DETERMINISTIC per B0 §4 (this overrides any "chosen step"
+  phrasing): the new version re-enters **at the step that requested the change**, and
+  **skips participants who already approved the prior version**. Configurable re-entry is
+  explicitly DEFERRED — do not build a chooser.
+
+## Step 4 — Audit + dashboards
+
+- Append-only audit already exists (`social_approval_events`); add exportable audit view
+  (CSV) covering lifecycle: created, viewed, comment, decision, send-back, new-version,
+  approved, time-to-approval.
+- Role-aware operator dashboard: proofs across the team by state/step (recon: mirror the
+  existing company-page tab + batch-results patterns).
+
+## Step 5 — Config UI evolution
+
+- Evolve the Workflow tab (built Phase 1) from 3 fixed gate cards into a step builder:
+  add/reorder steps, per-step role assignment + threshold, per-participant access
+  (login/magic-link via Brief 1). The operator setup wireframe (master brief §7a Screen 2)
+  is the target.
+
+## Step 6 — Tests + verify
+Gate→step migration is lossless (existing configs reproduce identical behaviour);
+mandatory/gatekeeper/approver semantics; send-back reopens prior step; custom_count
+threshold; new-version skips prior approvers; audit export; dashboard. L18 Definition of
+Done.
+
+## Constraints
+Extend the approval backbone + Brief 2 versioning — one engine, no fork. Migration bridge
+must be lossless (no company loses its current gate behaviour). Transactional, idempotent,
+preserve audit, RLS, mirror conventions. This is the complex tier — phase the PRs
+(migration+bridge first; roles; versioning depth; audit/dashboard; config UI).
+
+## Deferred beyond this brief
+DAM (asset library, reuse, delivery), advanced markup (DOM selectors, video frame-level),
+SDK/webhooks, SSO/SCIM. Per master brief — after this.
+
+## Report
+PRs, migrations prod-verified, the lossless-bridge proof, live verification, and the
+final state of the proofing/workflow subsystem vs the master-brief vision.

--- a/docs/proposals/BUILD_BRIEF_4_CLIENT_PORTAL.md
+++ b/docs/proposals/BUILD_BRIEF_4_CLIENT_PORTAL.md
@@ -1,0 +1,138 @@
+# Build Brief 4 — Client Portal (Social Connections)
+
+CONTRACT-DRIVEN AUTONOMOUS BUILD. DEPENDS ON Brief 1 (magic-link service). Can be built
+after Brief 1 — does NOT depend on Briefs 2/3 (proofing). Separate surface from the
+proofing review queue. Execute end-to-end, one PR per logical change, migration-first.
+Follows Brief 0 §1–2 for magic-link/session behaviour.
+
+> START WITH RECON: re-read docs/recon/CONNECTIONS_CLIENT_ACCESS_RECON.md + Brief 1's
+> drift report. CRITICAL corrections from recon (the original brief assumed wrong):
+> - `platform_session_grants` (migration 0126) ALREADY EXISTS as the designed home for
+>   magic-link reconnect sessions — columns grant_type, scope_connection_id, token_hash,
+>   expires_at, second_factor_required. It's a schema stub with zero app code. BUILD ON
+>   IT — do NOT invent a new table.
+> - Connection model `social_connections` already has a status enum (healthy / degraded /
+>   auth_required / disconnected / pending_identity), `expires_at`, `last_validated_at`,
+>   and a DAILY health cron. Expiry tracking EXISTS.
+> - OAuth binding does NOT use a `state` param — it uses `company_id` in the redirect URL
+>   + session cookie, with `external_identity_hash` (lib/platform/social/connections/
+>   identity.ts) as the cross-tenant safeguard. Survive the round-trip via THAT mechanism.
+> - Public token surfaces /approve/[token], /viewer/[token], /invite/[token] exist —
+>   mirror their pattern for the portal route. No portal exists yet (confirmed new surface).
+
+---
+
+## What this is
+
+A **client-facing portal** (separate from the proofing review queue) where an external
+client — with NO Opollo account, admitted by magic link — can set up and reconnect their
+own social media connections. Two entry modes, two trigger sources:
+
+- **Portal mode**: "set up my accounts" — client lands on a page showing ALL their
+  company's connections + status (connected / expired / needs attention) and can
+  connect/reconnect any of them.
+- **Deep-link mode**: "reconnect this expired one" — link targets a single connection and
+  lands the client straight on that connection's reauth.
+
+Triggers:
+- **Manual**: admin clicks "request client to connect/reconnect" → sends the client a link.
+- **Automatic**: when a connection expires, the system sends the client a reconnect link.
+
+## Locked decisions (Brief 0 + this session)
+
+- Magic link via Brief 1 service, `purpose='reconnect'`. One-time link + same-day session
+  + self-serve re-request (Brief 0 §1–2).
+- Client portal is a SEPARATE surface from the proofing queue.
+- Client has no account; identity = magic-link → session, scoped to one company.
+
+## Step 1 — Connection health (mostly EXISTS — verify, don't rebuild)
+
+Recon: `social_connections` already has the status enum (healthy / degraded /
+auth_required / disconnected / pending_identity), `expires_at`, `last_validated_at`,
+`idx_connections_expires_at`, and a daily health cron. So expiry IS detectable today.
+- Do NOT add expiry columns — they exist.
+- The ONLY missing piece for auto-notify is the **pre-expiry warning cron route** (index
+  + column exist, route was never written). That's the single greenfield bit here (Step 5).
+
+## Step 2 — Magic-link reconnect plumbing (build on platform_session_grants)
+
+Recon: `platform_session_grants` (migration 0126) is the DESIGNED home — `grant_type`,
+`scope_connection_id`, `token_hash`, `expires_at`, `second_factor_required`. Stub with no
+app code. Wire it via Brief 1's magic-link service:
+- `issue` a `purpose='reconnect'` link backed by a `platform_session_grants` row.
+  `scope_connection_id` set = deep-link mode (one connection); null + company scope =
+  portal mode (all the company's connections).
+- The link lands on the client portal route, establishing the grant-backed session
+  (same-day per Brief 0 §2). Do NOT create a new grants/sessions table.
+
+## Step 3 — The client portal route + UI
+
+- A client-facing route (no platform chrome — this is the client's small world, like the
+  Gain front door). Admitted by the magic-link session.
+- **Portal view**: lists the company's connections with status badges (connected /
+  expired / needs attention), each with a Connect / Reconnect action.
+- **Deep-link view**: opens straight on the single targeted connection's reauth.
+- Reuse the existing connection-status UI components if any exist; match the design system.
+
+## Step 4 — OAuth round-trip identity (the fiddly part — use the EXISTING mechanism)
+
+When the client clicks Connect/Reconnect, the flow bounces to the provider and returns via
+OAuth callback. Recon: binding uses `company_id` in the redirect URL + session cookie,
+with `external_identity_hash` (lib/platform/social/connections/identity.ts) as the
+cross-tenant safeguard — NOT a `state` param. So:
+- Carry the magic-link grant + company context through the EXISTING redirect-URL +
+  cookie + identity-hash mechanism so the returning callback reattaches correctly. Do NOT
+  invent a `state`-param scheme parallel to what exists.
+- The existing callback must accept a client-portal-initiated flow and bind the resulting
+  connection to the correct company via the identity-hash fingerprint (honour the
+  cross-tenant leak fix — this is the safeguard).
+- On return, land the client back in the portal with the connection now showing connected.
+
+## Step 5 — Triggers
+
+- **Manual**: an admin action ("request client to connect") → issues the link + sends
+  email (dispatch() + a new template, brand shell). Admin picks portal vs specific
+  connection.
+- **Automatic on expiry**: a check (reuse the QStash/cron pattern — NOT a new cron system)
+  that detects expired/expiring connections and sends the client a reconnect link.
+  Idempotent (don't spam — one notice per stage per expiry, dedup like the reminder
+  ladder). Make this an EXPLICIT component — it is the "auto" half and won't exist unless
+  built.
+
+**Portal recipient (who gets the email — was unspecified):** a designated company contact.
+Add a `portal_contact_email` (or reuse an existing company-contact field if one exists —
+check first) on the company. The reconnect/connect emails go to that contact. If none set,
+fall back to the company's primary admin contact and flag to the Opollo operator that no
+client contact is configured.
+
+**Notification cadence (was unspecified — lock it):** pre-expiry warning at **7 days** and
+**1 day** before `expires_at`, and **on expiry** (status → auth_required/disconnected).
+One notice per stage, idempotent. Reuse the reminder-ladder dedup pattern.
+
+## Step 5a — Failure-state contract (define these — do not let the builder invent)
+
+| State | Behaviour |
+|-------|-----------|
+| Expired link | Show "link expired" + self-serve re-request (enter email → fresh link, B0 §1) |
+| Revoked link | Show "this link is no longer valid, contact your account manager" — no self-serve |
+| Connection deleted / no longer exists | Portal shows it as removed; deep-link falls back to portal view |
+| Company inactive | Block access, show a neutral "unavailable" page, alert Opollo operator |
+| OAuth failure / reconnect failed | Land back in portal, connection shows failed + "try again" |
+| Wrong-company attempt (security) | Hard refuse via identity-hash/RLS; never expose another company's data |
+
+## Step 6 — Tests + verify
+Manual request issues + sends link; expiry auto-detect fires once per expiry; client
+admits via link → portal lists connections with correct status; deep-link lands on the
+right connection; OAuth round-trip returns and binds to the correct company (NOT an
+operator, NOT cross-tenant); same-day session + re-request work. L18 Definition of Done.
+
+## Constraints
+Consume Brief 1's magic-link service — no second token system. Honour the existing
+cross-tenant OAuth binding fix. QStash-only for the expiry check. Client portal is its own
+surface, no operator chrome. Transactional, idempotent, preserve audit, RLS (the company
+binding is security-critical — a client must only ever touch their own company's
+connections), mirror route conventions.
+
+## Report
+PRs, migration prod-verified, live verification (esp. the OAuth round-trip binds to the
+right company), and any drift.

--- a/docs/proposals/MASTER_PROOFING_DAM_WORKFLOW_BRIEF.md
+++ b/docs/proposals/MASTER_PROOFING_DAM_WORKFLOW_BRIEF.md
@@ -1,0 +1,297 @@
+# Master Brief — Content Proofing, DAM & Workflow Subsystem
+
+> Status: LEAN MASTER DOC, updated with Gain.app / PageProof research findings. Captures
+> what is built, what is now decided post-research, and the questions that remain open.
+> Not a build brief — the single orientation document for this subsystem.
+>
+> **IMPLEMENTATION AUTHORITY: B0–B4 + the recon docs are the source of truth for building.
+> This document is STRATEGIC CONTEXT ONLY.** Where this doc and a build brief differ, the
+> brief wins. Specifically superseded here: reviewer identity (resolved in B0 — named
+> reviewer + magic link + same-day session, no account), the state machine (B2/B3 define
+> the real version-chain behaviour), and markup scope (B0 §6 — image + carousel only for
+> V1). Do not build from this document's older phrasing on those points.
+>
+> Supersedes as the entry point: APPROVAL_WORKFLOW_ENGINE_PROPOSAL, _SPEC, and
+> _FULL_BUILD_BRIEF (those remain valid for the parts already built; this doc frames the
+> whole).
+> Repo destination: `docs/proposals/MASTER_PROOFING_DAM_WORKFLOW_BRIEF.md`
+
+---
+
+## 1. What this subsystem is
+
+A **content proofing + approval + workflow** capability for the Opollo platform. It
+started as image-review approval but is now understood to be a general **proofing
+system** — the review / approve / request-changes / revise loop — applied across **every
+content type Opollo produces**: social posts, blog articles, landing pages, and anything
+else in the content process.
+
+It is a **major subsystem, not the platform backbone.** It is core infrastructure that
+other parts (social publishing, content/blogs, CAP) consume, but it sits alongside the
+platform's identity/company/auth core rather than being it.
+
+The reference models are **Gain.app** and **PageProof** — full proofing platforms with
+content review, multi-round approval, per-stakeholder workflows, and rich feedback/markup.
+We have built one corner of this (image review). The research phase defines the rest.
+
+---
+
+## 2. Current state — what is BUILT and LIVE (as of prod 11272bd8)
+
+This is real, deployed, and working. The research/redesign builds ON this, not instead of.
+
+**Phase 1 (live):**
+- 3 fixed gate types: `copy_review`, `image_review`, `final_signoff`. Per-company,
+  independently optional. (`company_workflow_gates` + `company_workflow_gate_approvers`.)
+- Pass-rules `all_must` / `any_one` per gate; `timeout_days`; `auto_schedule`.
+- Image-review gate intercepts the approval path: gate enabled → draft held in
+  `pending_image_review` and submitted to an approval request; gate disabled → straight
+  to schedule (prior behaviour).
+- Reject → rework → next round, capped at 3 rounds; round 3 reject → `escalated_to_admin`.
+- Batch delete / `resetApprovalToFresh` / batch watch, with full cascade semantics
+  (revoke tokens, cancel requests, preserve audit, cancel callbacks).
+- Carousel review UI (real account avatars, fixed action bar, comment-required on reject).
+- Reuses the existing social approval backbone (`social_approval_requests` + recipients +
+  snapshots + events); `subject_type`/`subject_id` added so one approval system serves all.
+
+**Phase 1 add-ons (live):**
+- Workflow gate config UI (company page → Workflow tab).
+- Vertical slide-out workflow status drawer (stages, status, responsible party; only
+  enabled gates shown; image stage wired to real state, copy/final are placeholders).
+
+**Phase 2 (live):**
+- Auto-schedule on gate pass via the V2 publish-due cron (no variants row needed).
+- Escalation ladder: QStash day-3/7/14 reminders + day-14 admin alert, idempotent, with
+  cancelled-request no-op guards. Reminder templates incl. day-14 loss-aversion (warn-only).
+
+**Locked decisions** (carry forward; full list in the _SPEC doc §2, L1–L18): client=company;
+gates optional; reject=whole-post; 3-round cap; pass-rules; magic-link OR login approvers;
+no default gate; auto-schedule default; escalation ladder; warn-only-never-delete;
+admin-configured-at-onboarding; admin batch delete; round-3=escalate-to-admin; one engine
+not two; transactional; idempotent; preserve audit; QStash-not-cron; extend-not-replace;
+generic-to-content-type.
+
+---
+
+## 3. Known gaps in the built system (must be resolved, research-informed)
+
+These surfaced in testing and are real holes for a client-facing product:
+
+1. **Magic links are not yet core infrastructure.** Raw tokens are stored hashed only, so
+   reminders/notifications can't reconstruct a link for external approvers. External-client
+   emails therefore can't fully send. → Needs a **platform magic-link service** (see §5).
+2. **No notification when an approver is added.** Adding an approver silently creates a
+   record; the person is never told. Should notify + confirm account on add.
+3. **No day-0 invite when content enters a gate.** The "please review" email is not sent
+   at gate entry. (Partially specced; blocked on the magic-link service for externals.)
+4. **Add-approver UX trap.** Typed-but-not-added email is lost on Save (should auto-commit
+   on Save).
+5. **Copy-review and final-signoff gates are config + placeholder only** — not wired to a
+   state machine yet (were Phase 3/4).
+6. **No feedback/markup loop.** Current actions are approve / reject / request-changes
+   (comment). There is NO rich per-content markup/annotation — the core of PageProof/Gain.
+
+---
+
+## 4. The strategic direction (now decided by the research)
+
+The review process must be **built into the core, not piecemeal.** Every content type
+flows through the same proofing/approval/feedback loop; building per-feature forces a
+painful retrofit.
+
+**The research conclusion that drives everything: a "Gain-like front door with a
+PageProof-like engine behind it."**
+- **Gain** = the frictionless client experience: email-first entry, one-time magic links,
+  a single low-friction approval queue, batch approvals, clear states, view-only public
+  preview separate from the authenticated approval path.
+- **PageProof** = the engine that scales: structured content-item → version → workflow →
+  step → role model, reviewer-role semantics (reviewer / mandatory / gatekeeper /
+  approver), versioning discipline (revise = new version, never mutate the approved
+  record), threshold logic, append-only audit, and integration/SDK extensibility.
+
+This validates the foundation already built (the approval backbone, gates, magic-link
+direction, audit preservation) and tells us how to evolve it. We do NOT rip out Phase
+1–2; we grow it toward this hybrid.
+
+**Three things this subsystem must become, beyond what's built:**
+- **General proofing across content types** (social, blog, landing page, any future
+  type) — not image-specific. The data model becomes content-item → version → polymorphic
+  "review surface" (file / PDF / Office doc / text doc / URL proof / HTML-email proof /
+  video / social preview).
+- **A real feedback/revision loop** — the single most important missing piece. Adopt
+  PageProof's pattern: reviewer requests changes → structured to-do list returns to the
+  owner → assigned to an editor → **new version uploaded** (workflow can reuse, switch, or
+  skip already-approved reviewers). Markup depth (pins, regions, frame-level, DOM
+  selectors) scales by content type and by release.
+- **DAM relationship (still open — see §6 Q1).** The research leans toward proofing as the
+  core engine with DAM as a connected versioning/delivery layer (content-versions +
+  integration delivery), rather than one fused system — but this is Steven's call to
+  confirm.
+
+**Reviewer role model (research-recommended, supersedes the flat approver list):** evolve
+from "approvers with all_must/any_one" toward PageProof's roles — ordinary reviewer
+(non-blocking), mandatory reviewer (blocks), gatekeeper (can halt + send back), approver
+(final step), plus owner/editor. For simple clients "reviewer + approver" suffices; the
+richer roles matter for regulated/multi-stakeholder work. Our existing all_must/any_one
+maps onto the step-threshold concept.
+
+**State machine (research-recommended, supersedes ad-hoc states):**
+Draft → In review → Changes requested → In revision → Ready for next step → Approved →
+Published/Delivered → Archived. (Gain's explicit states, which are cleaner than what we
+have.)
+
+---
+
+## 5. The magic-link service (its own brief, pending)
+
+Magic links are to be **core platform infrastructure**, not approval-only. Used for:
+login, content approvals, reconnecting social connections, and approver/reviewer access.
+A general service that issues, stores (re-sendable), validates, and revokes links for any
+purpose. This unblocks gaps §3.1–3.3. **To be scoped as its own brief** (deferred this
+session at Steven's direction — it's an auth surface, get it right). Likely a prerequisite
+for completing the external-client proofing path.
+
+---
+
+## 6. Settled by the research vs still open
+
+**SETTLED (lock these):**
+- **Hybrid model** — Gain front door + PageProof engine (§4).
+- **Roles** — evolve to reviewer / mandatory / gatekeeper / approver / owner / editor (§4).
+- **State machine** — adopt the Gain-derived states (§4).
+- **Magic links** — core infrastructure, one-time + expiry + re-requestable, named-reviewer
+  identity-bound; public share defaults to view-only (§5).
+- **Revision loop** — to-do list → editor → new version; never mutate the approved record.
+- **Content-type generality** — content-item → version → polymorphic review surface.
+- **Q3 (was open): fixed gates vs configurable workflow** — RESOLVED toward configurable
+  workflow steps + roles. BUT phased: the 3 built gates are a valid foundation; the
+  configurable engine is a later release (see roadmap). Don't rebuild yet.
+
+**STILL OPEN (Steven's call):**
+- **Q1 — DAM relationship.** Research leans "proofing core + DAM as connected versioning/
+  delivery layer" rather than one fused engine, but not mandated. CONFIRM.
+- **Q2 — Markup depth & sequencing.** The to-do/new-version loop is settled as the
+  mechanism; what's open is HOW MUCH markup richness (simple region pins → DOM selectors →
+  frame-level video) and in which release. Different content types need different markup.
+- **Q4 — DAM scope.** Versioning, asset states, reuse across posts, library/search UI,
+  retention — how much, how soon.
+- **Q5 — Workflow config home.** Confirmed: onboarding wizard first (backlogged, own
+  brief), editable on company page, viewable during production.
+- **Q6 — External reviewer identity.** Research recommends Gain-style named invitation +
+  auto-created lightweight account + magic link (attributable, low-friction). Confirm this
+  over magic-link-only.
+
+---
+
+## 6a. Research-recommended phased roadmap (maps onto our build)
+
+- **Foundation** (≈ what we have + the immediate fixes): workspaces/projects, content
+  items + versions, named external reviewer invitations, one-time magic links, client
+  approval queue, comments/annotations, core states, email/in-app notifications. → We're
+  here. Gaps §3 finish this.
+- **Workflow & governance**: workflow templates, mandatory/gatekeeper/approver roles,
+  thresholds, due dates, reminders, bulk approvals, version comparison, exportable audit,
+  role-aware dashboards. → This is the evolution of our gate model.
+- **Advanced proofing & enterprise**: website/HTML-email proofs, video time-coded
+  feedback, editor assignment, lock/unlock, private/invisible comments, DAM delivery,
+  webhooks, SDK/API, SSO/SCIM, branding. → Long-horizon; differentiates from a basic
+  review app.
+
+Notification architecture (research-recommended): event-driven, not page-driven. Every
+workflow event emits a structured event → channel adapters (in-app, email, push, Slack,
+Teams, webhooks). Our QStash + dispatch() foundation already fits this shape.
+
+---
+
+## 7. Build status & what NOT to do next
+
+- Do NOT build Phase 3/4 (copy gate, final gate, orchestrator) or the in-flight fixes
+  (add-button, approver-notify) until this subsystem is re-framed by the research — they
+  should be built into the core proofing model, not bolted onto the image-specific path.
+- The built Phase 1–2 system stays live; it works for the image-review case and is the
+  foundation.
+- Next concrete step: Steven's Gain.app / PageProof research → resolve §6 questions →
+  expand this master brief into the full subsystem architecture → then resume building
+  (magic-link service likely first, as the unlock).
+
+---
+
+## 7a. UI/UX — key screens (full-vision wireframes)
+
+These depict the FULL PageProof-depth vision (Steven's direction). Build order is still
+staged by the three briefs (§7b) — the workflow-engine screens below are release 3, not
+V1. Wireframes were rendered in the design session; reproduce their structure.
+
+**Screen 1 — Operator proof dashboard** (PageProof-style control centre):
+Inbox / Outbox / Sent / Approved / Everything tabs, search + filter, per-proof tiles
+showing a decision-summary pill (approved / changes / pending counts + current workflow
+step). New proof starts via a file-dropper (upload / cloud / URL / email depending on
+type).
+
+**Screen 2 — Operator proof setup + workflow** (rendered): sequential workflow steps,
+each with a reviewer role (reviewer / mandatory / gatekeeper / approver), per-step
+threshold (any_one / all_must), blocking vs non-blocking, and per-approver access
+(login vs magic-link). Proof name, version, due date, reminders, message, checklist.
+"Add step" + "Send proof". → This is release 3 (workflow engine); V1 uses the simpler
+3-gate config already built.
+
+**Screen 3 — Client reviewer proofing screen** (rendered): the content with red-pen
+markup tools (pin / box / freehand / highlight), numbered pins tied to a comment thread,
+decision-summary pill, and decision controls — Approve / Approve with changes / Send
+to-do list. The to-do list is the revision trigger: structured changes return to the
+owner → assigned to editor → new version. → Markup DEPTH is staged (V1 = simple comments/
+region pins; richer markup — DOM selectors, video frame-level — is later, see §6 Q2).
+
+**Screen 4 — Client approval queue** (Gain-style front door, V1-critical): the
+low-friction landing after the magic-link. A simple list/queue of items awaiting this
+client's decision, batch-approve supported, item detail opens the reviewer screen
+(Screen 3). This is the screen that must stay SIMPLE — it's the client's whole world.
+
+**Screen 5 — Workflow status drawer** (BUILT, live): vertical slide-out, stages stacked,
+per-stage status + responsible party. Already in production; evolves to reflect the
+richer role/step model as the engine grows.
+
+UX principle (from research): keep the CLIENT world small (Screen 4 + Screen 3 only);
+the OPERATOR world is broader (dashboard, setup, versions, audit). Don't make clients
+learn workspaces/projects before they can review.
+
+---
+
+## 7b. The three build briefs (recommended next, in order)
+
+Per external review — turn this orientation doc into three sequential build briefs;
+defer DAM and advanced markup until after V1:
+
+1. **Magic Link Infrastructure Brief** — the unlock. Core service: issue / store
+   (re-sendable) / validate / revoke, one-time + expiry, for login + approvals +
+   reconnect + reviewer access. Closes gaps §3.1–3.3. Build FIRST.
+2. **Core Proofing V1 Brief** — the simple journey: create proof → invite client →
+   magic link → review (simple comments / region pins) → approve / request changes →
+   revise → new version → approve. Gain-style queue + reviewer screen. Named reviewers,
+   core states, email/in-app notifications. KEEP SIMPLE.
+3. **Workflow Engine + Versioning Brief** — the PageProof depth: workflow templates,
+   mandatory / gatekeeper / approver roles, thresholds, step transitions, skipping,
+   reassignment, version comparison, audit export, role-aware dashboards. Supersedes the
+   3 fixed gates (with a migration bridge from gates → steps).
+
+DEFER until after V1: DAM (§6 Q1/Q4), advanced markup (DOM selectors, video frame-level),
+SDK/webhooks, SSO/SCIM.
+
+Each brief must add what this doc deliberately doesn't: exact schema (fields, relations,
+constraints, indexes, migrations, backward-compat), the gate→step migration bridge, the
+notification trigger matrix (events × recipients × channels × resend × failure), and
+per-screen component/empty-state/permission detail.
+
+---
+
+## 8. Document map (for whoever picks this up)
+
+- THIS DOC — master orientation, current state, open questions.
+- `APPROVAL_WORKFLOW_ENGINE_SPEC.md` — detailed spec of the approval engine as built/
+  designed (locked decisions L1–L18, state machine, batch-deletion §6.1, email §7.1).
+- `APPROVAL_WORKFLOW_FULL_BUILD_BRIEF.md` — the phased build brief (Phases 1–2 done,
+  3–4 pending and now subject to the research re-frame).
+- Onboarding wizard — backlogged, own brief (approvals is one step within it).
+- Magic-link service — to be scoped as build brief 1 (§7b).
+- Core Proofing V1 — build brief 2 (§7b).
+- Workflow Engine + Versioning — build brief 3 (§7b).


### PR DESCRIPTION
## Summary

- Adds `docs/proposals/AUDIT_INDEX.md` — index of all proposal docs in this folder
- Adds `docs/proposals/MASTER_PROOFING_DAM_WORKFLOW_BRIEF.md` — top-level brief covering the full proofing/DAM/workflow engine initiative
- Adds `docs/proposals/BUILD_BRIEF_0_PROOFING_UX_CONTRACT.md` — slice 0: proofing UX contract
- Adds `docs/proposals/BUILD_BRIEF_1_MAGIC_LINK.md` — slice 1: magic link (client access)
- Adds `docs/proposals/BUILD_BRIEF_2_CORE_PROOFING_V1.md` — slice 2: core proofing v1
- Adds `docs/proposals/BUILD_BRIEF_3_WORKFLOW_ENGINE.md` — slice 3: workflow engine
- Adds `docs/proposals/BUILD_BRIEF_4_CLIENT_PORTAL.md` — slice 4: client portal

Referenced recon files confirmed present:
- `docs/recon/PROOFING_RECON.md` ✓
- `docs/recon/CONNECTIONS_CLIENT_ACCESS_RECON.md` ✓

## Notes

Docs-only PR — no code changes, no migrations, no test coverage required.

## Pre-PR checklist

- [x] Lint, typecheck, build all green (docs-only, not applicable)
- [x] No code, no migration, no coverage requirement
- [x] PR is under 500 net lines OR exception stated (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)