### PR TITLE
test(b4): rewrite binding test to call real route POST() handler

### DIFF
--- a/lib/__tests__/b4-portal-binding.test.ts
+++ b/lib/__tests__/b4-portal-binding.test.ts
@@ -1,3 +1,4 @@
+import { NextRequest } from "next/server";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -6,26 +7,30 @@ import { issue, validate } from "@/lib/platform/magic-link";
 // ---------------------------------------------------------------------------
 // B4 cross-tenant binding test — DONE CRITERIA
 //
-// Requirement #1 (CLAUDE.md B4): company_id is derived server-side from the
-// magic_links row. A portal token issued for Company A must NEVER resolve
-// a connection that belongs to Company B — even if the caller supplies
-// Company B's connectionId in the request body.
+// Tests the REAL route handler POST() from the actual route file.
+// NOT a copy of the route's query — the real function.
 //
-// What this test proves:
+// Red-proof contract: if the binding guard in the actual route is removed
+// (.eq("company_id", companyId) in the social_connections lookup), the
+// NEGATIVE test goes red because the route finds Company B's connection and
+// returns a DIFFERENT 400 error ("no profile") instead of "Connection not
+// found." The edit that causes red must be in:
 //
-//   1. POSITIVE PATH: A token for Company A resolves Company A's connection.
+//   app/api/portal/connections/[connectionId]/reconnect/route.ts
 //
-//   2. NEGATIVE PATH (the security contract): A token for Company A, combined
-//      with Company B's connectionId, hits the SAME DB guard the route uses
-//      (.eq("company_id", companyId) where companyId = magic_links.company_id)
-//      and returns zero rows — i.e. the connection is invisible to the
-//      Company A token holder.
+// NOT in this test file. If editing this file is required to make it fail,
+// the test is wrong.
 //
-// This test runs against the CI ephemeral local Supabase DB (not production).
-// It must be green before B4 is considered fully verified.
+// Test server note: Next.js route handlers import server-only modules but
+// run fine in Vitest's Node environment. No HTTP server needed — we call
+// POST() directly and check the returned NextResponse.
 // ---------------------------------------------------------------------------
 
-// Stable test IDs — unique to this suite, cleaned up in afterAll.
+// Import the ACTUAL route handler — not a copy of its query.
+// If the route drifts, this import ensures the test runs the real code.
+import { POST } from "@/app/api/portal/connections/[connectionId]/reconnect/route";
+
+// Stable test IDs unique to this suite.
 const COMPANY_A = "b4bind0a-0000-4000-8000-000000000001";
 const COMPANY_B = "b4bind0b-0000-4000-8000-000000000002";
 const CONN_A_ID = "b4bind0a-0000-4000-8000-000000000011";
@@ -34,180 +39,126 @@ const CONN_B_ID = "b4bind0b-0000-4000-8000-000000000012";
 async function seedEnv() {
   const svc = getServiceRoleClient();
 
-  // Company A
   await svc.from("platform_companies").delete().eq("id", COMPANY_A);
   const { error: errA } = await svc.from("platform_companies").insert({
-    id: COMPANY_A,
-    name: "B4 Binding Test Co A",
+    id: COMPANY_A, name: "B4 Binding Co A",
     slug: `b4bind-a-${COMPANY_A.slice(-4)}`,
   });
-  if (errA) throw new Error(`seedCompanyA failed: ${errA.message}`);
+  if (errA) throw new Error(`seedCompanyA: ${errA.message}`);
 
-  // Company B
   await svc.from("platform_companies").delete().eq("id", COMPANY_B);
   const { error: errB } = await svc.from("platform_companies").insert({
-    id: COMPANY_B,
-    name: "B4 Binding Test Co B",
+    id: COMPANY_B, name: "B4 Binding Co B",
     slug: `b4bind-b-${COMPANY_B.slice(-4)}`,
   });
-  if (errB) throw new Error(`seedCompanyB failed: ${errB.message}`);
+  if (errB) throw new Error(`seedCompanyB: ${errB.message}`);
 
-  // Connection for Company A
   await svc.from("social_connections").delete().eq("id", CONN_A_ID);
   const { error: errConnA } = await svc.from("social_connections").insert({
-    id:                      CONN_A_ID,
-    company_id:              COMPANY_A,
-    platform:                "x",
-    bundle_social_account_id: `b4-test-account-a-${CONN_A_ID.slice(-4)}`,
-    status:                  "auth_required",
+    id: CONN_A_ID, company_id: COMPANY_A,
+    platform: "x",
+    bundle_social_account_id: `b4-acct-a-${CONN_A_ID.slice(-4)}`,
+    status: "auth_required",
   });
-  if (errConnA) throw new Error(`seedConnA failed: ${errConnA.message}`);
+  if (errConnA) throw new Error(`seedConnA: ${errConnA.message}`);
 
-  // Connection for Company B
   await svc.from("social_connections").delete().eq("id", CONN_B_ID);
   const { error: errConnB } = await svc.from("social_connections").insert({
-    id:                      CONN_B_ID,
-    company_id:              COMPANY_B,
-    platform:                "x",
-    bundle_social_account_id: `b4-test-account-b-${CONN_B_ID.slice(-4)}`,
-    status:                  "auth_required",
+    id: CONN_B_ID, company_id: COMPANY_B,
+    platform: "x",
+    bundle_social_account_id: `b4-acct-b-${CONN_B_ID.slice(-4)}`,
+    status: "auth_required",
   });
-  if (errConnB) throw new Error(`seedConnB failed: ${errConnB.message}`);
+  if (errConnB) throw new Error(`seedConnB: ${errConnB.message}`);
 }
 
-// _setup.ts truncateAll() runs before each test and wipes companies.
-// Re-seed before each test.
-beforeEach(async () => {
-  await seedEnv();
-});
+beforeEach(async () => { await seedEnv(); });
 
 afterAll(async () => {
   const svc = getServiceRoleClient();
   await svc.from("social_connections").delete().in("id", [CONN_A_ID, CONN_B_ID]);
-  await svc.from("magic_links").delete().eq("company_id", COMPANY_A);
-  await svc.from("magic_links").delete().eq("company_id", COMPANY_B);
+  await svc.from("magic_links").delete().in("company_id", [COMPANY_A, COMPANY_B]);
   await svc.from("platform_companies").delete().in("id", [COMPANY_A, COMPANY_B]);
 });
 
-describe("B4 portal reconnect — cross-tenant binding", () => {
-  // ─── Helper: issue a token bound to a specific company ─────────────────
-  async function issuePortalToken(companyId: string, connectionId: string) {
-    return issue({
-      purpose:     "reconnect",
-      subjectType: "social_connection",
-      subjectId:   connectionId,
-      companyId,
+// Helper: create a test request to the real route.
+function makeReq(token: string): NextRequest {
+  return new NextRequest(
+    "http://localhost:3000/api/portal/connections/reconnect",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    },
+  );
+}
+
+// Helper: issue a portal magic link for a given company / connection.
+async function issuePortalToken(companyId: string, connectionId: string) {
+  return issue({
+    purpose: "reconnect",
+    subjectType: "social_connection",
+    subjectId: connectionId,
+    companyId,
+  });
+}
+
+describe("B4 portal reconnect — cross-tenant binding (REAL route)", () => {
+  it("NEGATIVE (security contract): Company A token + Company B connectionId returns 400 'Connection not found' — binding guard in the real route fires", async () => {
+    // Issue a token bound to Company A.
+    const { rawToken } = await issuePortalToken(COMPANY_A, CONN_A_ID);
+
+    // Call the REAL POST handler with Company B's connectionId.
+    // The route derives companyId server-side from the magic_links row (= COMPANY_A).
+    // The binding guard .eq("company_id", companyId) then filters out CONN_B
+    // because CONN_B.company_id = COMPANY_B ≠ COMPANY_A.
+    const response = await POST(makeReq(rawToken), {
+      params: Promise.resolve({ connectionId: CONN_B_ID }),
     });
-  }
 
-  // ─── The exact DB query the portal reconnect route uses ─────────────────
-  // Copied verbatim from the route:
-  //   svc.from("social_connections")
-  //     .select(...)
-  //     .eq("id", connectionId)
-  //     .eq("company_id", companyId)  // ← the binding guard
-  //     .maybeSingle()
-  async function routeConnectionQuery(
-    companyIdFromToken: string,
-    connectionIdFromRequest: string,
-  ) {
-    const svc = getServiceRoleClient();
-    return svc
-      .from("social_connections")
-      .select("id, platform, profile_id, status, company_id")
-      .eq("id", connectionIdFromRequest)
-      .eq("company_id", companyIdFromToken) // server-side binding guard
-      .maybeSingle();
-  }
+    // THE CRITICAL ASSERTION:
+    // "Connection not found." is returned ONLY when the binding guard fires.
+    // If the guard is removed from the actual route, the route finds CONN_B and
+    // returns a DIFFERENT 400 ("This connection has no associated profile..."),
+    // making this assertion fail RED — which is exactly the signal we want.
+    expect(response.status).toBe(400);
+    const body = await response.json() as { error?: { message?: string } };
+    expect(body.error?.message).toBe("Connection not found.");
+  });
 
-  it("POSITIVE: Company A token resolves Company A's own connection", async () => {
+  it("POSITIVE: Company A token + Company A's own connectionId does NOT return 'Connection not found' — binding check passes", async () => {
+    // Issue a token for Company A.
     const { rawToken } = await issuePortalToken(COMPANY_A, CONN_A_ID);
 
-    // Validate session (mirrors what the route does)
-    const session = await validate(rawToken);
-    expect(session.valid).toBe(true);
-    if (!session.valid) return;
+    // Call the REAL POST handler with Company A's own connection.
+    const response = await POST(makeReq(rawToken), {
+      params: Promise.resolve({ connectionId: CONN_A_ID }),
+    });
 
-    // company_id derived server-side from magic_links row — must be A
-    expect(session.link.company_id).toBe(COMPANY_A);
-    const companyIdFromToken = session.link.company_id!;
-
-    // The route queries with this company_id — should resolve Company A's connection
-    const { data, error } = await routeConnectionQuery(companyIdFromToken, CONN_A_ID);
-    expect(error).toBeNull();
-    expect(data).not.toBeNull();
-    expect(data?.id).toBe(CONN_A_ID);
-    expect(data?.company_id).toBe(COMPANY_A);
+    // The binding check passes (CONN_A belongs to COMPANY_A).
+    // The route then fails at profile_id (null) or bundle.social config — both are
+    // 400 errors that come AFTER the binding check, not from it.
+    // What we're asserting: NOT the binding error.
+    const body = await response.json() as { error?: { message?: string } };
+    expect(body.error?.message).not.toBe("Connection not found.");
+    // The error is "no profile" — the binding passed and the route went further.
+    expect(body.error?.message).toContain("no associated profile");
   });
 
-  it("NEGATIVE (security contract): Company A token with Company B connectionId returns null — cross-tenant blocked", async () => {
-    // Issue a token bound to Company A (simulates the magic link an operator
-    // sent to their Company A client)
-    const { rawToken } = await issuePortalToken(COMPANY_A, CONN_A_ID);
-
-    // Validate — session is valid for Company A
-    const session = await validate(rawToken);
-    expect(session.valid).toBe(true);
-    if (!session.valid) return;
-
-    // company_id derived server-side = Company A
-    expect(session.link.company_id).toBe(COMPANY_A);
-    const companyIdFromToken = session.link.company_id!;
-
-    // Attacker supplies Company B's connectionId in the request body.
-    // The route ignores any client-supplied company_id and uses
-    // companyIdFromToken (Company A) exclusively.
-    // Query: WHERE id = CONN_B AND company_id = COMPANY_A → zero rows.
-    const { data, error } = await routeConnectionQuery(
-      companyIdFromToken, // server-side: Company A
-      CONN_B_ID,          // attacker-supplied: Company B's connection
-    );
-
-    expect(error).toBeNull();
-    // THE CRITICAL ASSERTION: null means the binding guard held.
-    // If this were non-null, a Company A token holder could
-    // reconnect Company B's social accounts.
-    expect(data).toBeNull();
-  });
-
-  it("NEGATIVE: Company B token cannot see Company A's connection", async () => {
-    // Symmetric test — Company B token, Company A connection
-    const { rawToken } = await issuePortalToken(COMPANY_B, CONN_B_ID);
-    const session = await validate(rawToken);
-    expect(session.valid).toBe(true);
-    if (!session.valid) return;
-
-    expect(session.link.company_id).toBe(COMPANY_B);
-    const companyIdFromToken = session.link.company_id!;
-
-    const { data, error } = await routeConnectionQuery(
-      companyIdFromToken, // Company B
-      CONN_A_ID,          // Company A's connection
-    );
-    expect(error).toBeNull();
-    expect(data).toBeNull(); // binding guard held
-  });
-
-  it("magic_links.company_id is always the binding source — client body is irrelevant", async () => {
-    // This test documents the invariant explicitly:
-    // The route's Schema only accepts { token }. Any company_id a client
-    // embeds in the body is structurally ignored (Zod strips unknown fields).
-    // The only company_id that matters is the one on the magic_links row.
+  it("INVARIANT: magic_links.company_id is the only binding source — validate() confirms it came from the row, not the client", async () => {
+    // Prove that the token encodes company_id server-side and can't be forged.
     const { rawToken, link } = await issuePortalToken(COMPANY_A, CONN_A_ID);
 
+    // validate() reads back the magic_links row.
     const session = await validate(rawToken);
     expect(session.valid).toBe(true);
     if (!session.valid) return;
 
-    // The binding lives here — on the row the operator created
+    // company_id on the row matches what was set at issue time.
+    expect(session.link.company_id).toBe(COMPANY_A);
+    // The row has the right subject (the specific connection).
     expect(link.company_id).toBe(COMPANY_A);
-    expect(link.purpose).toBe("reconnect");
-    expect(link.subject_type).toBe("social_connection");
     expect(link.subject_id).toBe(CONN_A_ID);
-
-    // Simulating "client POSTs { token, company_id: COMPANY_B }":
-    // The route ignores company_id and uses session.link.company_id.
-    // Proven above by the NEGATIVE test — COMPANY_B connection returns null
-    // when the token's company is COMPANY_A.
+    expect(link.purpose).toBe("reconnect");
   });
 });

--- a/lib/__tests__/b4-portal-binding.test.ts
+++ b/lib/__tests__/b4-portal-binding.test.ts
@@ -31,10 +31,10 @@ import { issue, validate } from "@/lib/platform/magic-link";
 import { POST } from "@/app/api/portal/connections/[connectionId]/reconnect/route";
 
 // Stable test IDs unique to this suite.
-const COMPANY_A = "b4bind0a-0000-4000-8000-000000000001";
-const COMPANY_B = "b4bind0b-0000-4000-8000-000000000002";
-const CONN_A_ID = "b4bind0a-0000-4000-8000-000000000011";
-const CONN_B_ID = "b4bind0b-0000-4000-8000-000000000012";
+const COMPANY_A = "b4b400aa-0000-4000-8000-000000000001";
+const COMPANY_B = "b4b400bb-0000-4000-8000-000000000002";
+const CONN_A_ID = "b4b400aa-0000-4000-8000-000000000011";
+const CONN_B_ID = "b4b400bb-0000-4000-8000-000000000012";
 
 async function seedEnv() {
   const svc = getServiceRoleClient();


### PR DESCRIPTION
Replaces test-helper routeConnectionQuery() (copy of route logic) with
a direct call to the actual POST() from the real route file.

Red-proof edit must be in route.ts line 95, not this file.
See PR body for verification instructions.

NOT auto-merging — awaiting Steven's local red/green confirmation first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)