### PR TITLE
THROWAWAY: red-proof remove binding guard — DO NOT MERGE

### DIFF
--- a/app/api/portal/connections/[connectionId]/reconnect/route.ts
+++ b/app/api/portal/connections/[connectionId]/reconnect/route.ts
@@ -92,7 +92,7 @@ export async function POST(
     .from("social_connections")
     .select("id, platform, profile_id, status, company_id")
     .eq("id", connectionId)
-    .eq("company_id", companyId)  // ← cross-company guard
+    // GUARD REMOVED — throwaway red-proof only, never merges to main
     .maybeSingle();
 
   if (connErr) {


### PR DESCRIPTION
## DO NOT MERGE — Red-proof only

Removes .eq(company_id) from the portal reconnect route. The b4 binding NEGATIVE test must fail with a different error than 'Connection not found.' to prove the guard is what produces that response.

Will be closed without merging once CI shows the red failure.