### PR TITLE
test(b3): add Case B hard-rule assertion — expired link (never consumed) must not fall through

### DIFF
--- a/app/api/approve/[token]/decision/route.ts
+++ b/app/api/approve/[token]/decision/route.ts
@@ -222,7 +222,7 @@ export async function POST(
           }
         }
 
-        if (companyId && createdBy) {
+        if (companyId && createdBy && result.data.postId) {
           if (parsed.data.decision === "changes_requested") {
             await dispatch({
               event: "changes_requested",

--- a/lib/__tests__/proofing-service.test.ts
+++ b/lib/__tests__/proofing-service.test.ts
@@ -346,23 +346,30 @@ describe("B1 hard rule: expired magic_links row is NOT resolvable via legacy fal
     // Without the hard rule, the token_hash on social_approval_recipients
     // is still valid and the 14-day parent-request window is still open,
     // so the legacy path would admit the reviewer. It must not.
+    //
+    // IMPORTANT: do NOT call resolveRecipientByToken before expiry.
+    // resolveRecipientByToken calls consume() which sets consumed_at — after
+    // that the session governs, not expires_at. The link must stay unconsumed
+    // (consumed_at IS NULL) for this case to test the right code path.
     const { createResult, rec, svc } = await seedProofWithRecipient("hard-rule-link-expiry@test.example.com");
 
     const { regenerateApprovalLink } = await import("@/lib/platform/magic-link");
     const { rawToken } = await regenerateApprovalLink(rec.id);
 
-    // Verify works before manipulation.
-    expect((await resolveRecipientByToken(rawToken)).ok).toBe(true);
-
-    // Expire the LINK itself (never clicked — consumed_at stays NULL).
+    // Verify the magic_links row exists and is unconsumed (sanity, no consume side-effect).
     const { data: currentRec } = await svc.from("social_approval_recipients")
       .select("magic_link_id").eq("id", rec.id).maybeSingle();
-    if (currentRec?.magic_link_id) {
-      await svc.from("magic_links").update({
-        expires_at: new Date(Date.now() - 5000).toISOString(),
-        // consumed_at intentionally NOT set (stays NULL — link was never clicked)
-      }).eq("id", currentRec.magic_link_id);
-    }
+    expect(currentRec?.magic_link_id).not.toBeNull();
+
+    const { data: mlBefore } = await svc.from("magic_links")
+      .select("consumed_at, expires_at").eq("id", currentRec!.magic_link_id!).single();
+    expect(mlBefore?.consumed_at).toBeNull(); // not yet clicked
+    expect(new Date(mlBefore!.expires_at).getTime()).toBeGreaterThan(Date.now()); // not yet expired
+
+    // Expire the LINK itself (consumed_at stays NULL — link was never clicked).
+    await svc.from("magic_links").update({
+      expires_at: new Date(Date.now() - 5000).toISOString(),
+    }).eq("id", currentRec!.magic_link_id!);
 
     // Verify parent request is still within 14 days (the hole the rule closes).
     const { data: parentReq } = await svc.from("social_approval_requests")
@@ -372,15 +379,15 @@ describe("B1 hard rule: expired magic_links row is NOT resolvable via legacy fal
     expect(parentReq!.final_approved_at).toBeNull();
     expect(parentReq!.final_rejected_at).toBeNull();
 
-    // HARD RULE: magic_links row exists + is invalid → must reject.
+    // HARD RULE: magic_links row exists (expired, never consumed) → must reject.
     // Must NOT fall through to social_approval_recipients.token_hash lookup.
+    // If it fell through, the 14-day parent-request window would admit the token.
     const result = await resolveRecipientByToken(rawToken);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      // 'expired' (never consumed, link expiry passed) — not SESSION_EXPIRED
+      // 'expired' reason (consume() returns this when expires_at < now and consumed_at IS NULL)
+      // The function maps this to NOT_FOUND for the caller — the key point is ok=false.
       expect(result.error.code).not.toBe(undefined);
-      // The critical assertion: the result is NOT ok, proving the hard rule held.
-      // If the legacy path had fired, the 14-day window would have admitted the token.
     }
   });
 });

--- a/lib/__tests__/proofing-service.test.ts
+++ b/lib/__tests__/proofing-service.test.ts
@@ -266,17 +266,28 @@ describe("onProofReject", () => {
 });
 
 // ---------------------------------------------------------------------------
-// B1 HARD RULE — DONE CRITERIA assertion
+// B1 HARD RULE — DONE CRITERIA assertions (TWO separate cases required)
 //
-// An expired magic_links row with its social_approval_recipients.token_hash
-// still intact and the parent request still inside its 14-day window MUST
-// be rejected at /approve/[token]. It must NOT fall through to the legacy
-// token_hash lookup. Fallback fires on magic_links row-ABSENCE only.
+// The hard rule: if a magic_links row EXISTS for a token, its verdict is
+// FINAL. The fallback to social_approval_recipients.token_hash fires ONLY
+// when no magic_links row exists (row-ABSENCE). It must NEVER fire when the
+// row exists but is invalid (expired link OR expired session).
+//
+// Case A — expired SESSION (link was clicked, session window elapsed):
+//   consumed_at IS NOT NULL, session_expires_at in the past.
+//   Magic links row exists → rejects as SESSION_EXPIRED.
+//   The parent request's 14-day window is irrelevant.
+//
+// Case B — expired LINK (link never clicked, expires_at in the past):
+//   consumed_at IS NULL, expires_at in the past.
+//   THIS IS THE RESURRECTION HOLE: without the hard rule, an attacker whose
+//   link "expired" could still be admitted via the legacy token_hash lookup
+//   since the parent request's 14-day window is still open.
+//   Must reject as 'expired', NOT fall through to legacy lookup.
 // ---------------------------------------------------------------------------
 
 describe("B1 hard rule: expired magic_links row is NOT resolvable via legacy fallback", () => {
-  it("expired magic_links row → SESSION_EXPIRED, never falls through to legacy 14-day window", async () => {
-    // Seed a draft and create a proof to get a real approval recipient
+  async function seedProofWithRecipient(email: string) {
     const draft = await seedDraft();
     const svc = getServiceRoleClient();
     const createResult = await createProof({
@@ -284,64 +295,92 @@ describe("B1 hard rule: expired magic_links row is NOT resolvable via legacy fal
       companyId: COMPANY_ID,
       submitterUserId: submitterUser.id,
       approvalRule: "any_one",
-      recipients: [{ email: "hard-rule-test@test.example.com" }],
+      recipients: [{ email }],
       origin: "http://localhost:3000",
     });
-
-    // Get the recipient's magic_link_id
     const { data: rec } = await svc
       .from("social_approval_recipients")
-      .select("id, magic_link_id, token_hash")
+      .select("id, magic_link_id")
       .eq("approval_request_id", createResult.approvalRequestId)
-      .eq("email", "hard-rule-test@test.example.com")
+      .eq("email", email)
       .single();
-
     expect(rec?.magic_link_id).not.toBeNull();
+    return { createResult, rec: rec!, svc };
+  }
 
-    // Get a fresh raw token for the existing recipient via regenerateApprovalLink.
-    // This avoids a second addRecipient call (which can fail intermittently)
-    // and tests the regenerate path at the same time.
+  it("Case A — consumed link with expired session rejects as SESSION_EXPIRED, not via legacy 14-day path", async () => {
+    const { createResult, rec, svc } = await seedProofWithRecipient("hard-rule-session@test.example.com");
+
     const { regenerateApprovalLink } = await import("@/lib/platform/magic-link");
-    const { rawToken } = await regenerateApprovalLink(rec!.id);
+    const { rawToken } = await regenerateApprovalLink(rec.id);
 
-    // Verify the raw token works before expiry.
-    const beforeExpire = await resolveRecipientByToken(rawToken);
-    expect(beforeExpire.ok).toBe(true);
+    // Verify works before manipulation.
+    expect((await resolveRecipientByToken(rawToken)).ok).toBe(true);
 
-    // Get the current magic_link_id for the regenerated token.
-    const { data: currentRec } = await svc
-      .from("social_approval_recipients")
-      .select("magic_link_id")
-      .eq("id", rec!.id)
-      .maybeSingle();
-
+    // Expire the session (link was clicked, window elapsed).
+    const { data: currentRec } = await svc.from("social_approval_recipients")
+      .select("magic_link_id").eq("id", rec.id).maybeSingle();
     if (currentRec?.magic_link_id) {
-      await svc
-        .from("magic_links")
-        .update({
-          consumed_at: new Date(Date.now() - 2000).toISOString(),
-          session_expires_at: new Date(Date.now() - 1000).toISOString(),
-        })
-        .eq("id", currentRec.magic_link_id);
+      await svc.from("magic_links").update({
+        consumed_at: new Date(Date.now() - 2000).toISOString(),
+        session_expires_at: new Date(Date.now() - 1000).toISOString(),
+      }).eq("id", currentRec.magic_link_id);
     }
 
-    // Verify the parent request is still inside its 14-day window
-    const { data: parentReq } = await svc
-      .from("social_approval_requests")
+    // Verify parent request is still within 14 days (the hole the rule closes).
+    const { data: parentReq } = await svc.from("social_approval_requests")
       .select("expires_at, final_approved_at, final_rejected_at")
-      .eq("id", createResult.approvalRequestId)
-      .single();
-
+      .eq("id", createResult.approvalRequestId).single();
     expect(new Date(parentReq!.expires_at).getTime()).toBeGreaterThan(Date.now());
     expect(parentReq!.final_approved_at).toBeNull();
     expect(parentReq!.final_rejected_at).toBeNull();
 
-    // THE HARD RULE: must be SESSION_EXPIRED, NOT resolved via legacy fallback.
-    const afterExpire = await resolveRecipientByToken(rawToken);
-    expect(afterExpire.ok).toBe(false);
-    if (!afterExpire.ok) {
-      // Must be a session error — NOT a successful resolution via the 14-day window.
-      expect(afterExpire.error.code).toBe("SESSION_EXPIRED");
+    // Must be SESSION_EXPIRED — NOT resolved via legacy 14-day window.
+    const result = await resolveRecipientByToken(rawToken);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("SESSION_EXPIRED");
+  });
+
+  it("Case B — never-clicked link with expired expires_at rejects as expired, not via legacy 14-day path", async () => {
+    // THE RESURRECTION HOLE: expires_at in the past, consumed_at NULL.
+    // Without the hard rule, the token_hash on social_approval_recipients
+    // is still valid and the 14-day parent-request window is still open,
+    // so the legacy path would admit the reviewer. It must not.
+    const { createResult, rec, svc } = await seedProofWithRecipient("hard-rule-link-expiry@test.example.com");
+
+    const { regenerateApprovalLink } = await import("@/lib/platform/magic-link");
+    const { rawToken } = await regenerateApprovalLink(rec.id);
+
+    // Verify works before manipulation.
+    expect((await resolveRecipientByToken(rawToken)).ok).toBe(true);
+
+    // Expire the LINK itself (never clicked — consumed_at stays NULL).
+    const { data: currentRec } = await svc.from("social_approval_recipients")
+      .select("magic_link_id").eq("id", rec.id).maybeSingle();
+    if (currentRec?.magic_link_id) {
+      await svc.from("magic_links").update({
+        expires_at: new Date(Date.now() - 5000).toISOString(),
+        // consumed_at intentionally NOT set (stays NULL — link was never clicked)
+      }).eq("id", currentRec.magic_link_id);
+    }
+
+    // Verify parent request is still within 14 days (the hole the rule closes).
+    const { data: parentReq } = await svc.from("social_approval_requests")
+      .select("expires_at, final_approved_at, final_rejected_at")
+      .eq("id", createResult.approvalRequestId).single();
+    expect(new Date(parentReq!.expires_at).getTime()).toBeGreaterThan(Date.now());
+    expect(parentReq!.final_approved_at).toBeNull();
+    expect(parentReq!.final_rejected_at).toBeNull();
+
+    // HARD RULE: magic_links row exists + is invalid → must reject.
+    // Must NOT fall through to social_approval_recipients.token_hash lookup.
+    const result = await resolveRecipientByToken(rawToken);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // 'expired' (never consumed, link expiry passed) — not SESSION_EXPIRED
+      expect(result.error.code).not.toBe(undefined);
+      // The critical assertion: the result is NOT ok, proving the hard rule held.
+      // If the legacy path had fired, the 14-day window would have admitted the token.
     }
   });
 });

--- a/lib/platform/social/approvals/decisions/record.ts
+++ b/lib/platform/social/approvals/decisions/record.ts
@@ -37,8 +37,8 @@ export type RecordDecisionInput = {
 
 export type RecordDecisionResult = {
   requestId: string;
-  postId: string;
-  postState: string;
+  postId: string | null;      // null for content_proof (no V1 post)
+  postState: string | null;   // null for content_proof
   finalised: boolean;
   eventId: string;
 };
@@ -64,7 +64,7 @@ export async function resolveRecipientByToken(
       snapshot_payload: unknown;
     };
     company: { id: string; name: string };
-    postState: string;
+    postState: string | null;
   }>
 > {
   if (!rawToken || !/^[0-9a-f]{64}$/i.test(rawToken)) {
@@ -156,13 +156,20 @@ export async function resolveRecipientByToken(
     return internal("Company missing for this approval request.");
   }
 
-  const post = await svc
-    .from("social_post_master")
-    .select("state")
-    .eq("id", request.data.post_master_id as string)
-    .maybeSingle();
-  if (post.error || !post.data) {
-    return internal("Post missing for this approval request.");
+  // V2 content_proof subject_type: post_master_id is null — skip V1 post lookup.
+  // postState is returned as null; the approve page treats null as non-finalised
+  // (the finalisation check uses final_approved_at / final_rejected_at instead).
+  let postState: string | null = null;
+  if (request.data.post_master_id) {
+    const post = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", request.data.post_master_id as string)
+      .maybeSingle();
+    if (post.error || !post.data) {
+      return internal("Post missing for this approval request.");
+    }
+    postState = post.data.state as string;
   }
 
   return {
@@ -181,7 +188,7 @@ export async function resolveRecipientByToken(
         snapshot_payload: unknown;
       },
       company: company.data as { id: string; name: string },
-      postState: post.data.state as string,
+      postState,
     },
     timestamp: new Date().toISOString(),
   };


### PR DESCRIPTION
## Summary

**Production bug fix:** `resolveRecipientByToken` unconditionally queried `social_post_master` even when `post_master_id IS NULL` (the case for all content_proof approval requests introduced in B2). This caused every content_proof approval link to return `ok: false` with "Post missing for this approval request" — breaking the entire V2 review flow.

**B1 hard-rule test — both cases added:**

Case A: consumed link with expired session (`consumed_at` set, `session_expires_at` in past) → SESSION_EXPIRED
Case B: never-clicked link with expired `expires_at` (`consumed_at` IS NULL) → the resurrection hole — must reject without falling through to legacy token_hash lookup

Updated the test comment to describe both cases clearly.

## Files changed

- `lib/platform/social/approvals/decisions/record.ts`: skip `social_post_master` query when `post_master_id IS NULL`; update return types to `string | null`
- `app/api/approve/[token]/decision/route.ts`: guard V1 dispatch against null `postId`
- `lib/__tests__/proofing-service.test.ts`: Case A + Case B hard-rule assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)