### PR TITLE
feat(b4): portal oauth callback + reconnect route (step 5)

### DIFF
--- a/app/api/portal/connections/[connectionId]/reconnect/route.ts
+++ b/app/api/portal/connections/[connectionId]/reconnect/route.ts
@@ -1,0 +1,169 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { internalError, readJsonBody, validationError } from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { validate } from "@/lib/platform/magic-link";
+import {
+  initiateProfileConnect,
+  type ProfileSocialPlatform,
+} from "@/lib/platform/social/profiles/connect";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// Same mapping as app/api/platform/social/connections/reconnect/route.ts.
+// Keep aligned with lib/platform/social/variants/types.ts SocialPlatform.
+const SOCIAL_TO_BUNDLE: Record<string, ProfileSocialPlatform> = {
+  linkedin_personal: "LINKEDIN",
+  linkedin_company:  "LINKEDIN",
+  facebook_page:     "FACEBOOK",
+  x:                 "TWITTER",
+  gbp:               "GOOGLE_BUSINESS",
+};
+
+const WITH_BUSINESS_SCOPE: ReadonlySet<string> = new Set(["FACEBOOK", "INSTAGRAM"]);
+
+// ---------------------------------------------------------------------------
+// POST /api/portal/connections/[connectionId]/reconnect
+//
+// B4 client portal — initiates OAuth reconnect for a specific connection.
+// No Supabase session. Token IS the auth.
+//
+// SECURITY — COMPANY BINDING (Requirement #1, hard requirement):
+//   company_id is derived SERVER-SIDE from the magic_links row.
+//   The client never supplies company_id — it comes from the magic link
+//   the operator already bound to their company at issue time.
+//   This is the exact surface the 2026-05-11 LinkedIn leak came through.
+//
+// Flow:
+//   1. validate(token) → session active, get company_id from magic_links row
+//   2. verify connectionId belongs to that company (server-side FK guard)
+//   3. initiateProfileConnect() with portal callback as redirectUrl
+//   4. return { url } — client opens OAuth popup
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Schema = z.object({
+  // Raw magic-link token — used to validate the session server-side.
+  // company_id is derived from the magic_links row, NEVER from this payload.
+  token: z.string().regex(/^[0-9a-f]{64}$/i, "Invalid token format"),
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ connectionId: string }> },
+): Promise<NextResponse> {
+  const { connectionId } = await params;
+
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body required.");
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Invalid request.", { issues: parsed.error.issues });
+  }
+
+  const { token } = parsed.data;
+
+  // ─── Step 1: validate magic_links session ──────────────────────────────
+  // validate() is read-only — does not consume. Checks session_expires_at.
+  const session = await validate(token);
+  if (!session.valid) {
+    return NextResponse.json(
+      { ok: false, error: { code: "SESSION_EXPIRED", message: "Your session has expired. Request a fresh link." } },
+      { status: 401 },
+    );
+  }
+
+  // company_id comes exclusively from the magic_links row.
+  // The operator bound this to their company when they issued the link.
+  const companyId = session.link.company_id;
+  if (!companyId) {
+    logger.error("portal.reconnect.no_company_id", { link_id: session.link.id });
+    return internalError("This link is not associated with a company.");
+  }
+
+  const svc = getServiceRoleClient();
+
+  // ─── Step 2: verify the connection belongs to this company ─────────────
+  // Server-side FK guard: client cannot reconnect a connection from a
+  // different company by sending a different connectionId.
+  const { data: connection, error: connErr } = await svc
+    .from("social_connections")
+    .select("id, platform, profile_id, status, company_id")
+    .eq("id", connectionId)
+    .eq("company_id", companyId)  // ← cross-company guard
+    .maybeSingle();
+
+  if (connErr) {
+    logger.error("portal.reconnect.connection_lookup_failed", { err: connErr.message });
+    return internalError("Failed to load connection.");
+  }
+  if (!connection) {
+    // Either connection doesn't exist or belongs to a different company.
+    // Return the same message for both — don't reveal which case it is.
+    return validationError("Connection not found.");
+  }
+
+  const conn = connection as {
+    id: string;
+    platform: string;
+    profile_id: string | null;
+    status: string;
+    company_id: string;
+  };
+
+  if (conn.status !== "auth_required" && conn.status !== "disconnected") {
+    return validationError(
+      `Connection status is '${conn.status}' — reconnect only applies to auth_required or disconnected connections.`,
+    );
+  }
+
+  if (!conn.profile_id) {
+    // No bundle.social profile — connection was never fully provisioned.
+    // Can't reconnect without a profile (this is a connect, not a reconnect).
+    return validationError("This connection has no associated profile. Contact your account manager.");
+  }
+
+  const bundlePlatform = SOCIAL_TO_BUNDLE[conn.platform];
+  if (!bundlePlatform) {
+    return validationError(
+      `Platform "${conn.platform}" cannot be reconnected via the portal. Contact your account manager.`,
+    );
+  }
+
+  // ─── Step 3: initiate OAuth popup via bundle.social ────────────────────
+  // The portal callback URL carries the raw token as portal_token so the
+  // callback can validate the session server-side without a Supabase cookie.
+  // company_id is NOT embedded in the redirect URL — it is re-derived from
+  // the portal_token in the callback (server-side only).
+  const portalCallbackUrl = `${req.nextUrl.origin}/api/portal/connections/callback?portal_token=${token}&popup=1`;
+
+  const result = await initiateProfileConnect({
+    profileId: conn.profile_id,
+    platform: bundlePlatform,
+    redirectUrl: portalCallbackUrl,
+    disableAutoLogin: true,
+    withBusinessScope: WITH_BUSINESS_SCOPE.has(bundlePlatform),
+  });
+
+  if (!result.ok) {
+    logger.error("portal.reconnect.initiate_failed", {
+      connectionId,
+      companyId,
+      err: result.error.message,
+    });
+    return internalError(result.error.message);
+  }
+
+  logger.info("portal.reconnect.initiated", {
+    connectionId,
+    companyId,
+    platform: conn.platform,
+  });
+
+  return NextResponse.json(
+    { ok: true, data: { url: result.data.url }, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/app/api/portal/connections/callback/route.ts
+++ b/app/api/portal/connections/callback/route.ts
@@ -166,8 +166,26 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 }
 
 // ---------------------------------------------------------------------------
-// popupClose — same pattern as the operator callback.
-// Sends HTML that postMessages the result to window.opener and closes.
+// jsonHtml — produce HTML-safe JSON for embedding inside <script> tags.
+//
+// JSON.stringify does NOT escape <, >, or / by default in Node.js, so
+// a payload like {"reason":"</script><script>..."} would break out of
+// the <script> tag and enable reflected XSS. Unicode-escape those three
+// characters so the JSON is safe inside any HTML context.
+//
+// This is the standard fix for CWE-79 / OWASP A03 in <script> contexts.
+// ---------------------------------------------------------------------------
+function jsonHtml(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/\//g, "\\u002f");
+}
+
+// ---------------------------------------------------------------------------
+// popupClose — sends HTML that postMessages the result to window.opener.
+// Uses jsonHtml() to prevent the bundle.social error-code param from
+// breaking out of the <script> tag via reflected XSS.
 // ---------------------------------------------------------------------------
 function popupClose(
   req: NextRequest,
@@ -175,7 +193,7 @@ function popupClose(
   reason?: string,
 ): NextResponse {
   const origin = req.nextUrl.origin;
-  const payload = JSON.stringify({
+  const payload = jsonHtml({
     type: "bundle-connect-complete",
     connect,
     ...(reason ? { reason } : {}),
@@ -188,7 +206,7 @@ function popupClose(
 (function () {
   try {
     if (window.opener && !window.opener.closed) {
-      window.opener.postMessage(${payload}, ${JSON.stringify(origin)});
+      window.opener.postMessage(${payload}, ${jsonHtml(origin)});
     }
   } catch (e) {}
   window.close();

--- a/app/api/portal/connections/callback/route.ts
+++ b/app/api/portal/connections/callback/route.ts
@@ -1,0 +1,204 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { logger } from "@/lib/logger";
+import { validate } from "@/lib/platform/magic-link";
+import { syncBundlesocialConnections } from "@/lib/platform/social/connections";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// GET /api/portal/connections/callback
+//
+// B4 client portal — receives bundle.social OAuth callback after a client
+// reconnects their social connection. No Supabase session. portal_token IS
+// the auth.
+//
+// SECURITY — COMPANY BINDING (Requirement #1, hard requirement):
+//   company_id is derived SERVER-SIDE from the magic_links row identified by
+//   portal_token. The client never supplies company_id. bundle.social never
+//   supplies company_id. No URL param from this request is used for binding.
+//
+// Cross-tenant guard (Requirement #2):
+//   checkCrossTenantConflict() runs via the SAME syncBundlesocialConnections()
+//   function as the operator path — not reimplemented, not branched around.
+//
+// Cron carry-forward (from Steven 2026-06-03):
+//   On reconnect success, NULL both pre_expiry_7d_sent_at and
+//   pre_expiry_1d_sent_at on the connection so the next expiry cycle can
+//   send fresh notices.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const url = new URL(req.url);
+  const portalToken = url.searchParams.get("portal_token");
+  const isPopup = url.searchParams.get("popup") === "1";
+
+  // ─── Step 1: validate magic_links session ──────────────────────────────
+  if (!portalToken || !/^[0-9a-f]{64}$/i.test(portalToken)) {
+    return popupClose(req, "error", "invalid-session");
+  }
+
+  const session = await validate(portalToken);
+  if (!session.valid) {
+    logger.warn("portal.callback.session_invalid", {
+      reason: session.reason,
+      popup: isPopup,
+    });
+    return popupClose(req, "error", "session-expired");
+  }
+
+  // company_id derived exclusively from magic_links row.
+  // No URL parameter, no request body, no cookie contributes to this value.
+  const companyId = session.link.company_id;
+  if (!companyId) {
+    logger.error("portal.callback.no_company_id", { link_id: session.link.id });
+    return popupClose(req, "error", "invalid-session");
+  }
+
+  // ─── Step 2: classify bundle.social callback params ────────────────────
+  // bundle.social posts back with ?success=... or ?error=... params (new
+  // format) or ?<platform>-callback=... (old format). Errors mean OAuth
+  // never completed — return early without syncing.
+  const successParam = url.searchParams.get("success");
+  const errorParam   = url.searchParams.get("error");
+
+  if (errorParam) {
+    logger.info("portal.callback.oauth_error", { companyId, error: errorParam });
+    return popupClose(req, "error", errorParam);
+  }
+
+  if (!successParam) {
+    // No success or error — check old-format params
+    const isOldFormat = Array.from(url.searchParams.keys()).some(
+      (k) => k.endsWith("-callback"),
+    );
+    if (!isOldFormat) {
+      // No recognisable OAuth completion signal — close without action.
+      logger.warn("portal.callback.no_oauth_signal", { companyId });
+      return popupClose(req, "noop");
+    }
+  }
+
+  // ─── Step 3: sync — SAME function as operator path ─────────────────────
+  // syncBundlesocialConnections calls checkCrossTenantConflict() internally
+  // on every inserted connection. attributeNewToCompanyId is the server-side
+  // derived companyId — never influenced by the client.
+  //
+  // forceCrossTenantOverride is intentionally omitted — the portal never
+  // overrides cross-tenant protection (no "I manage both" flow for clients).
+  const sync = await syncBundlesocialConnections({
+    companyId,
+    attributeNewToCompanyId: companyId,
+  });
+
+  if (!sync.ok) {
+    logger.error("portal.callback.sync_failed", {
+      companyId,
+      err: sync.error.message,
+      code: sync.error.code,
+    });
+    return popupClose(req, "error", "sync-failed");
+  }
+
+  logger.info("portal.callback.synced", {
+    companyId,
+    inserted: sync.data.inserted,
+    updated: sync.data.updated,
+  });
+
+  // ─── Step 4: reset pre_expiry sent-at columns on reconnected connection ─
+  // Carry-forward requirement (Steven 2026-06-03): when a connection is
+  // successfully reconnected and expires_at is refreshed by the sync, NULL
+  // both pre_expiry_*_sent_at columns so the next expiry cycle can send
+  // fresh notices. Without this, the cron silently stops after one cycle.
+  //
+  // We find the most recently-updated healthy connection for this company
+  // (the one just reconnected). The sync already set status=healthy.
+  if (sync.data.inserted > 0 || sync.data.updated > 0) {
+    const svc = getServiceRoleClient();
+    const { data: reconnected } = await svc
+      .from("social_connections")
+      .select("id")
+      .eq("company_id", companyId)
+      .eq("status", "healthy")
+      .not("expires_at", "is", null)
+      .order("updated_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (reconnected?.id) {
+      const { error: resetErr } = await svc
+        .from("social_connections")
+        .update({
+          pre_expiry_7d_sent_at: null,
+          pre_expiry_1d_sent_at: null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", reconnected.id)
+        .eq("company_id", companyId); // explicit company guard even on update
+
+      if (resetErr) {
+        // Non-fatal: log and continue. The cron will re-send notices
+        // after the existing timestamps expire regardless.
+        logger.warn("portal.callback.reset_sent_at_failed", {
+          connectionId: reconnected.id,
+          err: resetErr.message,
+        });
+      } else {
+        logger.info("portal.callback.reset_pre_expiry_sent_at", {
+          connectionId: reconnected.id,
+          companyId,
+        });
+      }
+    }
+  }
+
+  // ─── Step 5: return popup close response ───────────────────────────────
+  const connectResult = sync.data.inserted > 0
+    ? "success"
+    : sync.data.updated > 0
+      ? "success"
+      : "noop";
+
+  return popupClose(req, connectResult);
+}
+
+// ---------------------------------------------------------------------------
+// popupClose — same pattern as the operator callback.
+// Sends HTML that postMessages the result to window.opener and closes.
+// ---------------------------------------------------------------------------
+function popupClose(
+  req: NextRequest,
+  connect: string,
+  reason?: string,
+): NextResponse {
+  const origin = req.nextUrl.origin;
+  const payload = JSON.stringify({
+    type: "bundle-connect-complete",
+    connect,
+    ...(reason ? { reason } : {}),
+  });
+
+  const html = `<!DOCTYPE html>
+<html>
+<body>
+<script>
+(function () {
+  try {
+    if (window.opener && !window.opener.closed) {
+      window.opener.postMessage(${payload}, ${JSON.stringify(origin)});
+    }
+  } catch (e) {}
+  window.close();
+})();
+</script>
+</body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -157,6 +157,9 @@ function isPublicPath(pathname: string): boolean {
   // Does NOT match /portals, /portalnews, /portal-admin etc. because
   // those do not begin with "/portal/" and are not "/portal" exactly.
   if (pathname === "/portal" || pathname.startsWith("/portal/")) return true;
+  // /api/portal/* — B4 portal API (session validated via magic-link token,
+  // no Supabase cookie). Covers the reconnect initiation and OAuth callback.
+  if (pathname.startsWith("/api/portal/")) return true;
   // /api/platform/proofing/link-request — public re-request endpoint.
   if (pathname === "/api/platform/proofing/link-request") return true;
   // All /api/auth/* endpoints (login, logout-not-applicable-here,

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -788,8 +788,10 @@ function check7_unauthenticatedApi(): Issue[] {
     "/api/platform/invitations/accept", // P2-3 magic-link redemption (token-is-auth)
     "/api/optimiser/health",            // module liveness probe (middleware-gated, no user data)
     "/api/debug/env-check",             // staging/dev diagnostic; returns 404 in production (VERCEL_ENV guard)
-    "/api/platform/magic-link/login",       // B1 passwordless login issuance — intentionally public; rate-limited; no user data returned
-    "/api/platform/proofing/link-request",  // B2 self-serve re-request — intentionally public; rate-limited; returns ok:true regardless of match
+    "/api/platform/magic-link/login",         // B1 passwordless login issuance — intentionally public; rate-limited; no user data returned
+    "/api/platform/proofing/link-request",    // B2 self-serve re-request — intentionally public; rate-limited; returns ok:true regardless of match
+    "/api/portal/connections/:param/reconnect", // B4 portal reconnect initiation — token-is-auth; magic-link session validated server-side
+    "/api/portal/connections/callback",         // B4 portal OAuth callback — token-is-auth via portal_token query param
   ]);
 
   // Auth markers — any of these in the file body indicates the route gates itself.


### PR DESCRIPTION
## Summary

B4 Step 5 — portal OAuth callback and reconnect initiation routes.

**HARD STOP — Steven approved binding logic, merge manually, no auto-merge.**

## Security properties (confirmed before merge)

**company_id binding (Requirement #1):**
- Reconnect initiation: derived from `magic_links.company_id` via `validate(token)` — client never supplies it
- OAuth callback: derived from `magic_links.company_id` via `validate(portal_token)` — not from any URL param
- No `company_id` anywhere in the redirect URL

**checkCrossTenantConflict (Requirement #2):**
- Called via `syncBundlesocialConnections()` — same function as operator path, not reimplemented

**forceCrossTenantOverride:** intentionally omitted — portal never bypasses cross-tenant protection

**pre_expiry reset (carry-forward):** both `pre_expiry_7d_sent_at` and `pre_expiry_1d_sent_at` NULLed on reconnect success

## Confirms (from Steven's review)

1. `/api/portal/*` is treated as a deliberate public boundary where token-is-auth is the stated invariant. Both current routes validate `portal_token` before acting.
2. `validate()` not `consume()` in callback — intentional. `consumed_at` was set when the client first loaded the portal page. `validate()` checks `session_expires_at` only, surviving the OAuth round-trip within the 2h reconnect TTL.

## Files

- `app/api/portal/connections/[connectionId]/reconnect/route.ts` — initiation
- `app/api/portal/connections/callback/route.ts` — callback
- `middleware.ts` — `/api/portal/*` public
- `scripts/audit.ts` — allowlist (token-is-auth, no platform session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)