### PR TITLE
feat(magic-link): b1 service lib, approval consumer wiring, login/reconnect stubs

### DIFF
--- a/app/api/platform/magic-link/login/route.ts
+++ b/app/api/platform/magic-link/login/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { sendEmail } from "@/lib/email/sendgrid";
+import { renderMagicLinkLoginEmail } from "@/lib/email/templates/magic-link-login";
+import { internalError, readJsonBody, validationError } from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { issue } from "@/lib/platform/magic-link";
+import { checkRateLimit, getClientIp, rateLimitExceeded } from "@/lib/rate-limit";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/magic-link/login
+//
+// Passwordless magic-link login issuance. Validates the email belongs to a
+// platform user, issues a magic_links row (purpose='login'), and sends a
+// sign-in email. Returns { ok: true } regardless of whether the email
+// matched a user (prevents enumeration). Rate-limited per email + IP.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Schema = z.object({
+  email: z.string().email(),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const ip = getClientIp(req);
+  const rl = await checkRateLimit("magic-link-login", ip);
+  if (!rl.ok) return rateLimitExceeded(rl);
+
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body is required.");
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Invalid request.", { issues: parsed.error.issues });
+  }
+
+  const email = parsed.data.email.toLowerCase().trim();
+
+  const svc = getServiceRoleClient();
+  const { data: user } = await svc
+    .from("platform_users")
+    .select("id")
+    .eq("email", email)
+    .maybeSingle();
+
+  if (!user) {
+    // Deliberately return ok to prevent email enumeration
+    return NextResponse.json({ ok: true }, { status: 200 });
+  }
+
+  let rawToken: string;
+  let link: { expires_at: string };
+  try {
+    const result = await issue({
+      purpose: "login",
+      subjectType: "user",
+      subjectId: user.id,
+      email,
+    });
+    rawToken = result.rawToken;
+    link = result.link;
+  } catch (err) {
+    logger.error("magic_link.login.issue_failed", { err: String(err) });
+    return internalError("Failed to issue login link.");
+  }
+
+  const origin = req.nextUrl.origin;
+  const loginUrl = `${origin}/magic-link/login?token=${rawToken}`;
+
+  try {
+    const { subject, html, text } = renderMagicLinkLoginEmail({
+      recipient_email: email,
+      login_url: loginUrl,
+      expires_at: link.expires_at,
+    });
+    await sendEmail({ to: email, subject, html, text });
+  } catch (err) {
+    logger.error("magic_link.login.email_failed", { err: String(err) });
+    return internalError("Failed to send login email.");
+  }
+
+  return NextResponse.json({ ok: true }, { status: 200 });
+}

--- a/app/api/platform/social/connections/magic-link-reconnect/route.ts
+++ b/app/api/platform/social/connections/magic-link-reconnect/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { internalError, readJsonBody, validationError } from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { issue } from "@/lib/platform/magic-link";
+import { checkRateLimit, getClientIp, rateLimitExceeded } from "@/lib/rate-limit";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/social/connections/magic-link-reconnect
+//
+// Issues a magic link for reconnecting a specific social connection.
+// Gate: editor+ (mirrors the interactive reconnect route permission).
+// Returns { ok: true, magicLinkUrl } — caller embeds this in a notification
+// or displays a "reconnect" button.
+//
+// The consumption route at /magic-link/reconnect validates + consumes the
+// link and redirects to the OAuth reconnect start for the connection.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Schema = z.object({
+  company_id: z.string().uuid(),
+  connection_id: z.string().uuid(),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const ip = getClientIp(req);
+  const rl = await checkRateLimit("magic-link-reconnect", ip);
+  if (!rl.ok) return rateLimitExceeded(rl);
+
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body is required.");
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Invalid request.", { issues: parsed.error.issues });
+  }
+
+  const { company_id, connection_id } = parsed.data;
+
+  const gate = await requireCanDoForApi(company_id, "reconnect_connection");
+  if (gate.kind === "deny") return gate.response;
+
+  const svc = getServiceRoleClient();
+
+  // Verify the connection belongs to this company and needs reconnect
+  const { data: connection, error: connErr } = await svc
+    .from("social_connections")
+    .select("id, status, company_id")
+    .eq("id", connection_id)
+    .eq("company_id", company_id)
+    .maybeSingle();
+
+  if (connErr || !connection) {
+    return validationError("Connection not found in this company.");
+  }
+  if (
+    connection.status !== "auth_required" &&
+    connection.status !== "disconnected"
+  ) {
+    return validationError(
+      "Connection does not require reconnect (status: " + connection.status + ").",
+    );
+  }
+
+  let rawToken: string;
+  try {
+    const result = await issue({
+      purpose: "reconnect",
+      subjectType: "social_connection",
+      subjectId: connection_id,
+      companyId: company_id,
+    });
+    rawToken = result.rawToken;
+  } catch (err) {
+    logger.error("magic_link.reconnect.issue_failed", { err: String(err) });
+    return internalError("Failed to issue reconnect link.");
+  }
+
+  const magicLinkUrl = `${req.nextUrl.origin}/magic-link/reconnect?token=${rawToken}`;
+
+  return NextResponse.json(
+    { ok: true, data: { magicLinkUrl }, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/app/approve/[token]/page.tsx
+++ b/app/approve/[token]/page.tsx
@@ -51,6 +51,9 @@ export default async function ApproveViewerPage({
 
   const resolved = await resolveRecipientByToken(token);
   if (!resolved.ok) {
+    if (resolved.error?.code === "SESSION_EXPIRED") {
+      return <SessionExpiredPanel />;
+    }
     return <InvalidLink />;
   }
 
@@ -192,6 +195,18 @@ function ExpiredPanel({ companyName }: { companyName: string }) {
       <p className="mt-3 text-muted-foreground">
         The approval window for this {companyName} post has expired.
         If you still need to review it, ask the team for a fresh link.
+      </p>
+    </main>
+  );
+}
+
+function SessionExpiredPanel() {
+  return (
+    <main className="mx-auto max-w-xl p-6 text-sm">
+      <h1 className="text-page-title text-foreground">Session expired</h1>
+      <p className="mt-3 text-muted-foreground">
+        Your review session has expired. Enter your email address to receive a
+        fresh link and continue your review.
       </p>
     </main>
   );

--- a/app/magic-link/login/route.ts
+++ b/app/magic-link/login/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { logger } from "@/lib/logger";
+import { consume } from "@/lib/platform/magic-link";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// GET /magic-link/login?token=<raw_token>
+//
+// Consumption route for passwordless login magic links.
+// Flow:
+//   1. Validate + consume the magic_links row.
+//   2. Generate a Supabase-native one-time login URL for the user
+//      (delegates session establishment to Supabase's /auth/v1/verify).
+//   3. Redirect to the Supabase action link, which goes through
+//      /auth/callback and establishes the session cookie.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const rawToken = req.nextUrl.searchParams.get("token") ?? "";
+
+  if (!rawToken || !/^[0-9a-f]{64}$/i.test(rawToken)) {
+    return NextResponse.redirect(
+      new URL("/login?error=invalid_link", req.nextUrl.origin),
+    );
+  }
+
+  // Consume the magic link (session TTL for login = 0; consumed_at is set
+  // but session_expires_at stays null since login creates a real Supabase session)
+  const result = await consume(rawToken);
+  if (!result.valid) {
+    logger.warn("magic_link.login.consume_failed", { reason: result.reason });
+    return NextResponse.redirect(
+      new URL(`/login?error=${result.reason}`, req.nextUrl.origin),
+    );
+  }
+
+  const link = result.link;
+  if (!link.email) {
+    logger.error("magic_link.login.no_email", { link_id: link.id });
+    return NextResponse.redirect(
+      new URL("/login?error=invalid_link", req.nextUrl.origin),
+    );
+  }
+
+  // Exchange our consumed magic link for a Supabase-native magic link.
+  // Supabase handles session cookie creation; we just redirect to the
+  // action_link it returns (which goes through /auth/v1/verify → /auth/callback).
+  const svc = getServiceRoleClient();
+  const { data: generated, error } =
+    await svc.auth.admin.generateLink({
+      type: "magiclink",
+      email: link.email,
+      options: {
+        redirectTo: `${req.nextUrl.origin}/company`,
+      },
+    });
+
+  if (error || !generated?.properties?.action_link) {
+    logger.error("magic_link.login.generate_link_failed", {
+      err: error?.message,
+    });
+    return NextResponse.redirect(
+      new URL("/login?error=session_error", req.nextUrl.origin),
+    );
+  }
+
+  return NextResponse.redirect(generated.properties.action_link);
+}

--- a/app/magic-link/reconnect/route.ts
+++ b/app/magic-link/reconnect/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { logger } from "@/lib/logger";
+import { consume } from "@/lib/platform/magic-link";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// GET /magic-link/reconnect?token=<raw_token>
+//
+// Consumption route for social-connection reconnect magic links.
+// Flow:
+//   1. Validate + consume the magic_links row.
+//   2. Look up the connection referenced by subject_id.
+//   3. Redirect to the interactive reconnect OAuth start
+//      (/api/platform/social/connections/reconnect) via a POST form or
+//      by redirecting to a page that triggers the OAuth popup.
+//
+// Note: the full reconnect OAuth requires an authenticated session (editor+).
+// If the requesting user has no session they will be redirected to login first
+// with ?next pointing back here. The B4 client-portal work extends this to
+// support sessionless clients.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const rawToken = req.nextUrl.searchParams.get("token") ?? "";
+
+  if (!rawToken || !/^[0-9a-f]{64}$/i.test(rawToken)) {
+    return NextResponse.redirect(
+      new URL("/login?error=invalid_link", req.nextUrl.origin),
+    );
+  }
+
+  const result = await consume(rawToken);
+  if (!result.valid) {
+    logger.warn("magic_link.reconnect.consume_failed", { reason: result.reason });
+    return NextResponse.redirect(
+      new URL(`/login?error=${result.reason}`, req.nextUrl.origin),
+    );
+  }
+
+  const link = result.link;
+  if (!link.subject_id || link.subject_type !== "social_connection") {
+    logger.error("magic_link.reconnect.invalid_subject", {
+      subject_type: link.subject_type,
+      link_id: link.id,
+    });
+    return NextResponse.redirect(
+      new URL("/login?error=invalid_link", req.nextUrl.origin),
+    );
+  }
+
+  // Look up the connection to surface the correct company context
+  const svc = getServiceRoleClient();
+  const { data: connection } = await svc
+    .from("social_connections")
+    .select("id, company_id")
+    .eq("id", link.subject_id)
+    .maybeSingle();
+
+  if (!connection) {
+    return NextResponse.redirect(
+      new URL("/login?error=invalid_link", req.nextUrl.origin),
+    );
+  }
+
+  // Redirect to the connections page for this company; the UI can
+  // surface the reconnect button for this specific connection.
+  // B4 will replace this with a sessionless client portal flow.
+  const connectionsUrl = new URL(
+    `/company/social/connections?reconnect=${link.subject_id}`,
+    req.nextUrl.origin,
+  );
+  return NextResponse.redirect(connectionsUrl);
+}

--- a/lib/__tests__/magic-link-service.test.ts
+++ b/lib/__tests__/magic-link-service.test.ts
@@ -1,0 +1,399 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  consume,
+  issue,
+  regenerate,
+  revoke,
+  validate,
+} from "@/lib/platform/magic-link";
+import { regenerateApprovalLink } from "@/lib/platform/magic-link";
+import { addRecipient } from "@/lib/platform/social/approvals/recipients/add";
+import { resolveRecipientByToken } from "@/lib/platform/social/approvals";
+
+// ---------------------------------------------------------------------------
+// Integration tests for the magic-link service (B1).
+// Runs against the real local Supabase instance.
+// ---------------------------------------------------------------------------
+
+const COMPANY_ID = "00001740-0000-0000-0000-000000000001";
+
+async function seedCompany(id: string) {
+  const svc = getServiceRoleClient();
+  await svc.from("platform_companies").upsert(
+    { id, name: "Magic Link Test Co", slug: `ml-test-${id.slice(-4)}` },
+    { onConflict: "id" },
+  );
+}
+
+async function seedApprovalRequest(companyId: string) {
+  const svc = getServiceRoleClient();
+  // Create a minimal post master row for the approval request
+  const { data: post } = await svc
+    .from("social_post_master")
+    .insert({
+      company_id: companyId,
+      master_text: "Magic link test post",
+      state: "pending_client_approval",
+    })
+    .select("id")
+    .single();
+  if (!post) throw new Error("Failed to seed post master");
+
+  const { data: req } = await svc
+    .from("social_approval_requests")
+    .insert({
+      company_id: companyId,
+      post_master_id: post.id,
+      approval_rule: "any_one",
+      expires_at: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString(),
+      snapshot_payload: { master_text: "Magic link test post" },
+    })
+    .select("id")
+    .single();
+  if (!req) throw new Error("Failed to seed approval request");
+  return { requestId: req.id, postId: post.id };
+}
+
+beforeAll(async () => {
+  await seedCompany(COMPANY_ID);
+});
+
+afterAll(async () => {
+  const svc = getServiceRoleClient();
+  await svc.from("magic_links").delete().eq("company_id", COMPANY_ID);
+  await svc.from("social_approval_recipients").delete().eq("email", "reviewer@ml-test.example.com");
+  await svc.from("social_approval_requests").delete().eq("company_id", COMPANY_ID);
+  await svc.from("social_post_master").delete().eq("company_id", COMPANY_ID);
+  await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
+});
+
+// ---------------------------------------------------------------------------
+// Core service
+// ---------------------------------------------------------------------------
+
+describe("issue", () => {
+  it("returns a 64-char hex raw token and stores only the hash", async () => {
+    const { rawToken, link } = await issue({
+      purpose: "approval",
+      companyId: COMPANY_ID,
+      email: "reviewer@ml-test.example.com",
+    });
+    expect(rawToken).toMatch(/^[0-9a-f]{64}$/i);
+    expect(link.token_hash).toHaveLength(64);
+    expect(link.token_hash).not.toBe(rawToken);
+    expect(link.consumed_at).toBeNull();
+    expect(link.revoked_at).toBeNull();
+    expect(link.session_expires_at).toBeNull();
+  });
+
+  it("respects custom ttlMs", async () => {
+    const before = Date.now();
+    const { link } = await issue({
+      purpose: "login",
+      ttlMs: 60_000, // 1 minute
+      email: "short-ttl@ml-test.example.com",
+    });
+    const expiresAt = new Date(link.expires_at).getTime();
+    expect(expiresAt).toBeGreaterThan(before + 55_000);
+    expect(expiresAt).toBeLessThan(before + 65_000);
+  });
+});
+
+describe("validate", () => {
+  it("returns valid for a fresh unused link", async () => {
+    const { rawToken } = await issue({
+      purpose: "approval",
+      companyId: COMPANY_ID,
+      email: "v@ml-test.example.com",
+    });
+    const r = await validate(rawToken);
+    expect(r.valid).toBe(true);
+    if (r.valid) expect(r.sessionActive).toBe(false);
+  });
+
+  it("returns not_found for an unknown token", async () => {
+    const r = await validate("a".repeat(64));
+    expect(r).toMatchObject({ valid: false, reason: "not_found" });
+  });
+
+  it("returns revoked for a revoked link", async () => {
+    const { rawToken, link } = await issue({
+      purpose: "approval",
+      companyId: COMPANY_ID,
+      email: "revoke-validate@ml-test.example.com",
+    });
+    await revoke({ linkId: link.id });
+    const r = await validate(rawToken);
+    expect(r).toMatchObject({ valid: false, reason: "revoked" });
+  });
+
+  it("returns expired for a link past expires_at", async () => {
+    const { rawToken, link } = await issue({
+      purpose: "approval",
+      ttlMs: -1000, // immediately expired
+      companyId: COMPANY_ID,
+      email: "expired@ml-test.example.com",
+    });
+    // Force the expires_at to be in the past
+    const svc = getServiceRoleClient();
+    await svc
+      .from("magic_links")
+      .update({ expires_at: new Date(Date.now() - 5000).toISOString() })
+      .eq("id", link.id);
+    const r = await validate(rawToken);
+    expect(r).toMatchObject({ valid: false, reason: "expired" });
+  });
+});
+
+describe("consume", () => {
+  it("first click sets consumed_at and session_expires_at", async () => {
+    const { rawToken, link: issued } = await issue({
+      purpose: "approval",
+      companyId: COMPANY_ID,
+      email: "consume1@ml-test.example.com",
+    });
+    const before = Date.now();
+    const r = await consume(rawToken);
+    expect(r.valid).toBe(true);
+    if (!r.valid) return;
+    expect(r.isNewConsumption).toBe(true);
+    expect(r.link.consumed_at).not.toBeNull();
+    expect(r.link.session_expires_at).not.toBeNull();
+    const sessionExpiry = new Date(r.link.session_expires_at!).getTime();
+    // session should be ~23h from now
+    expect(sessionExpiry).toBeGreaterThan(before + 22 * 60 * 60 * 1000);
+    expect(sessionExpiry).toBeLessThan(before + 24 * 60 * 60 * 1000);
+  });
+
+  it("second consume within session returns isNewConsumption=false", async () => {
+    const { rawToken } = await issue({
+      purpose: "approval",
+      companyId: COMPANY_ID,
+      email: "consume2@ml-test.example.com",
+    });
+    await consume(rawToken);
+    const r = await consume(rawToken);
+    expect(r.valid).toBe(true);
+    if (r.valid) expect(r.isNewConsumption).toBe(false);
+  });
+
+  it("returns session_expired after session_expires_at has passed", async () => {
+    const { rawToken, link } = await issue({
+      purpose: "approval",
+      companyId: COMPANY_ID,
+      email: "session-expired@ml-test.example.com",
+    });
+    // Consume + immediately expire the session
+    await consume(rawToken);
+    const svc = getServiceRoleClient();
+    await svc
+      .from("magic_links")
+      .update({ session_expires_at: new Date(Date.now() - 5000).toISOString() })
+      .eq("id", link.id);
+    const r = await consume(rawToken);
+    expect(r).toMatchObject({ valid: false, reason: "session_expired" });
+  });
+
+  it("login purpose: consumed_at set but session_expires_at is null", async () => {
+    const { rawToken } = await issue({
+      purpose: "login",
+      email: "login-consume@ml-test.example.com",
+    });
+    const r = await consume(rawToken);
+    expect(r.valid).toBe(true);
+    if (!r.valid) return;
+    expect(r.link.consumed_at).not.toBeNull();
+    expect(r.link.session_expires_at).toBeNull();
+  });
+});
+
+describe("revoke", () => {
+  it("revoke by linkId marks revoked_at", async () => {
+    const { rawToken, link } = await issue({
+      purpose: "approval",
+      companyId: COMPANY_ID,
+      email: "revoke-by-id@ml-test.example.com",
+    });
+    const { ok, count } = await revoke({ linkId: link.id });
+    expect(ok).toBe(true);
+    expect(count).toBe(1);
+    const r = await validate(rawToken);
+    expect(r).toMatchObject({ valid: false, reason: "revoked" });
+  });
+
+  it("revoke by subject revokes all active links for that subject", async () => {
+    const subjectId = "00001740-0000-0000-0000-000000000099";
+    const { rawToken: t1 } = await issue({
+      purpose: "approval",
+      subjectType: "approval_recipient",
+      subjectId,
+      companyId: COMPANY_ID,
+      email: "revoke-subj-a@ml-test.example.com",
+    });
+    const { rawToken: t2 } = await issue({
+      purpose: "approval",
+      subjectType: "approval_recipient",
+      subjectId,
+      companyId: COMPANY_ID,
+      email: "revoke-subj-b@ml-test.example.com",
+    });
+    const { count } = await revoke({ subjectType: "approval_recipient", subjectId });
+    expect(count).toBe(2);
+    expect((await validate(t1)).valid).toBe(false);
+    expect((await validate(t2)).valid).toBe(false);
+  });
+
+  it("is idempotent — revoking an already-revoked link returns count=0", async () => {
+    const { link } = await issue({
+      purpose: "approval",
+      companyId: COMPANY_ID,
+      email: "idempotent-revoke@ml-test.example.com",
+    });
+    await revoke({ linkId: link.id });
+    const { ok, count } = await revoke({ linkId: link.id });
+    expect(ok).toBe(true);
+    expect(count).toBe(0);
+  });
+});
+
+describe("regenerate", () => {
+  it("revokes old link and issues a new one with regenerated_from set", async () => {
+    const { rawToken: old, link: oldLink } = await issue({
+      purpose: "approval",
+      companyId: COMPANY_ID,
+      email: "regen@ml-test.example.com",
+    });
+    const { rawToken: fresh, link: freshLink } = await regenerate(oldLink.id);
+
+    expect(fresh).not.toBe(old);
+    expect(freshLink.regenerated_from).toBe(oldLink.id);
+    // Old token is revoked
+    expect((await validate(old)).valid).toBe(false);
+    // New token is valid
+    expect((await validate(fresh)).valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Approval consumer wiring
+// ---------------------------------------------------------------------------
+
+describe("addRecipient (B1 upgrade)", () => {
+  it("creates a magic_links row, sets magic_link_id FK, and dual-writes token_hash", async () => {
+    const { requestId } = await seedApprovalRequest(COMPANY_ID);
+    const svc = getServiceRoleClient();
+
+    const result = await addRecipient({
+      approvalRequestId: requestId,
+      companyId: COMPANY_ID,
+      email: "wired-reviewer@ml-test.example.com",
+      name: "Test Reviewer",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const { recipient, rawToken } = result.data;
+
+    // Recipient has magic_link_id set
+    const { data: recipientRow } = await svc
+      .from("social_approval_recipients")
+      .select("magic_link_id, token_hash")
+      .eq("id", recipient.id)
+      .single();
+    expect(recipientRow?.magic_link_id).not.toBeNull();
+
+    // magic_links row exists
+    const { data: ml } = await svc
+      .from("magic_links")
+      .select("id, token_hash, subject_id")
+      .eq("id", recipientRow!.magic_link_id!)
+      .single();
+    expect(ml).not.toBeNull();
+    expect(ml?.subject_id).toBe(recipient.id);
+
+    // Dual write: token_hash on recipient matches magic_links row
+    expect(recipientRow?.token_hash).toBe(ml?.token_hash);
+
+    // Raw token validates
+    expect((await validate(rawToken)).valid).toBe(true);
+  });
+});
+
+describe("resolveRecipientByToken (service-aware lookup)", () => {
+  it("resolves a new-style token via magic_links (consumes on first access)", async () => {
+    const { requestId } = await seedApprovalRequest(COMPANY_ID);
+    const addResult = await addRecipient({
+      approvalRequestId: requestId,
+      companyId: COMPANY_ID,
+      email: "resolve-new@ml-test.example.com",
+      name: "Resolve Test",
+    });
+    expect(addResult.ok).toBe(true);
+    if (!addResult.ok) return;
+
+    const resolved = await resolveRecipientByToken(addResult.data.rawToken);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.data.recipient.email).toBe("resolve-new@ml-test.example.com");
+
+    // Second resolve within session should also succeed
+    const resolved2 = await resolveRecipientByToken(addResult.data.rawToken);
+    expect(resolved2.ok).toBe(true);
+  });
+
+  it("resolves a legacy token (no magic_links row) via fallback", async () => {
+    // Insert a recipient directly with a raw token hash but NO magic_link_id
+    const svc = getServiceRoleClient();
+    const { requestId } = await seedApprovalRequest(COMPANY_ID);
+    const { generateRawToken, hashToken } = await import("@/lib/platform/invitations");
+    const legacyRaw = generateRawToken();
+    const legacyHash = hashToken(legacyRaw);
+
+    await svc.from("social_approval_recipients").insert({
+      approval_request_id: requestId,
+      email: "legacy@ml-test.example.com",
+      token_hash: legacyHash,
+      // magic_link_id intentionally null (legacy row)
+    });
+
+    const resolved = await resolveRecipientByToken(legacyRaw);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.data.recipient.email).toBe("legacy@ml-test.example.com");
+  });
+});
+
+describe("back-compat HARD RULE: magic_links row present → verdict is final", () => {
+  it("an expired magic_links row is NOT resolvable even if token_hash still on recipient", async () => {
+    const { requestId } = await seedApprovalRequest(COMPANY_ID);
+    const addResult = await addRecipient({
+      approvalRequestId: requestId,
+      companyId: COMPANY_ID,
+      email: "expired-ml@ml-test.example.com",
+    });
+    expect(addResult.ok).toBe(true);
+    if (!addResult.ok) return;
+
+    // Expire the magic link
+    const svc = getServiceRoleClient();
+    const { data: rec } = await svc
+      .from("social_approval_recipients")
+      .select("magic_link_id")
+      .eq("email", "expired-ml@ml-test.example.com")
+      .single();
+    await svc
+      .from("magic_links")
+      .update({ expires_at: new Date(Date.now() - 5000).toISOString() })
+      .eq("id", rec!.magic_link_id!);
+
+    // Must NOT fall through to the legacy 14-day token_hash lookup
+    const resolved = await resolveRecipientByToken(addResult.data.rawToken);
+    expect(resolved.ok).toBe(false);
+    // The token_hash is still on social_approval_recipients but the verdict is expired
+    if (!resolved.ok) {
+      expect(resolved.error.code).not.toBe(undefined);
+    }
+  });
+});

--- a/lib/email/templates/magic-link-login.ts
+++ b/lib/email/templates/magic-link-login.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import { escapeHtml, renderBaseEmail } from "./base";
+
+export interface MagicLinkLoginEmailInput {
+  recipient_email: string;
+  login_url: string;
+  expires_at: string;
+}
+
+export function renderMagicLinkLoginEmail(
+  input: MagicLinkLoginEmailInput,
+): { subject: string; html: string; text: string } {
+  const subject = "Your Opollo sign-in link";
+  const expiresLocal = new Date(input.expires_at).toLocaleString("en-AU", {
+    weekday: "short",
+    day: "numeric",
+    month: "long",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+  });
+
+  const bodyHtml = `
+    <p style="margin:0 0 12px 0;font-size:14px;line-height:1.5;color:#0f172a;">
+      Click the button below to sign in to Opollo. This link can only be
+      used once and expires on <strong>${escapeHtml(expiresLocal)}</strong>.
+    </p>
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:16px 0;">
+      <tr>
+        <td style="border-radius:6px;background-color:#16a34a;">
+          <a href="${escapeHtml(input.login_url)}" style="display:inline-block;padding:12px 24px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">
+            Sign in to Opollo
+          </a>
+        </td>
+      </tr>
+    </table>
+    <p style="margin:0;font-size:12px;line-height:1.5;color:#64748b;">
+      If you didn't request this link, you can safely ignore this email.
+      Your account is not at risk.
+    </p>
+  `;
+
+  const textBody = [
+    `Sign in to Opollo`,
+    ``,
+    `Click the link below to sign in. This link expires on ${expiresLocal}.`,
+    ``,
+    input.login_url,
+    ``,
+    `If you didn't request this, ignore this email.`,
+  ].join("\n");
+
+  const { html, text } = renderBaseEmail({
+    heading: subject,
+    bodyHtml,
+    bodyText: textBody,
+    footerNote: "Sent automatically by Opollo.",
+  });
+
+  return { subject, html, text };
+}

--- a/lib/platform/magic-link/__tests__/magic-link.unit.test.ts
+++ b/lib/platform/magic-link/__tests__/magic-link.unit.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import type { ConsumeResult, MagicLink, ValidateResult } from "../types";
+import { LINK_TTL_MS, SESSION_TTL_MS } from "../types";
+
+// ---------------------------------------------------------------------------
+// Unit tests for the magic-link state machine. No DB required.
+// Tests the TTL constants and result-type exhaustiveness.
+// ---------------------------------------------------------------------------
+
+describe("LINK_TTL_MS / SESSION_TTL_MS constants", () => {
+  it("approval link TTL is 24h", () => {
+    expect(LINK_TTL_MS.approval).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("approval session TTL is 23h (same-day, ≤24h)", () => {
+    expect(SESSION_TTL_MS.approval).toBe(23 * 60 * 60 * 1000);
+  });
+
+  it("login link TTL is 15 minutes", () => {
+    expect(LINK_TTL_MS.login).toBe(15 * 60 * 1000);
+  });
+
+  it("login session TTL is 0 (delegates to Supabase session)", () => {
+    expect(SESSION_TTL_MS.login).toBe(0);
+  });
+
+  it("reconnect session TTL is 2h", () => {
+    expect(SESSION_TTL_MS.reconnect).toBe(2 * 60 * 60 * 1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State-machine logic: simulate the validate / consume conditions
+// without hitting the database. These verify the INTENDED behaviour
+// of the service functions; the integration tests verify the DB writes.
+// ---------------------------------------------------------------------------
+
+function makeMagicLink(
+  overrides: Partial<MagicLink> = {},
+): MagicLink {
+  const base: MagicLink = {
+    id: "00000000-0000-0000-0000-000000000001",
+    purpose: "approval",
+    token_hash: "a".repeat(64),
+    subject_type: "approval_recipient",
+    subject_id: "00000000-0000-0000-0000-000000000002",
+    company_id: "00000000-0000-0000-0000-000000000003",
+    email: "reviewer@example.com",
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    consumed_at: null,
+    session_expires_at: null,
+    revoked_at: null,
+    regenerated_from: null,
+    created_at: new Date().toISOString(),
+  };
+  return { ...base, ...overrides };
+}
+
+function applyValidateLogic(link: MagicLink, now = Date.now()): ValidateResult {
+  if (link.revoked_at) return { valid: false, reason: "revoked" };
+
+  if (link.consumed_at) {
+    const sessionOk =
+      link.session_expires_at &&
+      new Date(link.session_expires_at).getTime() > now;
+    if (!sessionOk) return { valid: false, reason: "session_expired" };
+    return { valid: true, link, sessionActive: true };
+  }
+
+  if (new Date(link.expires_at).getTime() <= now) {
+    return { valid: false, reason: "expired" };
+  }
+
+  return { valid: true, link, sessionActive: false };
+}
+
+describe("validate logic — state machine", () => {
+  it("valid: unconsumed + not expired", () => {
+    const link = makeMagicLink();
+    const r = applyValidateLogic(link);
+    expect(r.valid).toBe(true);
+    if (r.valid) expect(r.sessionActive).toBe(false);
+  });
+
+  it("invalid: revoked_at set", () => {
+    const link = makeMagicLink({ revoked_at: new Date().toISOString() });
+    expect(applyValidateLogic(link)).toMatchObject({ valid: false, reason: "revoked" });
+  });
+
+  it("invalid: expires_at in the past (never consumed)", () => {
+    const link = makeMagicLink({
+      expires_at: new Date(Date.now() - 1000).toISOString(),
+    });
+    expect(applyValidateLogic(link)).toMatchObject({ valid: false, reason: "expired" });
+  });
+
+  it("valid: consumed + active session", () => {
+    const now = Date.now();
+    const link = makeMagicLink({
+      consumed_at: new Date(now - 1000).toISOString(),
+      session_expires_at: new Date(now + 60_000).toISOString(),
+    });
+    const r = applyValidateLogic(link, now);
+    expect(r.valid).toBe(true);
+    if (r.valid) expect(r.sessionActive).toBe(true);
+  });
+
+  it("invalid: consumed + session expired", () => {
+    const now = Date.now();
+    const link = makeMagicLink({
+      consumed_at: new Date(now - 2000).toISOString(),
+      session_expires_at: new Date(now - 1000).toISOString(),
+    });
+    expect(applyValidateLogic(link, now)).toMatchObject({
+      valid: false,
+      reason: "session_expired",
+    });
+  });
+
+  it("invalid: consumed + session_expires_at is null (login purpose)", () => {
+    const now = Date.now();
+    const link = makeMagicLink({
+      purpose: "login",
+      consumed_at: new Date(now - 1000).toISOString(),
+      session_expires_at: null,
+    });
+    expect(applyValidateLogic(link, now)).toMatchObject({
+      valid: false,
+      reason: "session_expired",
+    });
+  });
+});

--- a/lib/platform/magic-link/approval.ts
+++ b/lib/platform/magic-link/approval.ts
@@ -1,0 +1,88 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { hashToken } from "@/lib/platform/invitations";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { issue, regenerate } from "./service";
+import type { IssueResult } from "./types";
+
+// ---------------------------------------------------------------------------
+// regenerateApprovalLink — the resend primitive that was missing.
+//
+// Recon finding 5: raw tokens are discarded after creation, so Phase-2
+// external-approver reminders (approval-callbacks.ts) could not send a
+// fresh working link. After B1 this is the fix: call this to get a fresh
+// raw token for reminder emails.
+//
+// Flow:
+//   1. If the recipient has a magic_link_id → regenerate from that link
+//      (revokes old, issues new with regenerated_from chain).
+//   2. If the recipient has no magic_link_id (legacy row) → issue a brand-
+//      new link and back-fill both token_hash and magic_link_id.
+// ---------------------------------------------------------------------------
+export async function regenerateApprovalLink(
+  recipientId: string,
+): Promise<IssueResult & { email: string }> {
+  const svc = getServiceRoleClient();
+
+  const { data: recipient, error: recipientErr } = await svc
+    .from("social_approval_recipients")
+    .select("id, approval_request_id, email, magic_link_id")
+    .eq("id", recipientId)
+    .maybeSingle();
+
+  if (recipientErr || !recipient) {
+    throw new Error(`Recipient not found: ${recipientId}`);
+  }
+
+  const rec = recipient as {
+    id: string;
+    approval_request_id: string;
+    email: string;
+    magic_link_id: string | null;
+  };
+
+  let result: IssueResult;
+
+  if (rec.magic_link_id) {
+    result = await regenerate(rec.magic_link_id);
+  } else {
+    // Legacy recipient without a magic_links row — issue fresh and back-fill
+    const { data: req } = await svc
+      .from("social_approval_requests")
+      .select("company_id")
+      .eq("id", rec.approval_request_id)
+      .maybeSingle();
+
+    result = await issue({
+      purpose: "approval",
+      subjectType: "approval_recipient",
+      subjectId: rec.id,
+      companyId: req?.company_id ?? undefined,
+      email: rec.email,
+    });
+  }
+
+  // Back-fill: keep social_approval_recipients.token_hash in sync (dual write)
+  // and update the FK to the new link.
+  const { error: updateErr } = await svc
+    .from("social_approval_recipients")
+    .update({
+      token_hash: result.link.token_hash,
+      magic_link_id: result.link.id,
+    })
+    .eq("id", rec.id);
+
+  if (updateErr) {
+    logger.error("magic_link.approval.regenerate.update_failed", {
+      err: updateErr.message,
+      recipient_id: rec.id,
+    });
+    throw new Error(
+      `Failed to update recipient after regenerate: ${updateErr.message}`,
+    );
+  }
+
+  return { ...result, email: rec.email };
+}

--- a/lib/platform/magic-link/index.ts
+++ b/lib/platform/magic-link/index.ts
@@ -1,0 +1,11 @@
+export { issue, validate, consume, revoke, regenerate, hashToken } from "./service";
+export { regenerateApprovalLink } from "./approval";
+export { LINK_TTL_MS, SESSION_TTL_MS } from "./types";
+export type {
+  MagicLink,
+  MagicLinkPurpose,
+  IssueInput,
+  IssueResult,
+  ValidateResult,
+  ConsumeResult,
+} from "./types";

--- a/lib/platform/magic-link/service.ts
+++ b/lib/platform/magic-link/service.ts
@@ -1,0 +1,285 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { generateRawToken, hashToken } from "@/lib/platform/invitations";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import type {
+  ConsumeResult,
+  IssueInput,
+  IssueResult,
+  MagicLink,
+  MagicLinkPurpose,
+  ValidateResult,
+} from "./types";
+import { LINK_TTL_MS, SESSION_TTL_MS } from "./types";
+
+// ---------------------------------------------------------------------------
+// issue — create a new magic link row, return the raw token once.
+// Caller is responsible for embedding the raw token in the email and
+// never storing it; only the SHA-256 hash lands in the DB.
+// ---------------------------------------------------------------------------
+export async function issue(input: IssueInput): Promise<IssueResult> {
+  const rawToken = generateRawToken();
+  const tokenHash = hashToken(rawToken);
+  const ttl = input.ttlMs ?? LINK_TTL_MS[input.purpose];
+  const expiresAt = new Date(Date.now() + ttl).toISOString();
+
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("magic_links")
+    .insert({
+      purpose: input.purpose,
+      token_hash: tokenHash,
+      subject_type: input.subjectType ?? null,
+      subject_id: input.subjectId ?? null,
+      company_id: input.companyId ?? null,
+      email: input.email ?? null,
+      expires_at: expiresAt,
+    })
+    .select("*")
+    .single();
+
+  if (error || !data) {
+    logger.error("magic_link.issue.failed", {
+      err: error?.message,
+      purpose: input.purpose,
+    });
+    throw new Error(`Failed to issue magic link: ${error?.message}`);
+  }
+
+  return { rawToken, link: data as MagicLink };
+}
+
+// ---------------------------------------------------------------------------
+// validate — read-only session-aware check. Does NOT consume.
+// Used by the decision API to confirm the session is still active before
+// recording a decision (the page's consume() already ran on page-load).
+// ---------------------------------------------------------------------------
+export async function validate(rawToken: string): Promise<ValidateResult> {
+  if (!rawToken || !/^[0-9a-f]{64}$/i.test(rawToken)) {
+    return { valid: false, reason: "not_found" };
+  }
+
+  const tokenHash = hashToken(rawToken);
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("magic_links")
+    .select("*")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+
+  if (error) {
+    logger.error("magic_link.validate.lookup_failed", { err: error.message });
+    return { valid: false, reason: "not_found" };
+  }
+  if (!data) return { valid: false, reason: "not_found" };
+
+  const link = data as MagicLink;
+  if (link.revoked_at) return { valid: false, reason: "revoked" };
+
+  const now = Date.now();
+
+  if (link.consumed_at) {
+    const sessionOk =
+      link.session_expires_at &&
+      new Date(link.session_expires_at).getTime() > now;
+    if (!sessionOk) return { valid: false, reason: "session_expired" };
+    return { valid: true, link, sessionActive: true };
+  }
+
+  if (new Date(link.expires_at).getTime() <= now) {
+    return { valid: false, reason: "expired" };
+  }
+
+  return { valid: true, link, sessionActive: false };
+}
+
+// ---------------------------------------------------------------------------
+// consume — first click establishes the session (sets consumed_at +
+// session_expires_at). Idempotent within the session window: a reviewer
+// who returns the same day gets { isNewConsumption: false } without
+// error. Concurrent first-clicks are race-safe via the IS NULL guard.
+// ---------------------------------------------------------------------------
+export async function consume(rawToken: string): Promise<ConsumeResult> {
+  if (!rawToken || !/^[0-9a-f]{64}$/i.test(rawToken)) {
+    return { valid: false, reason: "not_found" };
+  }
+
+  const tokenHash = hashToken(rawToken);
+  const svc = getServiceRoleClient();
+
+  const { data: existing, error: lookupErr } = await svc
+    .from("magic_links")
+    .select("*")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+
+  if (lookupErr) {
+    logger.error("magic_link.consume.lookup_failed", { err: lookupErr.message });
+    return { valid: false, reason: "not_found" };
+  }
+  if (!existing) return { valid: false, reason: "not_found" };
+
+  const link = existing as MagicLink;
+  if (link.revoked_at) return { valid: false, reason: "revoked" };
+
+  const now = Date.now();
+
+  // Already consumed — validate the session is still active (idempotent return)
+  if (link.consumed_at) {
+    const sessionOk =
+      link.session_expires_at &&
+      new Date(link.session_expires_at).getTime() > now;
+    if (!sessionOk) return { valid: false, reason: "session_expired" };
+    return { valid: true, link, isNewConsumption: false };
+  }
+
+  // Link expired before first click
+  if (new Date(link.expires_at).getTime() <= now) {
+    return { valid: false, reason: "expired" };
+  }
+
+  // First click: atomically consume with race guard (IS NULL check)
+  const sessionTtl =
+    SESSION_TTL_MS[link.purpose as MagicLinkPurpose] ?? 0;
+  const consumedAt = new Date().toISOString();
+  const sessionExpiresAt =
+    sessionTtl > 0 ? new Date(now + sessionTtl).toISOString() : null;
+
+  const { data: updated, error: updateErr } = await svc
+    .from("magic_links")
+    .update({ consumed_at: consumedAt, session_expires_at: sessionExpiresAt })
+    .eq("id", link.id)
+    .is("consumed_at", null)
+    .select("*")
+    .maybeSingle();
+
+  if (updateErr) {
+    logger.error("magic_link.consume.update_failed", { err: updateErr.message });
+    return { valid: false, reason: "not_found" };
+  }
+
+  if (!updated) {
+    // Race: concurrent request consumed first — re-fetch and return session state
+    const { data: raced } = await svc
+      .from("magic_links")
+      .select("*")
+      .eq("id", link.id)
+      .single();
+    if (!raced) return { valid: false, reason: "not_found" };
+    const racedLink = raced as MagicLink;
+    const sessionOk =
+      racedLink.session_expires_at &&
+      new Date(racedLink.session_expires_at).getTime() > now;
+    if (!sessionOk) return { valid: false, reason: "session_expired" };
+    return { valid: true, link: racedLink, isNewConsumption: false };
+  }
+
+  return { valid: true, link: updated as MagicLink, isNewConsumption: true };
+}
+
+// ---------------------------------------------------------------------------
+// revoke — invalidate by link id or by subject reference.
+// Idempotent: already-revoked links are unaffected.
+// ---------------------------------------------------------------------------
+export async function revoke(args: {
+  linkId?: string;
+  subjectType?: string;
+  subjectId?: string;
+}): Promise<{ ok: boolean; count: number }> {
+  if (!args.linkId && !(args.subjectType && args.subjectId)) {
+    return { ok: false, count: 0 };
+  }
+
+  const svc = getServiceRoleClient();
+  const now = new Date().toISOString();
+
+  if (args.linkId) {
+    const { data, error } = await svc
+      .from("magic_links")
+      .update({ revoked_at: now })
+      .eq("id", args.linkId)
+      .is("revoked_at", null)
+      .select("id");
+    if (error) {
+      logger.error("magic_link.revoke.by_id.failed", { err: error.message });
+      return { ok: false, count: 0 };
+    }
+    return { ok: true, count: data?.length ?? 0 };
+  }
+
+  const { data, error } = await svc
+    .from("magic_links")
+    .update({ revoked_at: now })
+    .eq("subject_type", args.subjectType!)
+    .eq("subject_id", args.subjectId!)
+    .is("revoked_at", null)
+    .select("id");
+  if (error) {
+    logger.error("magic_link.revoke.by_subject.failed", { err: error.message });
+    return { ok: false, count: 0 };
+  }
+  return { ok: true, count: data?.length ?? 0 };
+}
+
+// ---------------------------------------------------------------------------
+// regenerate — revoke old link, issue a fresh one with regenerated_from set.
+// This is the resend primitive that was missing (recon finding 5).
+// The new link inherits purpose/subject/company/email from the original.
+// ---------------------------------------------------------------------------
+export async function regenerate(
+  linkId: string,
+  ttlMs?: number,
+): Promise<IssueResult> {
+  const svc = getServiceRoleClient();
+
+  const { data: original, error: fetchErr } = await svc
+    .from("magic_links")
+    .select("*")
+    .eq("id", linkId)
+    .maybeSingle();
+
+  if (fetchErr || !original) {
+    throw new Error(`Magic link not found for regenerate: ${linkId}`);
+  }
+
+  const link = original as MagicLink;
+
+  // Revoke the old link (idempotent if already revoked)
+  await svc
+    .from("magic_links")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", linkId)
+    .is("revoked_at", null);
+
+  // Issue fresh link pointing back at the original
+  const rawToken = generateRawToken();
+  const tokenHash = hashToken(rawToken);
+  const resolvedTtl = ttlMs ?? LINK_TTL_MS[link.purpose as MagicLinkPurpose];
+  const expiresAt = new Date(Date.now() + resolvedTtl).toISOString();
+
+  const { data: newLink, error: insertErr } = await svc
+    .from("magic_links")
+    .insert({
+      purpose: link.purpose,
+      token_hash: tokenHash,
+      subject_type: link.subject_type,
+      subject_id: link.subject_id,
+      company_id: link.company_id,
+      email: link.email,
+      expires_at: expiresAt,
+      regenerated_from: linkId,
+    })
+    .select("*")
+    .single();
+
+  if (insertErr || !newLink) {
+    throw new Error(`Failed to regenerate magic link: ${insertErr?.message}`);
+  }
+
+  return { rawToken, link: newLink as MagicLink };
+}
+
+// Re-exported for callers that need to hash a raw token themselves
+export { hashToken };

--- a/lib/platform/magic-link/types.ts
+++ b/lib/platform/magic-link/types.ts
@@ -1,0 +1,59 @@
+export type MagicLinkPurpose = "approval" | "login" | "reconnect";
+
+export type MagicLink = {
+  id: string;
+  purpose: MagicLinkPurpose;
+  token_hash: string;
+  subject_type: string | null;
+  subject_id: string | null;
+  company_id: string | null;
+  email: string | null;
+  expires_at: string;
+  consumed_at: string | null;
+  session_expires_at: string | null;
+  revoked_at: string | null;
+  regenerated_from: string | null;
+  created_at: string;
+};
+
+export type IssueInput = {
+  purpose: MagicLinkPurpose;
+  subjectType?: string;
+  subjectId?: string;
+  companyId?: string;
+  email?: string;
+  ttlMs?: number;
+};
+
+export type IssueResult = {
+  rawToken: string;
+  link: MagicLink;
+};
+
+export type ValidateResult =
+  | { valid: true; link: MagicLink; sessionActive: boolean }
+  | {
+      valid: false;
+      reason: "not_found" | "expired" | "revoked" | "session_expired";
+    };
+
+export type ConsumeResult =
+  | { valid: true; link: MagicLink; isNewConsumption: boolean }
+  | {
+      valid: false;
+      reason: "not_found" | "expired" | "revoked" | "session_expired";
+    };
+
+// Default link validity windows (ms from issuance to first-click deadline)
+export const LINK_TTL_MS: Record<MagicLinkPurpose, number> = {
+  approval: 24 * 60 * 60 * 1000,  // 24h — B0 §1: reviewer has 24h to click
+  login: 15 * 60 * 1000,           // 15min — short-lived passwordless link
+  reconnect: 24 * 60 * 60 * 1000, // 24h
+};
+
+// Session duration after first click (ms). Zero = no lingering session.
+export const SESSION_TTL_MS: Record<MagicLinkPurpose, number> = {
+  approval: 23 * 60 * 60 * 1000, // 23h — B0 §2: same-day session, ≤24h
+  login: 0,                        // login creates a Supabase session, not a link session
+  reconnect: 2 * 60 * 60 * 1000, // 2h
+};

--- a/lib/platform/social/approvals/decisions/record.ts
+++ b/lib/platform/social/approvals/decisions/record.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { logger } from "@/lib/logger";
 import { hashToken } from "@/lib/platform/invitations";
+import { consume, validate } from "@/lib/platform/magic-link";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { ApiResponse } from "@/lib/tool-schemas";
 
@@ -11,20 +12,17 @@ import type { ApprovalRecipient } from "../types";
 // S1-7 — record an approval decision via magic-link.
 //
 // Two phases:
-//   A. Token verification (this lib): hash the raw token, look up
-//      the recipient row, return NOT_FOUND on no match. We deliberately
-//      do NOT pre-check revoked_at / parent state here — we let the
-//      atomic SQL function handle that so the decision recording and
-//      the state checks happen in one transaction.
-//   B. RPC call to record_approval_decision (migration 0072) which:
-//      - re-checks recipient + parent request state
-//      - inserts the event row
-//      - finalises the request + flips the post state per approval_rule
-//      - all atomic
+//   A. Token resolution (this lib) — two lookup paths:
+//        • New tokens (magic_links row exists): validate via service.
+//          If a magic_links row exists, its verdict is FINAL — the legacy
+//          token_hash fallback MUST NOT be used even if the row is invalid.
+//        • Legacy tokens (no magic_links row): hash → direct lookup on
+//          social_approval_recipients.token_hash.
+//   B. RPC call to record_approval_decision (migration 0072).
 //
-// Token-as-auth: the route layer trusts the SHA-256 hash match; there
-// is no canDo gate. A leaked token grants exactly one decision on
-// exactly one approval request and can be revoked by an admin.
+// resolveRecipientByToken additionally calls consume() (session open)
+// for new tokens on every page-load; recordApprovalDecision calls
+// validate() (read-only) to confirm the session is still active.
 // ---------------------------------------------------------------------------
 
 export type Decision = "approved" | "rejected" | "changes_requested";
@@ -33,7 +31,6 @@ export type RecordDecisionInput = {
   rawToken: string;
   decision: Decision;
   comment?: string | null;
-  // For audit columns. Caller passes from the request headers.
   ipAddress?: string | null;
   userAgent?: string | null;
 };
@@ -42,34 +39,34 @@ export type RecordDecisionResult = {
   requestId: string;
   postId: string;
   postState: string;
-  // True when this decision finalised the request. False for the
-  // intermediate decisions in all_must mode.
   finalised: boolean;
   eventId: string;
 };
 
 // Resolve the recipient + parent context from a raw magic-link token.
-// Returns NOT_FOUND when the token doesn't match anything; never
-// throws. Useful for the viewer page (which renders state before
-// asking the user to decide).
+// Calls consume() for new tokens — establishes the session on first page-load.
+// Returns NOT_FOUND when the token doesn't match anything; SESSION_EXPIRED
+// when the reviewer needs a fresh link; never throws.
 export async function resolveRecipientByToken(
   rawToken: string,
-): Promise<ApiResponse<{
-  recipient: ApprovalRecipient;
-  request: {
-    id: string;
-    post_master_id: string;
-    company_id: string;
-    approval_rule: "any_one" | "all_must";
-    expires_at: string;
-    revoked_at: string | null;
-    final_approved_at: string | null;
-    final_rejected_at: string | null;
-    snapshot_payload: unknown;
-  };
-  company: { id: string; name: string };
-  postState: string;
-}>> {
+): Promise<
+  ApiResponse<{
+    recipient: ApprovalRecipient;
+    request: {
+      id: string;
+      post_master_id: string;
+      company_id: string;
+      approval_rule: "any_one" | "all_must";
+      expires_at: string;
+      revoked_at: string | null;
+      final_approved_at: string | null;
+      final_rejected_at: string | null;
+      snapshot_payload: unknown;
+    };
+    company: { id: string; name: string };
+    postState: string;
+  }>
+> {
   if (!rawToken || !/^[0-9a-f]{64}$/i.test(rawToken)) {
     return tokenNotFound();
   }
@@ -77,20 +74,67 @@ export async function resolveRecipientByToken(
   const tokenHash = hashToken(rawToken);
   const svc = getServiceRoleClient();
 
+  // -------------------------------------------------------------------------
+  // Step 1: check for a magic_links row.
+  // HARD RULE: if a row exists, honour its verdict exclusively.
+  // Fall back to legacy lookup only when NO magic_links row exists.
+  // -------------------------------------------------------------------------
+  const mlLookup = await svc
+    .from("magic_links")
+    .select("id")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+
+  let recipientRow: { id: string } | null = null;
+
+  if (mlLookup.error) {
+    logger.error("social.approvals.decisions.ml_lookup_failed", {
+      err: mlLookup.error.message,
+    });
+    return internal("Token lookup failed.");
+  }
+
+  if (mlLookup.data) {
+    // New token — consume (establishes session on first access; idempotent thereafter)
+    const consumeResult = await consume(rawToken);
+    if (!consumeResult.valid) {
+      if (consumeResult.reason === "session_expired") {
+        return sessionExpired();
+      }
+      return tokenNotFound();
+    }
+    // Resolve recipient via magic_link_id FK
+    const rl = await svc
+      .from("social_approval_recipients")
+      .select("id")
+      .eq("magic_link_id", mlLookup.data.id)
+      .maybeSingle();
+    if (rl.error || !rl.data) return tokenNotFound();
+    recipientRow = rl.data as { id: string };
+  } else {
+    // Legacy token — direct hash lookup (back-compat)
+    const rl = await svc
+      .from("social_approval_recipients")
+      .select("id")
+      .eq("token_hash", tokenHash)
+      .maybeSingle();
+    if (rl.error || !rl.data) return tokenNotFound();
+    recipientRow = rl.data as { id: string };
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 2: hydrate the full recipient + request + company + post state.
+  // -------------------------------------------------------------------------
   const recipient = await svc
     .from("social_approval_recipients")
     .select(
       "id, approval_request_id, email, name, platform_user_id, requires_otp, otp_expires_at, revoked_at, created_at",
     )
-    .eq("token_hash", tokenHash)
+    .eq("id", recipientRow.id)
     .maybeSingle();
-  if (recipient.error) {
-    logger.error("social.approvals.decisions.token_lookup_failed", {
-      err: recipient.error.message,
-    });
-    return internal(`Failed to read recipient: ${recipient.error.message}`);
+  if (recipient.error || !recipient.data) {
+    return internal("Approval recipient missing.");
   }
-  if (!recipient.data) return tokenNotFound();
 
   const request = await svc
     .from("social_approval_requests")
@@ -163,24 +207,60 @@ export async function recordApprovalDecision(
   const tokenHash = hashToken(input.rawToken);
   const svc = getServiceRoleClient();
 
-  // Resolve recipient_id from token. Refresh-safe: a revoked or
-  // expired recipient still resolves to its row here; the SQL
-  // function will reject the decision atomically.
-  const recipientRow = await svc
-    .from("social_approval_recipients")
+  // -------------------------------------------------------------------------
+  // Token resolution (same dual-path as resolveRecipientByToken).
+  // HARD RULE: magic_links row present → honour its verdict; no fallthrough.
+  // -------------------------------------------------------------------------
+  const mlLookup = await svc
+    .from("magic_links")
     .select("id")
     .eq("token_hash", tokenHash)
     .maybeSingle();
-  if (recipientRow.error) {
+
+  if (mlLookup.error) {
     logger.error("social.approvals.decisions.token_lookup_failed", {
-      err: recipientRow.error.message,
+      err: mlLookup.error.message,
     });
-    return internal(`Failed to read recipient: ${recipientRow.error.message}`);
+    return internal(`Token lookup failed: ${mlLookup.error.message}`);
   }
-  if (!recipientRow.data) return tokenNotFound();
+
+  let recipientId: string;
+
+  if (mlLookup.data) {
+    // New token — validate session is still active (read-only, no re-consume)
+    const vr = await validate(input.rawToken);
+    if (!vr.valid) {
+      if (vr.reason === "session_expired") {
+        return sessionExpired();
+      }
+      return tokenNotFound();
+    }
+    const rl = await svc
+      .from("social_approval_recipients")
+      .select("id")
+      .eq("magic_link_id", mlLookup.data.id)
+      .maybeSingle();
+    if (rl.error || !rl.data) return tokenNotFound();
+    recipientId = (rl.data as { id: string }).id;
+  } else {
+    // Legacy token — direct hash lookup
+    const rl = await svc
+      .from("social_approval_recipients")
+      .select("id")
+      .eq("token_hash", tokenHash)
+      .maybeSingle();
+    if (rl.error) {
+      logger.error("social.approvals.decisions.legacy_token_lookup_failed", {
+        err: rl.error.message,
+      });
+      return internal(`Token lookup failed: ${rl.error.message}`);
+    }
+    if (!rl.data) return tokenNotFound();
+    recipientId = (rl.data as { id: string }).id;
+  }
 
   const rpc = await svc.rpc("record_approval_decision", {
-    p_recipient_id: recipientRow.data.id as string,
+    p_recipient_id: recipientId,
     p_decision: input.decision,
     p_comment: input.comment ?? null,
     p_ip: input.ipAddress ?? null,
@@ -256,10 +336,22 @@ function invalidState<T>(message: string): ApiResponse<T> {
   };
 }
 
+function sessionExpired<T>(): ApiResponse<T> {
+  return {
+    ok: false,
+    error: {
+      code: "SESSION_EXPIRED",
+      message: "Your review session has expired.",
+      retryable: false,
+      suggested_action:
+        "Request a fresh link by entering your email on the re-request page.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
 function tokenNotFound<T>(): ApiResponse<T> {
-  return notFound<T>(
-    "This approval link is invalid or has been revoked.",
-  );
+  return notFound<T>("This approval link is invalid or has been revoked.");
 }
 
 function notFound<T>(message: string): ApiResponse<T> {

--- a/lib/platform/social/approvals/recipients/add.ts
+++ b/lib/platform/social/approvals/recipients/add.ts
@@ -1,7 +1,9 @@
 import "server-only";
 
+import { randomUUID } from "node:crypto";
+
 import { logger } from "@/lib/logger";
-import { generateRawToken, hashToken } from "@/lib/platform/invitations";
+import { issue } from "@/lib/platform/magic-link";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { ApiResponse } from "@/lib/tool-schemas";
 
@@ -10,22 +12,16 @@ import type { AddRecipientInput, AddRecipientResult } from "../types";
 // ---------------------------------------------------------------------------
 // S1-6 — add a recipient (reviewer) to an open approval_request.
 //
-// The caller passes an approval_request_id; we verify the parent
-// request belongs to companyId and is still open (not revoked + not
-// already finalised) before inserting the recipient row.
-//
-// Token contract:
-//   - Generate a 64-char hex random token.
-//   - Store SHA-256 hex hash in social_approval_recipients.token_hash.
-//   - Return the raw token ONCE to the caller for the email body.
-//   - Caller must build the magic-link URL and send the email; the
-//     lib does not know the deployment origin and stays decoupled
-//     from SendGrid for testability (mirror of sendInvitation in
-//     lib/platform/invitations).
+// Token contract (B1 upgrade):
+//   - Issue via magic-link service (purpose='approval').
+//   - Dual write: magic_links.token_hash AND social_approval_recipients.token_hash
+//     are kept in sync so the legacy /approve/[token] lookup still works
+//     for tokens issued before the service migration.
+//   - magic_link_id FK set on the recipient row for new-token lookups.
+//   - Pre-generate recipient UUID so magic_links.subject_id is set at
+//     issuance time (no second UPDATE round-trip).
 //
 // Caller is responsible for canDo("submit_for_approval", companyId).
-// Approval recipients can be added by anyone who could submit the
-// post — typically the editor who drafted it.
 // ---------------------------------------------------------------------------
 
 export async function addRecipient(
@@ -44,10 +40,7 @@ export async function addRecipient(
 
   const svc = getServiceRoleClient();
 
-  // 1. Look up the parent request, scope by company_id, verify it's
-  // still open. Open = !revoked_at AND no final_*_at timestamps.
-  // Scoping at the lib (in addition to RLS) so a service-role caller
-  // can't add recipients to another company's request via stale id.
+  // 1. Verify the parent request belongs to companyId and is still open.
   const reqLookup = await svc
     .from("social_approval_requests")
     .select(
@@ -62,7 +55,9 @@ export async function addRecipient(
       err: reqLookup.error.message,
       approval_request_id: input.approvalRequestId,
     });
-    return internal(`Failed to read approval request: ${reqLookup.error.message}`);
+    return internal(
+      `Failed to read approval request: ${reqLookup.error.message}`,
+    );
   }
   if (!reqLookup.data) {
     return notFound("No approval request with that id in this company.");
@@ -73,13 +68,8 @@ export async function addRecipient(
   if (reqLookup.data.final_approved_at || reqLookup.data.final_rejected_at) {
     return invalidState("Approval request is already finalised.");
   }
-  // expires_at is informational here — the recipient list works
-  // until revoke/finalise; the magic-link viewer slice will reject
-  // expired tokens server-side at click time.
 
-  // 2. Look up whether this email already corresponds to a platform
-  // user, to denormalise the link in social_approval_recipients
-  // (audit makes "approved by" attribution easier downstream).
+  // 2. Resolve platform user id for audit attribution.
   const userLookup = await svc
     .from("platform_users")
     .select("id")
@@ -93,22 +83,38 @@ export async function addRecipient(
   }
   const platformUserId = userLookup.data?.id ?? null;
 
-  // 3. Generate the token.
-  const rawToken = generateRawToken();
-  const tokenHash = hashToken(rawToken);
+  // 3. Pre-generate recipient UUID so magic_links.subject_id can be set
+  //    at issuance time without a second UPDATE.
+  const recipientId = randomUUID();
 
-  // 4. Insert. The schema has no UNIQUE on (approval_request_id, email)
-  // — operators can deliberately add the same email twice (e.g. send
-  // two reminder rounds with different tokens). That matches the spec:
-  // each recipient row is one magic link.
+  // 4. Issue via the magic-link service.
+  let magicLinkIssue: Awaited<ReturnType<typeof issue>>;
+  try {
+    magicLinkIssue = await issue({
+      purpose: "approval",
+      subjectType: "approval_recipient",
+      subjectId: recipientId,
+      companyId: input.companyId,
+      email,
+    });
+  } catch (err) {
+    logger.error("social.approvals.recipients.add.magic_link_issue_failed", {
+      err: String(err),
+    });
+    return internal("Failed to issue magic link for recipient.");
+  }
+
+  // 5. Insert recipient with dual-write token_hash + magic_link_id.
   const insertResult = await svc
     .from("social_approval_recipients")
     .insert({
+      id: recipientId,
       approval_request_id: input.approvalRequestId,
       email,
       name: input.name?.trim() || null,
       platform_user_id: platformUserId,
-      token_hash: tokenHash,
+      token_hash: magicLinkIssue.link.token_hash, // back-compat: legacy lookup still works
+      magic_link_id: magicLinkIssue.link.id,       // new service FK
       requires_otp: input.requiresOtp === true,
     })
     .select(
@@ -122,14 +128,16 @@ export async function addRecipient(
       code: insertResult.error.code,
       approval_request_id: input.approvalRequestId,
     });
-    return internal(`Failed to add recipient: ${insertResult.error.message}`);
+    return internal(
+      `Failed to add recipient: ${insertResult.error.message}`,
+    );
   }
 
   return {
     ok: true,
     data: {
       recipient: insertResult.data as AddRecipientResult["recipient"],
-      rawToken,
+      rawToken: magicLinkIssue.rawToken,
     },
     timestamp: new Date().toISOString(),
   };

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -50,7 +50,9 @@ export type LimiterName =
   | "error_report"
   | "client_errors"
   | "review_link"
-  | "social_publish";
+  | "social_publish"
+  | "magic-link-login"
+  | "magic-link-reconnect";
 
 type LimiterConfig = {
   requests: number;
@@ -139,6 +141,8 @@ const CONFIGS: Record<LimiterName, LimiterConfig> = {
   // call. 30/hour covers rapid editorial use without opening cost-amplification
   // paths. Keyed by user ID; service actors (CAP) bypass this limiter.
   social_publish: { requests: 30, window: "1 h" },
+  "magic-link-login": { requests: 5, window: "1 h" },
+  "magic-link-reconnect": { requests: 10, window: "1 h" },
 };
 
 export type RateLimitResult =

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -97,6 +97,8 @@ export const ERROR_CODES = [
   "CONFLICT",
   // Cross-tenant channel conflict (set-channel Layer 2 block with override path).
   "CROSS_TENANT_CONFLICT",
+  // B1 magic-link service — reviewer session expired.
+  "SESSION_EXPIRED",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];
@@ -229,6 +231,8 @@ export function errorCodeToStatus(code: ErrorCode): number {
     case "CONFLICT":
     case "CROSS_TENANT_CONFLICT":
       return 409;
+    case "SESSION_EXPIRED":
+      return 401;
   }
 }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -146,6 +146,9 @@ function isPublicPath(pathname: string): boolean {
   // External recipients aren't platform users; the link must work
   // pre-session.
   if (pathname.startsWith("/viewer/")) return true;
+  // /magic-link/* — consumption routes for login and reconnect magic links.
+  // Token IS the auth; no session required to reach the route handler.
+  if (pathname.startsWith("/magic-link/")) return true;
   // All /api/auth/* endpoints (login, logout-not-applicable-here,
   // callback, future invite/reset routes) are by definition pre-session.
   if (pathname.startsWith("/api/auth/")) return true;

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -788,6 +788,7 @@ function check7_unauthenticatedApi(): Issue[] {
     "/api/platform/invitations/accept", // P2-3 magic-link redemption (token-is-auth)
     "/api/optimiser/health",            // module liveness probe (middleware-gated, no user data)
     "/api/debug/env-check",             // staging/dev diagnostic; returns 404 in production (VERCEL_ENV guard)
+    "/api/platform/magic-link/login",   // B1 passwordless login issuance — intentionally public; rate-limited; no user data returned
   ]);
 
   // Auth markers — any of these in the file body indicates the route gates itself.


### PR DESCRIPTION
## Summary

Implements Build Brief 1 — Magic Link Infrastructure. Depends on #1253 (migration 0174, `magic_links` table).

**Service** (`lib/platform/magic-link/`):
- `issue` / `validate` / `consume` / `revoke` / `regenerate` — full token lifecycle
- `consume()` is session-aware: first click sets `consumed_at` + `session_expires_at` (≤24h per B0 §2); idempotent within the session window
- `regenerate()` is the resend primitive identified as missing in recon finding 5
- `regenerateApprovalLink(recipientId)` — Phase-2 external-approver reminder fix

**Approval consumer wiring** (B1 Step 3):
- `addRecipient()`: issues via service; dual-writes `magic_links` AND `social_approval_recipients.token_hash` (back-compat); sets `magic_link_id` FK
- `resolveRecipientByToken()`: calls `consume()` on page-load (session established); hard rule — if `magic_links` row exists, its verdict is final; fallback only when no row exists
- `recordApprovalDecision()`: `validate()` for session check; same hard rule
- `SESSION_EXPIRED` error code (→ 401) + `SessionExpiredPanel` on `/approve/[token]`

**Login stub** (B1 Step 4a):
- `POST /api/platform/magic-link/login` — rate-limited, enumeration-safe (no user found → still 200)
- `GET /magic-link/login` — consume → `auth.admin.generateLink` → redirect to Supabase action link → `/auth/callback` establishes cookie session

**Reconnect stub** (B1 Step 4b):
- `POST /api/platform/social/connections/magic-link-reconnect` — editor+ gate; verifies connection is `auth_required | disconnected`
- `GET /magic-link/reconnect` — consume → redirect to connections page with `?reconnect=<id>`

**Infrastructure**:
- `/magic-link/*` added to middleware public paths
- `SESSION_EXPIRED` added to `ErrorCode` union + `errorCodeToStatus` (→ 401)
- `magic-link-login` (5/h) + `magic-link-reconnect` (10/h) added to `LimiterName` + rate-limit CONFIGS
- `audit.ts`: login issuance route allowlisted as intentionally public (enumeration-safe)

## Working analog

`lib/platform/invitations/` — same token generation (`generateRawToken` / `hashToken`), same service-role client pattern, same return-raw-token-once / store-hash-only contract.

**Diff**: invitations are single-purpose; `magic_links` is generic by `purpose` with a session model (`consumed_at` + `session_expires_at`).

**Fix**: new service wraps the same hashing primitive and extends it with lifecycle operations.

## Back-compat decision (live `/approve/[token]`)

Dual-write + dual-lookup:
1. `addRecipient()` writes to both `magic_links` AND `social_approval_recipients.token_hash`
2. Lookup checks `magic_links` first; if a row exists → honour its verdict (no fallthrough on invalidity)
3. Fallback to `social_approval_recipients.token_hash` **only** when no `magic_links` row exists (legacy tokens drain naturally as their 14-day window expires)

## Pre-PR checklist

- [x] Lint, typecheck, build green (3217 unit tests pass; 0 HIGH audit findings)
- [x] Unit tests: `lib/platform/magic-link/__tests__/magic-link.unit.test.ts` — state machine, TTL constants
- [x] Integration tests: `lib/__tests__/magic-link-service.test.ts` — full lifecycle + approval wiring + back-compat HARD RULE
- [x] No new external dependencies
- [x] PR is under 500 net lines per file (largest new file: service.ts ~285 lines)

## Risks identified and mitigated

- **Live `/approve/[token]` break**: dual-write/dual-lookup means zero regression for existing tokens. Legacy tokens never touch `magic_links` and keep working through their 14-day window.
- **Race condition in consume()**: atomic `WHERE consumed_at IS NULL` guard; concurrent first-clicks converge via re-fetch.
- **Login route enumeration**: returns `{ ok: true }` regardless of whether the email has a platform user account.
- **Session expiry reveals timing**: `SESSION_EXPIRED` is a distinct client-facing error but does not reveal any user-specific data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)