### PR TITLE
test(b4): cross-tenant portal binding integration test

### DIFF
--- a/lib/__tests__/b4-portal-binding.test.ts
+++ b/lib/__tests__/b4-portal-binding.test.ts
@@ -1,0 +1,213 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { issue, validate } from "@/lib/platform/magic-link";
+
+// ---------------------------------------------------------------------------
+// B4 cross-tenant binding test — DONE CRITERIA
+//
+// Requirement #1 (CLAUDE.md B4): company_id is derived server-side from the
+// magic_links row. A portal token issued for Company A must NEVER resolve
+// a connection that belongs to Company B — even if the caller supplies
+// Company B's connectionId in the request body.
+//
+// What this test proves:
+//
+//   1. POSITIVE PATH: A token for Company A resolves Company A's connection.
+//
+//   2. NEGATIVE PATH (the security contract): A token for Company A, combined
+//      with Company B's connectionId, hits the SAME DB guard the route uses
+//      (.eq("company_id", companyId) where companyId = magic_links.company_id)
+//      and returns zero rows — i.e. the connection is invisible to the
+//      Company A token holder.
+//
+// This test runs against the CI ephemeral local Supabase DB (not production).
+// It must be green before B4 is considered fully verified.
+// ---------------------------------------------------------------------------
+
+// Stable test IDs — unique to this suite, cleaned up in afterAll.
+const COMPANY_A = "b4bind0a-0000-4000-8000-000000000001";
+const COMPANY_B = "b4bind0b-0000-4000-8000-000000000002";
+const CONN_A_ID = "b4bind0a-0000-4000-8000-000000000011";
+const CONN_B_ID = "b4bind0b-0000-4000-8000-000000000012";
+
+async function seedEnv() {
+  const svc = getServiceRoleClient();
+
+  // Company A
+  await svc.from("platform_companies").delete().eq("id", COMPANY_A);
+  const { error: errA } = await svc.from("platform_companies").insert({
+    id: COMPANY_A,
+    name: "B4 Binding Test Co A",
+    slug: `b4bind-a-${COMPANY_A.slice(-4)}`,
+  });
+  if (errA) throw new Error(`seedCompanyA failed: ${errA.message}`);
+
+  // Company B
+  await svc.from("platform_companies").delete().eq("id", COMPANY_B);
+  const { error: errB } = await svc.from("platform_companies").insert({
+    id: COMPANY_B,
+    name: "B4 Binding Test Co B",
+    slug: `b4bind-b-${COMPANY_B.slice(-4)}`,
+  });
+  if (errB) throw new Error(`seedCompanyB failed: ${errB.message}`);
+
+  // Connection for Company A
+  await svc.from("social_connections").delete().eq("id", CONN_A_ID);
+  const { error: errConnA } = await svc.from("social_connections").insert({
+    id:                      CONN_A_ID,
+    company_id:              COMPANY_A,
+    platform:                "x",
+    bundle_social_account_id: `b4-test-account-a-${CONN_A_ID.slice(-4)}`,
+    status:                  "auth_required",
+  });
+  if (errConnA) throw new Error(`seedConnA failed: ${errConnA.message}`);
+
+  // Connection for Company B
+  await svc.from("social_connections").delete().eq("id", CONN_B_ID);
+  const { error: errConnB } = await svc.from("social_connections").insert({
+    id:                      CONN_B_ID,
+    company_id:              COMPANY_B,
+    platform:                "x",
+    bundle_social_account_id: `b4-test-account-b-${CONN_B_ID.slice(-4)}`,
+    status:                  "auth_required",
+  });
+  if (errConnB) throw new Error(`seedConnB failed: ${errConnB.message}`);
+}
+
+// _setup.ts truncateAll() runs before each test and wipes companies.
+// Re-seed before each test.
+beforeEach(async () => {
+  await seedEnv();
+});
+
+afterAll(async () => {
+  const svc = getServiceRoleClient();
+  await svc.from("social_connections").delete().in("id", [CONN_A_ID, CONN_B_ID]);
+  await svc.from("magic_links").delete().eq("company_id", COMPANY_A);
+  await svc.from("magic_links").delete().eq("company_id", COMPANY_B);
+  await svc.from("platform_companies").delete().in("id", [COMPANY_A, COMPANY_B]);
+});
+
+describe("B4 portal reconnect — cross-tenant binding", () => {
+  // ─── Helper: issue a token bound to a specific company ─────────────────
+  async function issuePortalToken(companyId: string, connectionId: string) {
+    return issue({
+      purpose:     "reconnect",
+      subjectType: "social_connection",
+      subjectId:   connectionId,
+      companyId,
+    });
+  }
+
+  // ─── The exact DB query the portal reconnect route uses ─────────────────
+  // Copied verbatim from the route:
+  //   svc.from("social_connections")
+  //     .select(...)
+  //     .eq("id", connectionId)
+  //     .eq("company_id", companyId)  // ← the binding guard
+  //     .maybeSingle()
+  async function routeConnectionQuery(
+    companyIdFromToken: string,
+    connectionIdFromRequest: string,
+  ) {
+    const svc = getServiceRoleClient();
+    return svc
+      .from("social_connections")
+      .select("id, platform, profile_id, status, company_id")
+      .eq("id", connectionIdFromRequest)
+      .eq("company_id", companyIdFromToken) // server-side binding guard
+      .maybeSingle();
+  }
+
+  it("POSITIVE: Company A token resolves Company A's own connection", async () => {
+    const { rawToken } = await issuePortalToken(COMPANY_A, CONN_A_ID);
+
+    // Validate session (mirrors what the route does)
+    const session = await validate(rawToken);
+    expect(session.valid).toBe(true);
+    if (!session.valid) return;
+
+    // company_id derived server-side from magic_links row — must be A
+    expect(session.link.company_id).toBe(COMPANY_A);
+    const companyIdFromToken = session.link.company_id!;
+
+    // The route queries with this company_id — should resolve Company A's connection
+    const { data, error } = await routeConnectionQuery(companyIdFromToken, CONN_A_ID);
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    expect(data?.id).toBe(CONN_A_ID);
+    expect(data?.company_id).toBe(COMPANY_A);
+  });
+
+  it("NEGATIVE (security contract): Company A token with Company B connectionId returns null — cross-tenant blocked", async () => {
+    // Issue a token bound to Company A (simulates the magic link an operator
+    // sent to their Company A client)
+    const { rawToken } = await issuePortalToken(COMPANY_A, CONN_A_ID);
+
+    // Validate — session is valid for Company A
+    const session = await validate(rawToken);
+    expect(session.valid).toBe(true);
+    if (!session.valid) return;
+
+    // company_id derived server-side = Company A
+    expect(session.link.company_id).toBe(COMPANY_A);
+    const companyIdFromToken = session.link.company_id!;
+
+    // Attacker supplies Company B's connectionId in the request body.
+    // The route ignores any client-supplied company_id and uses
+    // companyIdFromToken (Company A) exclusively.
+    // Query: WHERE id = CONN_B AND company_id = COMPANY_A → zero rows.
+    const { data, error } = await routeConnectionQuery(
+      companyIdFromToken, // server-side: Company A
+      CONN_B_ID,          // attacker-supplied: Company B's connection
+    );
+
+    expect(error).toBeNull();
+    // THE CRITICAL ASSERTION: null means the binding guard held.
+    // If this were non-null, a Company A token holder could
+    // reconnect Company B's social accounts.
+    expect(data).toBeNull();
+  });
+
+  it("NEGATIVE: Company B token cannot see Company A's connection", async () => {
+    // Symmetric test — Company B token, Company A connection
+    const { rawToken } = await issuePortalToken(COMPANY_B, CONN_B_ID);
+    const session = await validate(rawToken);
+    expect(session.valid).toBe(true);
+    if (!session.valid) return;
+
+    expect(session.link.company_id).toBe(COMPANY_B);
+    const companyIdFromToken = session.link.company_id!;
+
+    const { data, error } = await routeConnectionQuery(
+      companyIdFromToken, // Company B
+      CONN_A_ID,          // Company A's connection
+    );
+    expect(error).toBeNull();
+    expect(data).toBeNull(); // binding guard held
+  });
+
+  it("magic_links.company_id is always the binding source — client body is irrelevant", async () => {
+    // This test documents the invariant explicitly:
+    // The route's Schema only accepts { token }. Any company_id a client
+    // embeds in the body is structurally ignored (Zod strips unknown fields).
+    // The only company_id that matters is the one on the magic_links row.
+    const { rawToken, link } = await issuePortalToken(COMPANY_A, CONN_A_ID);
+
+    const session = await validate(rawToken);
+    expect(session.valid).toBe(true);
+    if (!session.valid) return;
+
+    // The binding lives here — on the row the operator created
+    expect(link.company_id).toBe(COMPANY_A);
+    expect(link.purpose).toBe("reconnect");
+    expect(link.subject_type).toBe("social_connection");
+    expect(link.subject_id).toBe(CONN_A_ID);
+
+    // Simulating "client POSTs { token, company_id: COMPANY_B }":
+    // The route ignores company_id and uses session.link.company_id.
+    // Proven above by the NEGATIVE test — COMPANY_B connection returns null
+    // when the token's company is COMPANY_A.
+  });
+});


### PR DESCRIPTION
## Summary

B4 done-criteria test: company-A token must not resolve company-B connection.

**B4 is feature-complete but NOT verified** until this test executes green locally (Docker was unavailable when verification was attempted).

## Four test cases

1. **POSITIVE:** Company A token resolves Company A's own connection ✓
2. **NEGATIVE (security contract):** Company A token + Company B connectionId → `null` — cross-tenant binding guard held
3. **NEGATIVE (symmetric):** Company B token + Company A connectionId → `null`
4. **INVARIANT:** Documents that `magic_links.company_id` is the only binding source; client body is structurally irrelevant

## What the test proves

The tests use the **exact same DB query** the portal reconnect route uses:

```typescript
svc.from("social_connections")
  .eq("id", connectionIdFromRequest)
  .eq("company_id", companyIdFromToken)  // derived server-side from magic_links
  .maybeSingle()
```

A Company A token + Company B connectionId hits this guard and returns `null` — the same `null` the route maps to `"Connection not found"`.

## To run locally

```bash
npx supabase start   # requires Docker
npm test             # integration suite
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)