### PR TITLE
feat(b4): portal contact email/name fields on company settings (step 7)

### DIFF
--- a/app/api/platform/companies/[id]/portal-contact/route.ts
+++ b/app/api/platform/companies/[id]/portal-contact/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { internalError, readJsonBody, validationError } from "@/lib/http";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// PUT /api/platform/companies/[id]/portal-contact
+//
+// Update portal_contact_email and portal_contact_name on platform_companies.
+// Gate: manage_connections (admin). Both fields are optional and nullable.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Schema = z.object({
+  portal_contact_email: z.string().email().nullable().optional(),
+  portal_contact_name:  z.string().max(200).nullable().optional(),
+});
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id: companyId } = await params;
+
+  const gate = await requireCanDoForApi(companyId, "manage_connections");
+  if (gate.kind === "deny") return gate.response;
+
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body is required.");
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Invalid request.", { issues: parsed.error.issues });
+  }
+
+  const svc = getServiceRoleClient();
+  const { error } = await svc
+    .from("platform_companies")
+    .update({
+      portal_contact_email: parsed.data.portal_contact_email ?? null,
+      portal_contact_name:  parsed.data.portal_contact_name  ?? null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", companyId);
+
+  if (error) {
+    return internalError(`Failed to update portal contact: ${error.message}`);
+  }
+
+  return NextResponse.json(
+    { ok: true, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/components/PlatformCompanyDetail.tsx
+++ b/components/PlatformCompanyDetail.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { cn } from "@/lib/utils";
 import type { CompanyDetail, CompanyStats } from "@/lib/platform/companies";
+import { PortalContactForm } from "@/components/admin/PortalContactForm";
 
 // P3-3 — company detail. Tabs: Overview (default), Settings, Members.
 // Overview shows quick stats cards + key sections for staff operators.
@@ -284,6 +285,22 @@ function SettingsTab({ company }: { company: CompanyDetail["company"] }) {
           <dd>{formatDate(company.created_at)}</dd>
         </div>
       </dl>
+
+      {/* B4 — portal contact for pre-expiry and reconnect notifications */}
+      <div className="border-t px-4 py-4">
+        <h3 className="mb-3 text-sm font-semibold text-foreground">
+          Portal contact
+        </h3>
+        <p className="mb-3 text-xs text-muted-foreground">
+          Who receives pre-expiry warnings and reconnect invites for social
+          connections. Leave blank to fall back to the company&apos;s primary admin.
+        </p>
+        <PortalContactForm
+          companyId={company.id}
+          initialEmail={company.portal_contact_email ?? ""}
+          initialName={company.portal_contact_name ?? ""}
+        />
+      </div>
     </section>
   );
 }

--- a/components/admin/PortalContactForm.tsx
+++ b/components/admin/PortalContactForm.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+
+// ---------------------------------------------------------------------------
+// PortalContactForm — B4 admin UI to set portal_contact_email/name.
+// Rendered in the company Settings tab.
+// ---------------------------------------------------------------------------
+
+type Props = {
+  companyId: string;
+  initialEmail: string;
+  initialName: string;
+};
+
+export function PortalContactForm({ companyId, initialEmail, initialName }: Props) {
+  const [email, setEmail]   = useState(initialEmail);
+  const [name,  setName]    = useState(initialName);
+  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus("saving");
+    setErrorMsg(null);
+
+    const res = await fetch(
+      `/api/platform/companies/${companyId}/portal-contact`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          portal_contact_email: email.trim() || null,
+          portal_contact_name:  name.trim()  || null,
+        }),
+      },
+    );
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setErrorMsg(body?.error?.message ?? "Save failed.");
+      setStatus("error");
+      return;
+    }
+
+    setStatus("saved");
+    setTimeout(() => setStatus("idle"), 2000);
+  }
+
+  return (
+    <form onSubmit={handleSave} className="space-y-3 max-w-sm">
+      <div>
+        <label
+          htmlFor="portal-contact-email"
+          className="block text-xs font-medium text-muted-foreground mb-1"
+        >
+          Contact email
+        </label>
+        <input
+          id="portal-contact-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="client@example.com"
+          className="block w-full rounded-md border bg-background px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          disabled={status === "saving"}
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="portal-contact-name"
+          className="block text-xs font-medium text-muted-foreground mb-1"
+        >
+          Contact name <span className="font-normal">(optional)</span>
+        </label>
+        <input
+          id="portal-contact-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Jane Smith"
+          className="block w-full rounded-md border bg-background px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          disabled={status === "saving"}
+        />
+      </div>
+
+      {errorMsg && (
+        <p className="text-xs text-destructive">{errorMsg}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === "saving"}
+        className="rounded-md bg-primary px-3 py-1.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+      >
+        {status === "saving" ? "Saving…" : status === "saved" ? "Saved ✓" : "Save"}
+      </button>
+    </form>
+  );
+}

--- a/lib/platform/companies/get.ts
+++ b/lib/platform/companies/get.ts
@@ -75,7 +75,7 @@ export async function getPlatformCompany(
     svc
       .from("platform_companies")
       .select(
-        "id, name, slug, domain, timezone, is_opollo_internal, approval_default_required, approval_default_rule, concurrent_publish_limit, created_at, updated_at",
+        "id, name, slug, domain, timezone, is_opollo_internal, approval_default_required, approval_default_rule, concurrent_publish_limit, portal_contact_email, portal_contact_name, created_at, updated_at",
       )
       .eq("id", id)
       .maybeSingle(),

--- a/lib/platform/companies/types.ts
+++ b/lib/platform/companies/types.ts
@@ -8,6 +8,9 @@ export type PlatformCompany = {
   approval_default_required: boolean;
   approval_default_rule: "any_one" | "all_must";
   concurrent_publish_limit: number;
+  // B4 portal contact (migration 0177)
+  portal_contact_email: string | null;
+  portal_contact_name: string | null;
   created_at: string;
   updated_at: string;
 };


### PR DESCRIPTION
## Summary

B4 Step 7 — admin UI to configure who receives portal notifications.

- `PlatformCompany` type + query: adds `portal_contact_email`, `portal_contact_name`
- `PUT /api/platform/companies/[id]/portal-contact` — admin gate, nullable
- `PortalContactForm` component — in company Settings tab below existing fields

Used by the pre-expiry cron (Step 6) to determine email recipient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)