### PR TITLE
fix: workflow-steps seedCompany upsert + content_group_id in cap/auto-attach

### DIFF
--- a/lib/__tests__/workflow-steps.test.ts
+++ b/lib/__tests__/workflow-steps.test.ts
@@ -17,10 +17,11 @@ const COMPANY_ID = "00001760-0000-0000-0000-000000000001";
 
 async function seedCompany() {
   const svc = getServiceRoleClient();
-  // Delete first to avoid slug UNIQUE conflict from prior runs, then insert.
-  await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
-  const { error } = await svc.from("platform_companies").insert(
+  // Use upsert with onConflict:"id" — idempotent and handles the slug UNIQUE
+  // constraint cleanly (same pattern as magic-link-service.test.ts which passes).
+  const { error } = await svc.from("platform_companies").upsert(
     { id: COMPANY_ID, name: "Workflow Steps Test Co", slug: `wf-steps-${COMPANY_ID.slice(-8)}` },
+    { onConflict: "id" },
   );
   if (error) throw new Error(`seedCompany failed: ${error.message}`);
 }

--- a/lib/image/auto-attach.ts
+++ b/lib/image/auto-attach.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { randomUUID } from "crypto";
 import { fromZonedTime } from "date-fns-tz";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { logger } from "@/lib/logger";
@@ -457,6 +458,11 @@ async function createScheduledDraft(
       ? { target_connection_ids: connectionIds }
       : {},
   };
+
+  // B2 migration 0175 requires content_group_id + version_number explicitly.
+  // Each auto-attached draft is its own content group (standalone post, v1).
+  insertPayload.content_group_id = randomUUID();
+  insertPayload.version_number = 1;
 
   // workflow_state is null for the legacy path (gate disabled).
   // For the gate-enabled path it is 'pending_image_review'.

--- a/lib/platform/social/cap/generator.ts
+++ b/lib/platform/social/cap/generator.ts
@@ -153,6 +153,8 @@ export async function generateCAPPosts(
         media_urls:        [],
         target_profiles:   [],
         platform_variants: platformVariants,
+        content_group_id:  randomUUID(), // each CAP draft is its own content group (v1)
+        version_number:    1,
       })
       .select("id")
       .single();


### PR DESCRIPTION
## Summary

Two fixes for CI failures introduced by B2 migration 0175 (`content_group_id NOT NULL`):

**Fix 1: `workflow-steps.test.ts` seedCompany** — reverted from `delete+insert` to the proven `upsert(onConflict:"id")` pattern (same as B1/B2 tests that pass). The `delete+insert` pattern caused the company row to not exist by test time.

**Fix 2: Production code inserts into `social_post_drafts` without `content_group_id`**
- `lib/platform/social/cap/generator.ts` — CAP generator creates drafts without `content_group_id`/`version_number`; added `randomUUID()` + `1`
- `lib/image/auto-attach.ts` — image auto-attach creates scheduled drafts without these fields; same fix

## Pre-PR checklist
- [x] Typecheck clean; 3265 unit tests pass; 0 HIGH audit findings
- [x] 3 files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)