### PR TITLE
fix(tests): delete-then-insert seedCompany with verification in B1/B3 tests

### DIFF
--- a/lib/__tests__/magic-link-service.test.ts
+++ b/lib/__tests__/magic-link-service.test.ts
@@ -21,13 +21,21 @@ const COMPANY_ID = "00001740-0000-0000-0000-000000000001";
 
 async function seedCompany(id: string) {
   const svc = getServiceRoleClient();
-  // Use the last 8 chars for the slug to avoid UNIQUE collisions with other test
-  // suites. Fail loudly — silently swallowing the error leaves the FK dangling.
-  const { error } = await svc.from("platform_companies").upsert(
-    { id, name: "Magic Link Test Co", slug: `ml-test-${id.slice(-8)}` },
-    { onConflict: "id" },
-  );
+  // Delete any existing row with this ID before inserting to guarantee the row
+  // is fresh — avoids silent cascade-delete scenarios from prior test runs.
+  await svc.from("platform_companies").delete().eq("id", id);
+  const { error } = await svc.from("platform_companies").insert({
+    id,
+    name: "Magic Link Test Co",
+    // Include the first 8 chars of the UUID to make slug globally unique
+    // even across test files with the same trailing digits.
+    slug: `ml-${id.slice(0, 8)}-${id.slice(-4)}`,
+  });
   if (error) throw new Error(`seedCompany failed: ${error.message}`);
+  // Verify the company actually exists before tests run.
+  const { data: verify } = await svc.from("platform_companies")
+    .select("id").eq("id", id).maybeSingle();
+  if (!verify) throw new Error(`seedCompany: company ${id} not found after insert`);
 }
 
 async function seedApprovalRequest(companyId: string) {

--- a/lib/__tests__/workflow-steps.test.ts
+++ b/lib/__tests__/workflow-steps.test.ts
@@ -17,13 +17,17 @@ const COMPANY_ID = "00001760-0000-0000-0000-000000000001";
 
 async function seedCompany() {
   const svc = getServiceRoleClient();
-  // Use upsert with onConflict:"id" — idempotent and handles the slug UNIQUE
-  // constraint cleanly (same pattern as magic-link-service.test.ts which passes).
-  const { error } = await svc.from("platform_companies").upsert(
-    { id: COMPANY_ID, name: "Workflow Steps Test Co", slug: `wf-steps-${COMPANY_ID.slice(-8)}` },
-    { onConflict: "id" },
-  );
+  // Delete first then insert — guarantees a fresh row regardless of prior state.
+  await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
+  const { error } = await svc.from("platform_companies").insert({
+    id: COMPANY_ID,
+    name: "Workflow Steps Test Co",
+    slug: `wf-${COMPANY_ID.slice(0, 8)}-${COMPANY_ID.slice(-4)}`,
+  });
   if (error) throw new Error(`seedCompany failed: ${error.message}`);
+  const { data: verify } = await svc.from("platform_companies")
+    .select("id").eq("id", COMPANY_ID).maybeSingle();
+  if (!verify) throw new Error(`seedCompany: company not found after insert`);
 }
 
 beforeAll(async () => {


### PR DESCRIPTION
## Summary

`magic-link-service.test.ts` and `workflow-steps.test.ts` were failing intermittently in CI with `company_id_fkey` violations, indicating the `platform_companies` row wasn't present when test logic ran.

Changed from `upsert(onConflict:"id")` to `delete + insert + verify`:
- Delete any existing row first (idempotent cleanup)
- Insert fresh row
- Verify the row actually exists before tests proceed (fail loudly if not)
- Updated slug format to include UUID prefix to guarantee global uniqueness

## Pre-PR checklist
- [x] 3265 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)