### PR TITLE
THROWAWAY: red-proof remove binding guard — DO NOT MERGE

### DIFF
--- a/app/api/portal/connections/[connectionId]/reconnect/route.ts
+++ b/app/api/portal/connections/[connectionId]/reconnect/route.ts
@@ -92,7 +92,7 @@ export async function POST(
     .from("social_connections")
     .select("id, platform, profile_id, status, company_id")
     .eq("id", connectionId)
-    .eq("company_id", companyId)  // ← cross-company guard
+    // GUARD INTENTIONALLY REMOVED — throwaway red-proof branch only
     .maybeSingle();
 
   if (connErr) {


### PR DESCRIPTION
## DO NOT MERGE — Red-proof only

This PR intentionally removes the cross-tenant binding guard from the portal reconnect route to prove the NEGATIVE test in `lib/__tests__/b4-portal-binding.test.ts` goes RED when the guard is absent.

**Base:** `test/b4-portal-binding-real-route` (PR #1281, guard intact)  
**Purpose:** CI red-proof — the NEGATIVE test must fail with a different error than "Connection not found."

Will be closed and branch deleted without merging once CI shows the red failure.