### PR TITLE
feat(b4): add /portal public paths to middleware (step 3)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -152,6 +152,11 @@ function isPublicPath(pathname: string): boolean {
   // /proof/* — reviewer-facing queue, re-request, and proof pages.
   // All token-authenticated or public (no platform session required).
   if (pathname.startsWith("/proof/")) return true;
+  // /portal — B4 client portal (sessionless, magic-link session only).
+  // Two-condition pattern: exact /portal OR /portal/<child>.
+  // Does NOT match /portals, /portalnews, /portal-admin etc. because
+  // those do not begin with "/portal/" and are not "/portal" exactly.
+  if (pathname === "/portal" || pathname.startsWith("/portal/")) return true;
   // /api/platform/proofing/link-request — public re-request endpoint.
   if (pathname === "/api/platform/proofing/link-request") return true;
   // All /api/auth/* endpoints (login, logout-not-applicable-here,


### PR DESCRIPTION
## Summary

Adds `/portal` paths to middleware PUBLIC_PATHS for B4 client portal.

```typescript
if (pathname === "/portal" || pathname.startsWith("/portal/")) return true;
```

**Scoping** — exact match pattern approved by Steven:
- ✓ `/portal` — exact
- ✓ `/portal/` — child prefix
- ✓ `/portal/callback` — child
- ✗ `/portals` — not matched (no trailing `/`)
- ✗ `/portalnews` — not matched
- ✗ `/portal-admin` — not matched

**Hard stop completed** — approved by Steven with "merge it — Step 3 pattern approved."

🤖 Generated with [Claude Code](https://claude.com/claude-code)