### PR TITLE
fix(security): extract jsonHtml to lib/http; fix live reflected-xss in operator oauth callback (cwe-79)

### DIFF
--- a/app/api/platform/social/connections/callback/route.ts
+++ b/app/api/platform/social/connections/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
+import { jsonHtml } from "@/lib/http";
 import { enqueuePostHistoryImport } from "@/lib/platform/social/analytics-ingest";
 import { logger } from "@/lib/logger";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
@@ -226,7 +227,7 @@ function popupCloseResponse(
     process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ||
     new URL(req.url).origin;
 
-  const payload = JSON.stringify({
+  const payload = jsonHtml({
     type: "bundle-connect-complete",
     connect: connectParam,
     ...(reason ? { reason } : {}),
@@ -234,15 +235,13 @@ function popupCloseResponse(
     ...(attemptedPlatform ? { attempted_platform: attemptedPlatform } : {}),
   });
 
-  // Strict target origin — only our own origin accepts this message.
-  // No user-controlled data is embedded in the script.
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="utf-8"><title>Connecting…</title></head>
 <body>
 <script>
 (function () {
-  var targetOrigin = ${JSON.stringify(origin)};
+  var targetOrigin = ${jsonHtml(origin)};
   var payload = ${payload};
   try {
     if (window.opener && !window.opener.closed) {

--- a/app/api/portal/connections/callback/route.ts
+++ b/app/api/portal/connections/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
+import { jsonHtml } from "@/lib/http";
 import { logger } from "@/lib/logger";
 import { validate } from "@/lib/platform/magic-link";
 import { syncBundlesocialConnections } from "@/lib/platform/social/connections";
@@ -166,26 +167,9 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 }
 
 // ---------------------------------------------------------------------------
-// jsonHtml — produce HTML-safe JSON for embedding inside <script> tags.
-//
-// JSON.stringify does NOT escape <, >, or / by default in Node.js, so
-// a payload like {"reason":"</script><script>..."} would break out of
-// the <script> tag and enable reflected XSS. Unicode-escape those three
-// characters so the JSON is safe inside any HTML context.
-//
-// This is the standard fix for CWE-79 / OWASP A03 in <script> contexts.
-// ---------------------------------------------------------------------------
-function jsonHtml(data: unknown): string {
-  return JSON.stringify(data)
-    .replace(/</g, "\\u003c")
-    .replace(/>/g, "\\u003e")
-    .replace(/\//g, "\\u002f");
-}
-
-// ---------------------------------------------------------------------------
 // popupClose — sends HTML that postMessages the result to window.opener.
-// Uses jsonHtml() to prevent the bundle.social error-code param from
-// breaking out of the <script> tag via reflected XSS.
+// Uses jsonHtml() (from lib/http) to prevent the bundle.social error-code
+// param from breaking out of the <script> tag via reflected XSS (CWE-79).
 // ---------------------------------------------------------------------------
 function popupClose(
   req: NextRequest,

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -231,6 +231,26 @@ function formatZodIssues(err: ZodError): Array<{
   }));
 }
 
+// ---------------------------------------------------------------------------
+// jsonHtml — HTML-safe JSON serialisation for embedding inside <script> tags.
+//
+// JSON.stringify does NOT escape <, >, or / by default in Node.js. A value
+// containing `</script>` would break out of a <script> context and enable
+// reflected XSS (CWE-79). Unicode-escaping those three characters makes the
+// output safe in any HTML embedding position.
+//
+// Used by the bundle.social OAuth popup-close handlers:
+//   - app/api/platform/social/connections/callback/route.ts
+//   - app/api/portal/connections/callback/route.ts
+// One canonical implementation — no drift between the two paths.
+// ---------------------------------------------------------------------------
+export function jsonHtml(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/\//g, "\\u002f");
+}
+
 // Race a promise against a timeout; rejects with "Request timed out after Xms"
 // if the promise doesn't settle first. Use for external calls (Anthropic, WP,
 // Cloudflare) where a hanging request would drain the serverless function pool.


### PR DESCRIPTION
## Summary

Live reflected-XSS on the production OAuth callback route.

**Finding:** `JSON.stringify` does not HTML-encode `<`, `>`, `/` in Node.js. The `popupCloseResponse()` function in `app/api/platform/social/connections/callback/route.ts` embedded a bundle.social callback param (`reason`) directly in a `<script>` tag via template literal. A crafted `?error=` or `?reason=` param could break out of the tag. Same class as the CodeQL HIGH finding in PR #1276 (portal callback) — not caught by CodeQL on this route because it wasn't in the diff.

**Fix:** Extract `jsonHtml()` to `lib/http.ts` (one canonical implementation). Apply it in both callback files. No local copies.

## Diff

- `lib/http.ts` — adds `export function jsonHtml(data: unknown): string` with Unicode-escape of `<`, `>`, `/`
- `app/api/platform/social/connections/callback/route.ts` — imports `jsonHtml` from `lib/http`; removes local copy; uses it for `payload` and `targetOrigin`
- `app/api/portal/connections/callback/route.ts` — imports `jsonHtml` from `lib/http`; removes local copy that was added in #1276

## Binding / postMessage logic unchanged

The function signature, parameter names, `connectParam`/`reason`/`connectionId`/`attemptedPlatform` usage, HTML structure, and `postMessage` call are byte-for-byte identical. Only the JSON serialisation is replaced.

**HARD STOP — awaiting Steven's explicit merge. No auto-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)