### PR TITLE
fix(tests): move seedCompany to beforeEach (truncateAll wipes it between tests)

### DIFF
--- a/lib/__tests__/magic-link-service.test.ts
+++ b/lib/__tests__/magic-link-service.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { getServiceRoleClient } from "@/lib/supabase";
 import {
@@ -67,16 +67,15 @@ async function seedApprovalRequest(companyId: string) {
   return { requestId: req.id, postId: post.id };
 }
 
-beforeAll(async () => {
+// _setup.ts's global beforeEach calls truncateAll() which wipes platform_companies.
+// Re-seed the company before EACH test so it exists regardless of truncation order.
+beforeEach(async () => {
   await seedCompany(COMPANY_ID);
 });
 
 afterAll(async () => {
+  // truncateAll() will have cleaned up most rows already; this is defensive cleanup.
   const svc = getServiceRoleClient();
-  await svc.from("magic_links").delete().eq("company_id", COMPANY_ID);
-  await svc.from("social_approval_recipients").delete().eq("email", "reviewer@ml-test.example.com");
-  await svc.from("social_approval_requests").delete().eq("company_id", COMPANY_ID);
-  await svc.from("social_post_master").delete().eq("company_id", COMPANY_ID);
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
 });
 

--- a/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
+++ b/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { describe, expect, it, beforeAll, beforeEach, afterAll } from "vitest";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { seedAuthUser } from "./_auth-helpers";
@@ -63,6 +64,8 @@ describe("Migration 0155 — social_post_drafts schema gaps", () => {
         created_by: seededUserId,
         updated_by: seededUserId,
         link_url: "https://example.com/blog/post-1",
+        content_group_id: crypto.randomUUID(),
+        version_number: 1,
       })
       .select("id, link_url")
       .single();
@@ -85,6 +88,8 @@ describe("Migration 0155 — social_post_drafts schema gaps", () => {
           created_by: seededUserId,
           updated_by: seededUserId,
           source_type,
+          content_group_id: crypto.randomUUID(),
+          version_number: 1,
         })
         .select("id, source_type")
         .single();
@@ -107,6 +112,8 @@ describe("Migration 0155 — social_post_drafts schema gaps", () => {
         created_by: seededUserId,
         updated_by: seededUserId,
         source_type: "unknown_value" as string,
+        content_group_id: crypto.randomUUID(),
+        version_number: 1,
       })
       .select("id")
       .single();
@@ -123,6 +130,8 @@ describe("Migration 0155 — social_post_drafts schema gaps", () => {
         company_id: COMPANY_ID,
         created_by: seededUserId,
         updated_by: seededUserId,
+        content_group_id: crypto.randomUUID(),
+        version_number: 1,
       })
       .select("id, link_url, source_type")
       .single();

--- a/lib/__tests__/proofing-service.test.ts
+++ b/lib/__tests__/proofing-service.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { getServiceRoleClient } from "@/lib/supabase";
 import { createProof, reviseProof, onProofPass, onProofReject } from "@/lib/platform/proofing";
@@ -52,15 +52,16 @@ async function seedDraft(overrides: Record<string, unknown> = {}) {
 
 beforeAll(async () => {
   submitterUser = await seedAuthUser({ role: "user" });
+});
+
+// _setup.ts truncateAll() runs before each test and wipes platform_companies.
+// Re-seed the company before each test.
+beforeEach(async () => {
   await seedCompany();
 });
 
 afterAll(async () => {
   const svc = getServiceRoleClient();
-  await svc.from("social_approval_recipients").delete().eq("email", "proof-reviewer@test.example.com");
-  await svc.from("social_approval_requests").delete().eq("company_id", COMPANY_ID);
-  await svc.from("social_post_drafts").delete().eq("company_id", COMPANY_ID);
-  await svc.from("magic_links").delete().eq("company_id", COMPANY_ID);
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
   await cleanupTrackedAuthUsers();
 });

--- a/lib/__tests__/workflow-steps.test.ts
+++ b/lib/__tests__/workflow-steps.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { getServiceRoleClient } from "@/lib/supabase";
 import {
@@ -30,16 +30,14 @@ async function seedCompany() {
   if (!verify) throw new Error(`seedCompany: company not found after insert`);
 }
 
-beforeAll(async () => {
+// _setup.ts truncateAll() runs before each test and wipes platform_companies.
+// Re-seed the company before each test.
+beforeEach(async () => {
   await seedCompany();
-  // Clean up any leftover steps from prior runs
-  const svc = getServiceRoleClient();
-  await svc.from("workflow_steps").delete().eq("company_id", COMPANY_ID);
 });
 
 afterAll(async () => {
   const svc = getServiceRoleClient();
-  await svc.from("workflow_steps").delete().eq("company_id", COMPANY_ID);
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
 });
 


### PR DESCRIPTION
## Root cause

`_setup.ts`'s global `beforeEach` calls `truncateAll()` which includes `platform_companies` in the truncation list. Tests that seeded the company in `beforeAll` had the company wiped BEFORE the first test ran. This caused all `company_id` FK violations.

## Fix

Moved `seedCompany()` from `beforeAll` to `beforeEach` in all three affected integration test files:
- `magic-link-service.test.ts`
- `proofing-service.test.ts`
- `workflow-steps.test.ts`

Also added `content_group_id` + `version_number` to `migration-0155-v2-schema-gaps.test.ts` draft inserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)