### PR TITLE
fix(test): surface seedCompany upsert errors in magic-link integration test

### DIFF
--- a/lib/__tests__/magic-link-service.test.ts
+++ b/lib/__tests__/magic-link-service.test.ts
@@ -21,10 +21,13 @@ const COMPANY_ID = "00001740-0000-0000-0000-000000000001";
 
 async function seedCompany(id: string) {
   const svc = getServiceRoleClient();
-  await svc.from("platform_companies").upsert(
-    { id, name: "Magic Link Test Co", slug: `ml-test-${id.slice(-4)}` },
+  // Use the last 8 chars for the slug to avoid UNIQUE collisions with other test
+  // suites. Fail loudly — silently swallowing the error leaves the FK dangling.
+  const { error } = await svc.from("platform_companies").upsert(
+    { id, name: "Magic Link Test Co", slug: `ml-test-${id.slice(-8)}` },
     { onConflict: "id" },
   );
+  if (error) throw new Error(`seedCompany failed: ${error.message}`);
 }
 
 async function seedApprovalRequest(companyId: string) {


### PR DESCRIPTION
## Summary

`seedCompany()` in `lib/__tests__/magic-link-service.test.ts` silently swallowed `upsert` errors. When the call failed (e.g. a slug UNIQUE collision between test suites in the same CI shard), the `platform_companies` row was never created, causing all subsequent `magic_links` inserts to fail the `company_id` FK — 15 tests failed.

Two fixes:
- Check and throw on the `upsert` error so seed failures are visible immediately
- Use 8-char slug suffix instead of 4-char to reduce cross-suite slug collision probability

**Root cause of docs PR #1252 test(1) failure:** this was a real unit test failure, not a pre-existing flake. This PR is the fix.

## Pre-PR checklist

- [x] Lint, typecheck, unit tests green
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)