### PR TITLE
fix(tests): persistent seedAuthUser + beforeEach for step navigation tests

### DIFF
--- a/lib/__tests__/proofing-service.test.ts
+++ b/lib/__tests__/proofing-service.test.ts
@@ -4,7 +4,7 @@ import { getServiceRoleClient } from "@/lib/supabase";
 import { createProof, reviseProof, onProofPass, onProofReject } from "@/lib/platform/proofing";
 import { resolveRecipientByToken } from "@/lib/platform/social/approvals";
 import { addRecipient } from "@/lib/platform/social/approvals/recipients/add";
-import { seedAuthUser, cleanupTrackedAuthUsers } from "./_auth-helpers";
+import { seedAuthUser } from "./_auth-helpers";
 import type { SeededAuthUser } from "./_auth-helpers";
 
 // ---------------------------------------------------------------------------
@@ -51,7 +51,9 @@ async function seedDraft(overrides: Record<string, unknown> = {}) {
 }
 
 beforeAll(async () => {
-  submitterUser = await seedAuthUser({ role: "user" });
+  // persistent: true — not tracked by cleanupTrackedAuthUsers(), so truncateAll()
+  // doesn't delete this user between tests. Cleaned up explicitly in afterAll.
+  submitterUser = await seedAuthUser({ role: "user", persistent: true });
 });
 
 // _setup.ts truncateAll() runs before each test and wipes platform_companies.
@@ -63,7 +65,9 @@ beforeEach(async () => {
 afterAll(async () => {
   const svc = getServiceRoleClient();
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
-  await cleanupTrackedAuthUsers();
+  if (submitterUser?.id) {
+    await svc.auth.admin.deleteUser(submitterUser.id);
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/__tests__/workflow-steps.test.ts
+++ b/lib/__tests__/workflow-steps.test.ts
@@ -104,7 +104,8 @@ describe("upsertWorkflowSteps", () => {
 // ---------------------------------------------------------------------------
 
 describe("getNextStep / getPriorStep", () => {
-  beforeAll(async () => {
+  // truncateAll() wipes workflow_steps before each test; re-seed here.
+  beforeEach(async () => {
     await upsertWorkflowSteps(COMPANY_ID, [
       { step_order: 1, name: "Step 1", pass_rule: "any_one", participants: [] },
       { step_order: 2, name: "Step 2", pass_rule: "all_must", participants: [] },


### PR DESCRIPTION
Two fixes for remaining CI failures after #1264:

1. proofing-service.test.ts: seedAuthUser now uses persistent:true so cleanupTrackedAuthUsers() (called by truncateAll() in global beforeEach) doesn't delete the user between tests. Explicit cleanup in afterAll.

2. workflow-steps.test.ts: getNextStep/getPriorStep describe moved step seeding from beforeAll to beforeEach — truncateAll() also wipes workflow_steps (via CASCADE from platform_companies), so steps must be re-seeded before each test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)