### PR TITLE
feat(feedback): p3 — element picker, create popup, feedback widget

### DIFF
--- a/app/api/feedback/tickets/[id]/comments/route.ts
+++ b/app/api/feedback/tickets/[id]/comments/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { createRouteAuthClient } from "@/lib/auth";
+import { internalError, readJsonBody, validationError } from "@/lib/http";
+import { isCompanyMember, isOpolloStaff } from "@/lib/platform/auth";
+import { addComment } from "@/lib/feedback/tickets/comments";
+import { getTicket, listComments } from "@/lib/feedback/tickets/queries";
+
+// ---------------------------------------------------------------------------
+// POST /api/feedback/tickets/[id]/comments — add a comment (member or staff)
+// GET  /api/feedback/tickets/[id]/comments — list thread
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const CommentSchema = z.object({ body: z.string().min(1).max(2000) });
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResp?.user) {
+    return NextResponse.json({ ok: false, error: { code: "UNAUTHORIZED" } }, { status: 401 });
+  }
+  const userId = userResp.user.id;
+
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body must be valid JSON.");
+  const parsed = CommentSchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("body is required (max 2000 chars).", { issues: parsed.error.issues });
+  }
+
+  // Verify ticket visibility.
+  const ticket = await getTicket(id);
+  if (!ticket || ticket.deleted_at) {
+    return NextResponse.json({ ok: false, error: { code: "NOT_FOUND" } }, { status: 404 });
+  }
+
+  const [member, staff] = await Promise.all([
+    isCompanyMember(ticket.company_id, supabase),
+    isOpolloStaff(supabase),
+  ]);
+  if (!member && !staff) {
+    return NextResponse.json({ ok: false, error: { code: "FORBIDDEN" } }, { status: 403 });
+  }
+
+  const result = await addComment(id, parsed.data.body, userId);
+  if (!result.ok) return internalError(result.error);
+
+  return NextResponse.json(
+    { ok: true, data: { comment: result.comment }, timestamp: new Date().toISOString() },
+    { status: 201 },
+  );
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResp?.user) {
+    return NextResponse.json({ ok: false, error: { code: "UNAUTHORIZED" } }, { status: 401 });
+  }
+
+  const ticket = await getTicket(id);
+  if (!ticket || ticket.deleted_at) {
+    return NextResponse.json({ ok: false, error: { code: "NOT_FOUND" } }, { status: 404 });
+  }
+
+  const [member, staff] = await Promise.all([
+    isCompanyMember(ticket.company_id, supabase),
+    isOpolloStaff(supabase),
+  ]);
+  if (!member && !staff) {
+    return NextResponse.json({ ok: false, error: { code: "NOT_FOUND" } }, { status: 404 });
+  }
+
+  const comments = await listComments(id);
+  return NextResponse.json(
+    { ok: true, data: { comments }, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/app/api/feedback/tickets/[id]/reopen/route.ts
+++ b/app/api/feedback/tickets/[id]/reopen/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { createRouteAuthClient } from "@/lib/auth";
+import { internalError, readJsonBody } from "@/lib/http";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { addComment } from "@/lib/feedback/tickets/comments";
+import { updateTicketStatus } from "@/lib/feedback/tickets/update-status";
+import { getTicket } from "@/lib/feedback/tickets/queries";
+
+// ---------------------------------------------------------------------------
+// POST /api/feedback/tickets/[id]/reopen — "Still broken" controlled reopen.
+//
+// Only allowed to a member of the ticket's own company when status is
+// fixed or verified. Calls update-status.ts with customer-reporter context
+// via the service-role path (the RLS UPDATE policy is staff-only; we
+// validate membership here then use service role).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const ReopenSchema = z.object({
+  comment: z.string().max(2000).optional(),
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResp?.user) {
+    return NextResponse.json({ ok: false, error: { code: "UNAUTHORIZED" } }, { status: 401 });
+  }
+  const userId = userResp.user.id;
+
+  // Validate body.
+  const body = await readJsonBody(req);
+  const parsed = ReopenSchema.safeParse(body ?? {});
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: { code: "VALIDATION_FAILED" } }, { status: 400 });
+  }
+
+  // Load the ticket (service role — the RLS update policy is staff-only, so
+  // we need service role for the write path. For the read, use service role
+  // too and validate company membership explicitly).
+  const ticket = await getTicket(id);
+  if (!ticket || ticket.deleted_at) {
+    return NextResponse.json({ ok: false, error: { code: "NOT_FOUND" } }, { status: 404 });
+  }
+
+  // Membership check: the caller must be a member of the ticket's company.
+  const { data: memberCheck } = await supabase.rpc("is_company_member", {
+    company: ticket.company_id,
+  });
+  if (!memberCheck) {
+    return NextResponse.json({ ok: false, error: { code: "FORBIDDEN" } }, { status: 403 });
+  }
+
+  // Status must be fixed or verified.
+  if (ticket.status !== "fixed" && ticket.status !== "verified") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INVALID_STATE",
+          message: `"Still broken" is only available when the ticket status is fixed or verified (current: ${ticket.status}).`,
+        },
+      },
+      { status: 409 },
+    );
+  }
+
+  // Drive the transition with customer-reporter context (service role write).
+  let statusResult: Awaited<ReturnType<typeof updateTicketStatus>>;
+  try {
+    statusResult = await updateTicketStatus(id, "in_progress", {
+      kind: "customer-reporter",
+      userId,
+    });
+  } catch (err) {
+    // update-status.ts throws on unauthorized transition.
+    return NextResponse.json(
+      { ok: false, error: { code: "FORBIDDEN", message: String(err) } },
+      { status: 403 },
+    );
+  }
+
+  if (!statusResult.ok) {
+    return internalError(statusResult.error);
+  }
+
+  // Post the optional comment.
+  if (parsed.data.comment?.trim()) {
+    await addComment(id, parsed.data.comment.trim(), userId);
+  }
+
+  const updated = await getTicket(id);
+  return NextResponse.json(
+    { ok: true, data: { ticket: updated }, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/app/api/feedback/tickets/[id]/route.ts
+++ b/app/api/feedback/tickets/[id]/route.ts
@@ -1,0 +1,169 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { createRouteAuthClient } from "@/lib/auth";
+import { dbUuid, internalError, notFound, readJsonBody, validationError } from "@/lib/http";
+import { isOpolloStaff } from "@/lib/platform/auth";
+import { getTicket, listComments, listEvents } from "@/lib/feedback/tickets/queries";
+import { assignTicket } from "@/lib/feedback/tickets/assign";
+import { updateTicketStatus } from "@/lib/feedback/tickets/update-status";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+import type { TicketPriority, TicketSeverity, TicketStatus } from "@/lib/feedback/types";
+
+// ---------------------------------------------------------------------------
+// GET  /api/feedback/tickets/[id]  — get one ticket + comments + events
+// PATCH /api/feedback/tickets/[id] — update status/assignee/severity/priority (staff only)
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const PatchSchema = z.object({
+  status: z.enum(["backlog", "triaged", "in_progress", "fixed", "verified", "wont_fix", "closed"]).optional(),
+  assigneeId: dbUuid().nullable().optional(),
+  severity: z.enum(["low", "normal", "high", "blocker"]).optional(),
+  priority: z.enum(["low", "medium", "high", "urgent"]).optional(),
+  tags: z.array(z.string()).optional(),
+}).strict();
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResp?.user) {
+    return NextResponse.json({ ok: false, error: { code: "UNAUTHORIZED" } }, { status: 401 });
+  }
+
+  const ticket = await getTicket(id);
+  if (!ticket) return notFound("Ticket not found.");
+
+  // Visibility check: staff see all; members see own company.
+  const staff = await isOpolloStaff(supabase);
+  if (!staff) {
+    const { data: membership } = await supabase.rpc("is_company_member", { company: ticket.company_id });
+    if (!membership) {
+      return NextResponse.json({ ok: false, error: { code: "NOT_FOUND" } }, { status: 404 });
+    }
+  }
+
+  const [comments, events] = await Promise.all([
+    listComments(id),
+    listEvents(id),
+  ]);
+
+  return NextResponse.json(
+    { ok: true, data: { ticket, comments, events }, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResp?.user) {
+    return NextResponse.json({ ok: false, error: { code: "UNAUTHORIZED" } }, { status: 401 });
+  }
+  const userId = userResp.user.id;
+
+  // PATCH is staff-only.
+  const staff = await isOpolloStaff(supabase);
+  if (!staff) {
+    return NextResponse.json({ ok: false, error: { code: "FORBIDDEN" } }, { status: 403 });
+  }
+
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body must be valid JSON.");
+  const parsed = PatchSchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Invalid patch payload.", { issues: parsed.error.issues });
+  }
+
+  const { status, assigneeId, severity, priority, tags } = parsed.data;
+
+  // Status change goes through the state machine.
+  if (status !== undefined) {
+    const statusResult = await updateTicketStatus(
+      id,
+      status as TicketStatus,
+      { kind: "human-staff", userId },
+    );
+    if (!statusResult.ok) {
+      return NextResponse.json(
+        { ok: false, error: { code: "INVALID_STATE", message: statusResult.error } },
+        { status: 409 },
+      );
+    }
+  }
+
+  // Assignee change.
+  if (assigneeId !== undefined) {
+    const assignResult = await assignTicket(id, assigneeId, userId);
+    if (!assignResult.ok) {
+      return NextResponse.json(
+        { ok: false, error: { code: "VALIDATION_FAILED", message: assignResult.error } },
+        { status: 400 },
+      );
+    }
+  }
+
+  // Severity / priority / tags — direct update with event writes.
+  const svc = getServiceRoleClient();
+  const updates: Record<string, unknown> = { updated_by: userId };
+  const events: Array<{ event_type: string; from_value: string | null; to_value: string }> = [];
+
+  if (severity !== undefined || priority !== undefined || tags !== undefined) {
+    const { data: cur } = await svc
+      .from("feedback_tickets")
+      .select("severity, priority, tags")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (severity !== undefined && cur?.severity !== severity) {
+      updates.severity = severity;
+      events.push({ event_type: "severity_changed", from_value: cur?.severity ?? null, to_value: severity });
+    }
+    if (priority !== undefined && cur?.priority !== priority) {
+      updates.priority = priority;
+      events.push({ event_type: "priority_changed", from_value: cur?.priority ?? null, to_value: priority });
+    }
+    if (tags !== undefined) {
+      updates.tags = tags;
+    }
+
+    if (Object.keys(updates).length > 1) {
+      const { error: upErr } = await svc
+        .from("feedback_tickets")
+        .update(updates)
+        .eq("id", id);
+      if (upErr) {
+        logger.error("feedback.patch.update_failed", { ticket_id: id, err: upErr.message });
+        return internalError(upErr.message);
+      }
+    }
+
+    for (const ev of events) {
+      await svc.from("feedback_ticket_events").insert({
+        ticket_id: id,
+        event_type: ev.event_type,
+        from_value: ev.from_value,
+        to_value: ev.to_value,
+        actor_id: userId,
+        actor_kind: "human-staff",
+      });
+    }
+  }
+
+  const ticket = await getTicket(id);
+  return NextResponse.json(
+    { ok: true, data: { ticket }, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/app/api/feedback/tickets/route.ts
+++ b/app/api/feedback/tickets/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { createRouteAuthClient } from "@/lib/auth";
+import { dbUuid, internalError, readJsonBody, validationError } from "@/lib/http";
+import { isCompanyMember, isOpolloStaff } from "@/lib/platform/auth";
+import { createTicket } from "@/lib/feedback/tickets/create";
+import { listTickets } from "@/lib/feedback/tickets/queries";
+
+// ---------------------------------------------------------------------------
+// POST /api/feedback/tickets — create a ticket (member or staff)
+// GET  /api/feedback/tickets — list tickets (member: own company; staff: all)
+//
+// Auth:
+//   - Authenticated session required (401 if not).
+//   - POST: caller must be a member of the submitted company_id, OR Opollo staff.
+//   - GET:  company_id filter is mandatory for non-staff callers (they can only
+//     see their own company via RLS anyway). Staff can omit it for cross-company.
+//   - priority: never accepted from POST payload; defaults to 'medium' server-side.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const CreateSchema = z.object({
+  companyId: dbUuid(),
+  title: z.string().min(1).max(200),
+  description: z.string().min(1).max(2000),
+  severity: z.enum(["low", "normal", "high", "blocker"]).default("normal"),
+  tags: z.array(z.string()).default([]),
+  assigneeId: dbUuid().nullable().optional(),
+  pageUrl: z.string().url(),
+  routePattern: z.string().nullable().optional(),
+  cssSelector: z.string().min(1),
+  elementLabel: z.string().nullable().optional(),
+  clickXPct: z.number().min(0).max(100),
+  clickYPct: z.number().min(0).max(100),
+  viewportW: z.number().int().positive(),
+  viewportH: z.number().int().positive(),
+  devicePixelRatio: z.number().positive().nullable().optional(),
+  userAgent: z.string().nullable().optional(),
+  consoleErrors: z.array(z.unknown()).nullable().optional(),
+  screenshotObjectPath: z.string().nullable().optional(),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResp?.user) {
+    return NextResponse.json({ ok: false, error: { code: "UNAUTHORIZED" } }, { status: 401 });
+  }
+  const userId = userResp.user.id;
+
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body must be valid JSON.");
+
+  const parsed = CreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Invalid ticket payload.", { issues: parsed.error.issues });
+  }
+
+  const input = parsed.data;
+
+  // Auth: must be member of the target company or Opollo staff.
+  const [isMember, isStaff] = await Promise.all([
+    isCompanyMember(input.companyId, supabase),
+    isOpolloStaff(supabase),
+  ]);
+  if (!isMember && !isStaff) {
+    return NextResponse.json(
+      { ok: false, error: { code: "FORBIDDEN", message: "Not a member of this company." } },
+      { status: 403 },
+    );
+  }
+
+  // Non-staff cannot set assigneeId.
+  if (input.assigneeId && !isStaff) {
+    input.assigneeId = null;
+  }
+
+  const result = await createTicket(input, userId);
+  if (!result.ok) return internalError(result.error);
+
+  return NextResponse.json(
+    { ok: true, data: { id: result.ticket.id, status: result.ticket.status }, timestamp: new Date().toISOString() },
+    { status: 201 },
+  );
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResp?.user) {
+    return NextResponse.json({ ok: false, error: { code: "UNAUTHORIZED" } }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const params = {
+    companyId: url.searchParams.get("companyId") ?? undefined,
+    status: url.searchParams.get("status") ?? undefined,
+    severity: url.searchParams.get("severity") ?? undefined,
+    priority: url.searchParams.get("priority") ?? undefined,
+    assigneeId: url.searchParams.get("assigneeId") ?? undefined,
+    hasPr: url.searchParams.has("hasPr")
+      ? url.searchParams.get("hasPr") === "true"
+      : undefined,
+  };
+
+  const staff = await isOpolloStaff(supabase);
+
+  // Non-staff must have a companyId and must be a member of it.
+  if (!staff) {
+    if (!params.companyId) {
+      return validationError("companyId is required for non-staff callers.");
+    }
+    const member = await isCompanyMember(params.companyId, supabase);
+    if (!member) {
+      return NextResponse.json(
+        { ok: false, error: { code: "FORBIDDEN" } },
+        { status: 403 },
+      );
+    }
+  }
+
+  const tickets = await listTickets(params);
+  return NextResponse.json(
+    { ok: true, data: { tickets }, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/app/api/feedback/tickets/screenshot-url/route.ts
+++ b/app/api/feedback/tickets/screenshot-url/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { createRouteAuthClient } from "@/lib/auth";
+import { readJsonBody, validationError } from "@/lib/http";
+import { mintUploadUrl } from "@/lib/feedback/capture/screenshot";
+
+// ---------------------------------------------------------------------------
+// POST /api/feedback/tickets/screenshot-url
+//
+// Mints a short-lived signed upload URL for a screenshot PNG. The client
+// uploads directly to Supabase Storage; the returned objectPath is then
+// submitted with the ticket creation payload.
+//
+// Auth: authenticated session only (membership check deferred to ticket create).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  contentType: z.string().default("image/png"),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResp?.user) {
+    return NextResponse.json({ ok: false, error: { code: "UNAUTHORIZED" } }, { status: 401 });
+  }
+
+  const body = await readJsonBody(req);
+  const parsed = BodySchema.safeParse(body ?? {});
+  if (!parsed.success) {
+    return validationError("Invalid body.", { issues: parsed.error.issues });
+  }
+
+  const result = await mintUploadUrl(parsed.data.contentType);
+  if (!result.ok) {
+    return NextResponse.json(
+      { ok: false, error: { code: "INTERNAL_ERROR", message: result.error } },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { uploadUrl: result.uploadUrl, objectPath: result.objectPath },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/components/feedback/CreateTaskPopup.tsx
+++ b/components/feedback/CreateTaskPopup.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { PickResult } from "./ElementPicker";
+import type { TicketSeverity } from "@/lib/feedback/types";
+
+type Props = {
+  companyId: string;
+  pick: PickResult;
+  screenshotDataUrl: string | null;
+  consoleErrors: unknown[];
+  pageUrl: string;
+  onClose: () => void;
+  onSubmitted: (ticketId: string) => void;
+};
+
+// ---------------------------------------------------------------------------
+// CreateTaskPopup — capture popup that appears after element pick.
+//
+// Left: description textarea + screenshot thumbnail with click-pin.
+// Right: Severity selector, tags.
+// Submit → POST /api/feedback/tickets (screenshot already uploaded by parent).
+// ---------------------------------------------------------------------------
+
+export function CreateTaskPopup({
+  companyId,
+  pick,
+  screenshotDataUrl,
+  consoleErrors,
+  pageUrl,
+  onClose,
+  onSubmitted,
+}: Props) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [severity, setSeverity] = useState<TicketSeverity>("normal");
+  const [tags, setTagsRaw] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!title.trim() || !description.trim()) {
+      setError("Title and description are required.");
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      // Upload screenshot if we have one.
+      let screenshotObjectPath: string | null = null;
+      if (screenshotDataUrl) {
+        const urlResp = await fetch("/api/feedback/tickets/screenshot-url", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ contentType: "image/png" }),
+        });
+        if (urlResp.ok) {
+          const { data } = await urlResp.json();
+          // Convert data URL to blob.
+          const res = await fetch(screenshotDataUrl);
+          const blob = await res.blob();
+          await fetch(data.uploadUrl, { method: "PUT", body: blob });
+          screenshotObjectPath = data.objectPath;
+        }
+      }
+
+      const payload = {
+        companyId,
+        title: title.trim(),
+        description: description.trim(),
+        severity,
+        tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+        pageUrl,
+        cssSelector: pick.cssSelector,
+        elementLabel: pick.elementLabel,
+        clickXPct: pick.clickXPct,
+        clickYPct: pick.clickYPct,
+        viewportW: pick.viewportW,
+        viewportH: pick.viewportH,
+        devicePixelRatio: pick.devicePixelRatio,
+        userAgent: navigator.userAgent,
+        consoleErrors,
+        screenshotObjectPath,
+      };
+
+      const resp = await fetch("/api/feedback/tickets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({}));
+        setError(body?.error?.message ?? "Failed to submit ticket.");
+        return;
+      }
+
+      const { data } = await resp.json();
+      onSubmitted(data.id);
+    } catch (err) {
+      setError("An unexpected error occurred. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [companyId, consoleErrors, description, pageUrl, pick, screenshotDataUrl, severity, tags, title, onSubmitted]);
+
+  return (
+    <div
+      data-testid="feedback-create-popup"
+      className="fixed right-16 bottom-16 z-[10001] flex w-[640px] flex-col rounded-xl border border-gray-200 bg-white shadow-2xl"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+        <h2 className="text-sm font-semibold text-gray-900">Report a bug</h2>
+        <button
+          onClick={onClose}
+          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex gap-4 p-4">
+        {/* Left: description + screenshot */}
+        <div className="flex flex-1 flex-col gap-3">
+          <input
+            ref={titleRef}
+            type="text"
+            placeholder="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="rounded-md border border-gray-200 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-emerald-500"
+          />
+
+          <div className="relative">
+            <Textarea
+              placeholder="Describe what you expected vs. what happened…"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={2000}
+              rows={5}
+              className="resize-none text-sm"
+            />
+            <span className="absolute right-2 bottom-2 text-xs text-gray-400">
+              {description.length}/2000
+            </span>
+          </div>
+
+          {/* Screenshot thumbnail with click pin */}
+          {screenshotDataUrl && (
+            <div className="relative overflow-hidden rounded-md border border-gray-200">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={screenshotDataUrl}
+                alt="Screenshot"
+                className="w-full object-contain"
+                style={{ maxHeight: 200 }}
+              />
+              {/* Click-position pin */}
+              <div
+                className="pointer-events-none absolute h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-emerald-500 shadow"
+                style={{
+                  left: `${pick.clickXPct}%`,
+                  top: `${pick.clickYPct}%`,
+                }}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Right: metadata */}
+        <div className="flex w-48 flex-col gap-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Severity</label>
+            <select
+              value={severity}
+              onChange={(e) => setSeverity(e.target.value as TicketSeverity)}
+              className="w-full rounded-md border border-gray-200 px-2 py-1 text-xs outline-none focus:ring-2 focus:ring-emerald-500"
+            >
+              <option value="low">Low</option>
+              <option value="normal">Normal</option>
+              <option value="high">High</option>
+              <option value="blocker">Blocker</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Tags (comma-separated)</label>
+            <input
+              type="text"
+              value={tags}
+              onChange={(e) => setTagsRaw(e.target.value)}
+              placeholder="ui, navigation…"
+              className="w-full rounded-md border border-gray-200 px-2 py-1 text-xs outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+          </div>
+
+          <div className="rounded-md bg-gray-50 p-2 text-xs text-gray-500">
+            <p className="font-medium text-gray-700">Element</p>
+            <p className="truncate font-mono">{pick.cssSelector}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between border-t border-gray-100 px-4 py-3">
+        {error && <p className="text-xs text-red-500">{error}</p>}
+        <div className="ml-auto flex gap-2">
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            data-testid="feedback-submit"
+            size="sm"
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="bg-emerald-600 text-white hover:bg-emerald-700"
+          >
+            {submitting ? "Submitting…" : "Submit bug report"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/feedback/ElementPicker.tsx
+++ b/components/feedback/ElementPicker.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { elementLabel, resolveSelector } from "@/lib/feedback/capture/selector";
+
+export type PickResult = {
+  cssSelector: string;
+  elementLabel: string;
+  clickXPct: number;
+  clickYPct: number;
+  viewportW: number;
+  viewportH: number;
+  devicePixelRatio: number;
+};
+
+type Props = {
+  onPick: (result: PickResult) => void;
+  onCancel: () => void;
+};
+
+// ---------------------------------------------------------------------------
+// ElementPicker — crosshair overlay pick mode.
+//
+// Rules (§13 of spec):
+//   - NEVER mutate page styles or capture events outside pick mode.
+//   - The highlight box is a single absolutely-positioned overlay div — it
+//     tracks getBoundingClientRect() on mousemove. No style is applied to
+//     the target element.
+//   - Click coords are stored as % of the element's bounding box so they
+//     survive viewport resize (§13 "percentage coords, not pixels").
+// ---------------------------------------------------------------------------
+
+export function ElementPicker({ onPick, onCancel }: Props) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const [highlightRect, setHighlightRect] = useState<DOMRect | null>(null);
+  const targetRef = useRef<Element | null>(null);
+
+  const onMouseMove = useCallback((e: MouseEvent) => {
+    const el = document.elementFromPoint(e.clientX, e.clientY);
+    if (!el || el === overlayRef.current || overlayRef.current?.contains(el)) return;
+    targetRef.current = el;
+    setHighlightRect(el.getBoundingClientRect());
+  }, []);
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    },
+    [onCancel],
+  );
+
+  const onClick = useCallback(
+    (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const el = targetRef.current;
+      if (!el) return;
+
+      const rect = el.getBoundingClientRect();
+      const clickXPct = ((e.clientX - rect.left) / rect.width) * 100;
+      const clickYPct = ((e.clientY - rect.top) / rect.height) * 100;
+
+      onPick({
+        cssSelector: resolveSelector(el),
+        elementLabel: elementLabel(el),
+        clickXPct: Math.min(100, Math.max(0, clickXPct)),
+        clickYPct: Math.min(100, Math.max(0, clickYPct)),
+        viewportW: window.innerWidth,
+        viewportH: window.innerHeight,
+        devicePixelRatio: window.devicePixelRatio ?? 1,
+      });
+    },
+    [onPick],
+  );
+
+  useEffect(() => {
+    document.addEventListener("mousemove", onMouseMove, true);
+    document.addEventListener("click", onClick, true);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousemove", onMouseMove, true);
+      document.removeEventListener("click", onClick, true);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onMouseMove, onClick, onKeyDown]);
+
+  return (
+    <>
+      {/* Full-screen transparent overlay — cursor only, no pointer-events capture */}
+      <div
+        ref={overlayRef}
+        data-testid="feedback-picker"
+        className="pointer-events-none fixed inset-0 z-[9998]"
+        style={{ cursor: "crosshair" }}
+      />
+
+      {/* Highlight box tracking the hovered element */}
+      {highlightRect && (
+        <div
+          className="pointer-events-none fixed z-[9999] rounded-sm border-2 border-emerald-500 bg-emerald-500/10"
+          style={{
+            top: highlightRect.top - 2,
+            left: highlightRect.left - 2,
+            width: highlightRect.width + 4,
+            height: highlightRect.height + 4,
+          }}
+        />
+      )}
+
+      {/* Escape hint */}
+      <div className="pointer-events-none fixed bottom-6 left-1/2 z-[10000] -translate-x-1/2 rounded-md bg-gray-900/90 px-4 py-2 text-sm text-white shadow-lg">
+        Click an element to report a bug — <kbd className="rounded bg-gray-700 px-1">Esc</kbd> to cancel
+      </div>
+    </>
+  );
+}

--- a/components/feedback/FeedbackWidget.tsx
+++ b/components/feedback/FeedbackWidget.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import html2canvas from "html2canvas";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { CreateTaskPopup } from "./CreateTaskPopup";
+import { ElementPicker, type PickResult } from "./ElementPicker";
+
+type Mode = "collapsed" | "rail" | "picking" | "creating" | "submitted";
+
+type Props = {
+  companyId: string;
+};
+
+// ---------------------------------------------------------------------------
+// FeedbackWidget — tab → rail → picker → create popup flow.
+//
+// Mounted ONCE in the authenticated app shell. Not rendered:
+//   - before auth resolves
+//   - for logged-out users
+//   - on public/magic-link routes
+//
+// The component installs a console ring buffer at mount time to capture
+// the last N console.error / console.warn / window.onerror events.
+//
+// data-testid surface:
+//   feedback-tab, feedback-rail, feedback-picker (on ElementPicker),
+//   feedback-create-popup, feedback-submit (on CreateTaskPopup)
+// ---------------------------------------------------------------------------
+
+const MAX_CONSOLE_ERRORS = 50;
+
+type ConsoleLine = { level: "error" | "warn"; msg: string; at: string };
+
+export function FeedbackWidget({ companyId }: Props) {
+  const [mode, setMode] = useState<Mode>("collapsed");
+  const [openCount, setOpenCount] = useState<number | null>(null);
+  const [pick, setPick] = useState<PickResult | null>(null);
+  const [screenshotDataUrl, setScreenshotDataUrl] = useState<string | null>(null);
+  const [pageUrl, setPageUrl] = useState("");
+  const consoleRef = useRef<ConsoleLine[]>([]);
+
+  // Install console ring buffer on mount.
+  useEffect(() => {
+    const origError = console.error.bind(console);
+    const origWarn = console.warn.bind(console);
+
+    function push(level: "error" | "warn", ...args: unknown[]) {
+      const line: ConsoleLine = {
+        level,
+        msg: args.map(String).join(" ").slice(0, 500),
+        at: new Date().toISOString(),
+      };
+      consoleRef.current = [...consoleRef.current.slice(-(MAX_CONSOLE_ERRORS - 1)), line];
+    }
+
+    console.error = (...args: unknown[]) => { push("error", ...args); origError(...args); };
+    console.warn = (...args: unknown[]) => { push("warn", ...args); origWarn(...args); };
+
+    const onError = (e: ErrorEvent) => push("error", e.message, e.filename, e.lineno);
+    const onUnhandled = (e: PromiseRejectionEvent) => push("error", String(e.reason));
+
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onUnhandled);
+
+    return () => {
+      console.error = origError;
+      console.warn = origWarn;
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onUnhandled);
+    };
+  }, []);
+
+  // Fetch open ticket count for this company when rail opens.
+  useEffect(() => {
+    if (mode !== "rail") return;
+    fetch(`/api/feedback/tickets?companyId=${companyId}&status=backlog`)
+      .then((r) => r.json())
+      .then((body) => {
+        if (body.ok) setOpenCount(body.data.tickets.length);
+      })
+      .catch(() => {});
+  }, [mode, companyId]);
+
+  const startPicking = useCallback(() => {
+    setPageUrl(window.location.href);
+    setMode("picking");
+  }, []);
+
+  const onPick = useCallback(async (result: PickResult) => {
+    setMode("creating");
+    setPick(result);
+
+    // Capture screenshot with html2canvas (best-effort; cross-origin iframes may fail).
+    try {
+      const canvas = await html2canvas(document.body, {
+        useCORS: true,
+        allowTaint: true,
+        scale: 1,
+        logging: false,
+      });
+      // Draw the click pin.
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        const pinX = (result.clickXPct / 100) * canvas.width;
+        const pinY = (result.clickYPct / 100) * canvas.height;
+        ctx.beginPath();
+        ctx.arc(pinX, pinY, 12, 0, Math.PI * 2);
+        ctx.fillStyle = "rgba(0,191,102,0.9)";
+        ctx.fill();
+        ctx.strokeStyle = "#fff";
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+      setScreenshotDataUrl(canvas.toDataURL("image/png"));
+    } catch {
+      setScreenshotDataUrl(null);
+    }
+  }, []);
+
+  const onSubmitted = useCallback((ticketId: string) => {
+    setMode("submitted");
+    setTimeout(() => setMode("collapsed"), 2000);
+  }, []);
+
+  if (mode === "picking") {
+    return (
+      <ElementPicker
+        onPick={onPick}
+        onCancel={() => setMode("rail")}
+      />
+    );
+  }
+
+  if (mode === "creating" && pick) {
+    return (
+      <CreateTaskPopup
+        companyId={companyId}
+        pick={pick}
+        screenshotDataUrl={screenshotDataUrl}
+        consoleErrors={consoleRef.current}
+        pageUrl={pageUrl}
+        onClose={() => setMode("rail")}
+        onSubmitted={onSubmitted}
+      />
+    );
+  }
+
+  if (mode === "submitted") {
+    return (
+      <div className="fixed right-4 bottom-4 z-[10001] rounded-md bg-emerald-600 px-4 py-2 text-sm text-white shadow-lg">
+        ✓ Bug report submitted
+      </div>
+    );
+  }
+
+  if (mode === "rail") {
+    return (
+      <div
+        data-testid="feedback-rail"
+        className="fixed right-0 bottom-12 z-[9997] flex flex-col items-center rounded-l-xl border border-r-0 border-gray-200 bg-white shadow-xl"
+      >
+        {/* Brand mark */}
+        <div className="px-3 py-2 text-[10px] font-semibold tracking-widest text-gray-400">
+          BUGS
+        </div>
+
+        {/* + button */}
+        <button
+          onClick={startPicking}
+          className="flex h-10 w-10 items-center justify-center rounded-lg text-lg text-gray-600 hover:bg-emerald-50 hover:text-emerald-700"
+          title="Pick an element to report a bug"
+        >
+          +
+        </button>
+
+        {/* Open count badge */}
+        {openCount !== null && openCount > 0 && (
+          <div className="mb-1 h-5 w-5 rounded-full bg-emerald-600 text-center text-[10px] leading-5 text-white">
+            {openCount > 99 ? "99+" : openCount}
+          </div>
+        )}
+
+        {/* Collapse chevron */}
+        <button
+          onClick={() => setMode("collapsed")}
+          className="px-3 py-2 text-xs text-gray-400 hover:text-gray-600"
+          title="Collapse"
+          aria-label="Collapse feedback rail"
+        >
+          ›
+        </button>
+      </div>
+    );
+  }
+
+  // Collapsed: small tab.
+  return (
+    <button
+      data-testid="feedback-tab"
+      onClick={() => setMode("rail")}
+      className="fixed right-0 bottom-12 z-[9997] flex h-10 w-8 items-center justify-center rounded-l-md border border-r-0 border-gray-200 bg-white shadow-md hover:bg-emerald-50"
+      title="Report a bug"
+      aria-label="Open bug reporter"
+    >
+      <span className="rotate-90 text-xs font-semibold text-gray-500">BUG</span>
+    </button>
+  );
+}

--- a/components/feedback/FeedbackWidget.tsx
+++ b/components/feedback/FeedbackWidget.tsx
@@ -161,14 +161,14 @@ export function FeedbackWidget({ companyId }: Props) {
         className="fixed right-0 bottom-12 z-[9997] flex flex-col items-center rounded-l-xl border border-r-0 border-gray-200 bg-white shadow-xl"
       >
         {/* Brand mark */}
-        <div className="px-3 py-2 text-[10px] font-semibold tracking-widest text-gray-400">
+        <div className="px-3 py-2 text-xs font-semibold tracking-widest text-gray-400">
           BUGS
         </div>
 
         {/* + button */}
         <button
           onClick={startPicking}
-          className="flex h-10 w-10 items-center justify-center rounded-lg text-lg text-gray-600 hover:bg-emerald-50 hover:text-emerald-700"
+          className="flex h-10 w-10 items-center justify-center rounded-lg text-lg text-gray-600 hover:bg-[--color-success-bg] hover:text-[--color-success-fg]"
           title="Pick an element to report a bug"
         >
           +
@@ -176,7 +176,7 @@ export function FeedbackWidget({ companyId }: Props) {
 
         {/* Open count badge */}
         {openCount !== null && openCount > 0 && (
-          <div className="mb-1 h-5 w-5 rounded-full bg-emerald-600 text-center text-[10px] leading-5 text-white">
+          <div className="mb-1 h-5 w-5 rounded-full bg-emerald-600 text-center text-xs leading-5 text-white">
             {openCount > 99 ? "99+" : openCount}
           </div>
         )}
@@ -199,7 +199,7 @@ export function FeedbackWidget({ companyId }: Props) {
     <button
       data-testid="feedback-tab"
       onClick={() => setMode("rail")}
-      className="fixed right-0 bottom-12 z-[9997] flex h-10 w-8 items-center justify-center rounded-l-md border border-r-0 border-gray-200 bg-white shadow-md hover:bg-emerald-50"
+      className="fixed right-0 bottom-12 z-[9997] flex h-10 w-8 items-center justify-center rounded-l-md border border-r-0 border-gray-200 bg-white shadow-md hover:bg-[--color-success-bg]"
       title="Report a bug"
       aria-label="Open bug reporter"
     >

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -6,6 +6,30 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 
 <!-- CLAIM BLOCKS BELOW THIS LINE — append on slice start, remove on slice merge -->
 
+---
+## Session A
+- Started: 2026-06-03 UTC
+- Branch: feat/feedback-p1-foundation (stacked through feat/feedback-p8-rollout)
+- Slice: Feedback/Bug-Tracker v1 — P1 through P8 sequential PRs
+- Files claimed:
+  - lib/feedback/ (new module, all files)
+  - lib/platform/notifications/types.ts
+  - lib/platform/notifications/dispatch.ts
+  - lib/platform/auth/types.ts
+  - lib/platform/auth/permissions.ts
+  - lib/email/templates/base.ts
+  - app/(platform)/admin/feedback/ (new)
+  - app/(platform)/feedback/ (new)
+  - app/api/feedback/ (new)
+  - components/feedback/ (new)
+  - scripts/bugs-pull.ts (new)
+  - scripts/bugs-push.ts (new)
+  - supabase/migrations/0179_feedback_tracker.sql (new)
+  - tests/regressions/feedback-governance.test.ts (new)
+- Migration number reserved: 0179
+- Expected completion: same day
+---
+
 ## Hot-shared files (always check before claiming)
 
 Even with no other session active, assume these files are "hot" and coordinate explicitly if touching them while another session is in flight:
@@ -45,6 +69,7 @@ When a session starts a migration, reserve the number here before writing the fi
 - ~~0073 — S1-10 cancel_post_approval transactional function.~~ Shipped (0073_cancel_post_approval_fn.sql in main).
 - ~~0112 — Session A — Spec 22 PR 1 social_post_drafts table (branch: feat/spec22-pr1-composer-shell).~~ Shipped in #789.
 - ~~0113 — Session A — Spec 22 PR 2 social-media-uploads storage bucket (branch: feat/spec22-pr2-core-editor).~~ Shipped.
+- 0179 — Session A — Feedback/Bug-Tracker P1 foundation schema (branch: feat/feedback-p1-foundation)
 
 ## Claim block template
 

--- a/lib/feedback/README.md
+++ b/lib/feedback/README.md
@@ -1,0 +1,45 @@
+# lib/feedback — In-App Feedback & Issue Triage
+
+Bug-tracking module. Consumes the platform layer for identity, company scoping,
+and notifications. **Never** reads `platform_company_users` directly — always
+through `lib/platform/auth` public helpers.
+
+## Directory structure
+
+```
+lib/feedback/
+├── types/index.ts        CallerContext, TicketStatus, FeedbackTicket shapes
+├── tickets/
+│   ├── create.ts         validate + insert, event write, notification dispatch
+│   ├── assign.ts         assign/reassign (staff only; assignee must be staff)
+│   ├── update-status.ts  state machine + CallerContext guard (§1, §7 of spec)
+│   ├── comments.ts       two-way thread add/list; is_staff derived server-side
+│   └── queries.ts        list/get (member: own company; staff: all)
+├── capture/
+│   ├── selector.ts       stable-selector resolution (shared client/server type)
+│   ├── screenshot.ts     signed upload + signed-on-read resolution
+│   └── annotate.ts       overlay shapes persisted with the screenshot
+└── repo-bridge/
+    ├── pull.ts           Supabase → docs/bugs/<slug>.md
+    └── push.ts           docs/bugs/<slug>.md status/PR → Supabase (impl status only)
+```
+
+## Layer rules
+
+- Feature logic stays in `lib/feedback/`; reach into `lib/platform/` only
+  via public helpers (`isOpolloStaff`, `isCompanyMember`, `dispatch`, etc.).
+- `lib/feedback/` never imports `@sendgrid/mail` — notifications go through
+  `lib/platform/notifications/dispatch.ts`.
+- Screenshots: store the object path; sign on read via `screenshot.ts`.
+- The `CallerContext` guard in `update-status.ts` is the governance boundary —
+  automation may only write `in_progress` / `fixed`; customers only the
+  controlled reopen; humans can write everything.
+
+## Notification events (platform_notification_type enum)
+
+Added in migration 0179:
+- `ticket_created`
+- `ticket_assigned`
+- `ticket_comment_added`
+- `ticket_status_changed`
+- `ticket_reopened_by_customer`

--- a/lib/feedback/capture/annotate.ts
+++ b/lib/feedback/capture/annotate.ts
@@ -1,0 +1,16 @@
+// lib/feedback/capture/annotate.ts — overlay shape types persisted with a screenshot.
+// The actual annotation drawing lives in components/feedback/AnnotateOverlay.tsx (P9).
+// This file defines the shared type only so P3 and P4 can reference it without
+// pulling in the canvas/react-konva dependency.
+
+export type AnnotationShape =
+  | { type: "arrow"; x1: number; y1: number; x2: number; y2: number; colour: string }
+  | { type: "rect"; x: number; y: number; w: number; h: number; colour: string }
+  | { type: "text"; x: number; y: number; body: string; colour: string };
+
+export type Annotation = {
+  shapes: AnnotationShape[];
+  // Viewport the annotation was drawn on (for scaling on replay).
+  viewportW: number;
+  viewportH: number;
+};

--- a/lib/feedback/capture/screenshot.ts
+++ b/lib/feedback/capture/screenshot.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+const BUCKET = "feedback-screenshots";
+const SIGNED_URL_TTL_SECONDS = 3600; // 1 hour
+
+type MintUploadUrlResult =
+  | { ok: true; uploadUrl: string; objectPath: string }
+  | { ok: false; error: string };
+
+// Generate a short-lived signed upload URL for a screenshot. The client
+// uploads directly to storage; the object path is then stored on the ticket.
+export async function mintUploadUrl(
+  contentType: string,
+): Promise<MintUploadUrlResult> {
+  const svc = getServiceRoleClient();
+  const objectPath = `screenshots/${Date.now()}-${Math.random().toString(36).slice(2)}.png`;
+
+  const { data, error } = await svc.storage
+    .from(BUCKET)
+    .createSignedUploadUrl(objectPath);
+
+  if (error) {
+    logger.error("feedback.screenshot.mint_upload_url_failed", { err: error.message });
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true, uploadUrl: data.signedUrl, objectPath };
+}
+
+// Resolve a stored object path to a short-lived signed download URL.
+// Never persist signed URLs — call this at render time.
+export async function resolveSignedUrl(objectPath: string): Promise<string | null> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc.storage
+    .from(BUCKET)
+    .createSignedUrl(objectPath, SIGNED_URL_TTL_SECONDS);
+
+  if (error) {
+    logger.error("feedback.screenshot.resolve_signed_url_failed", {
+      path: objectPath,
+      err: error.message,
+    });
+    return null;
+  }
+
+  return data.signedUrl;
+}

--- a/lib/feedback/capture/selector.ts
+++ b/lib/feedback/capture/selector.ts
@@ -1,0 +1,58 @@
+// lib/feedback/capture/selector.ts — stable CSS selector resolution.
+//
+// Priority (highest to lowest):
+//   1. [data-testid] on the element or nearest ancestor (survives refactors)
+//   2. Stable id attribute
+//   3. Short tag:nth-of-type chain (capped at 4 levels)
+//
+// Used by ElementPicker.tsx (client) and by the server when normalising
+// an inbound selector for storage.
+
+export function resolveSelector(element: Element): string {
+  // 1. [data-testid] — walk up to find the nearest one.
+  let cursor: Element | null = element;
+  while (cursor && cursor !== document.body) {
+    const tid = cursor.getAttribute("data-testid");
+    if (tid) return `[data-testid="${CSS.escape(tid)}"]`;
+    cursor = cursor.parentElement;
+  }
+
+  // 2. Stable id on the element itself.
+  if (element.id) return `#${CSS.escape(element.id)}`;
+
+  // 3. Short structural chain — cap at 4 levels.
+  const parts: string[] = [];
+  let el: Element | null = element;
+  for (let depth = 0; depth < 4; depth++) {
+    if (!el || el === document.documentElement) break;
+    const tag: string = el.tagName.toLowerCase();
+    const parentEl: Element | null = el.parentElement;
+    if (!parentEl) {
+      parts.unshift(tag);
+      break;
+    }
+    const elTag: string = el.tagName;
+    const siblings: Element[] = Array.from(parentEl.children).filter(
+      (c: Element) => c.tagName === elTag,
+    );
+    if (siblings.length > 1) {
+      const idx: number = siblings.indexOf(el) + 1;
+      parts.unshift(`${tag}:nth-of-type(${idx})`);
+    } else {
+      parts.unshift(tag);
+    }
+    el = parentEl;
+  }
+  return parts.join(" > ");
+}
+
+// Derive a human-readable label for an element.
+export function elementLabel(element: Element): string {
+  const ariaLabel = element.getAttribute("aria-label");
+  if (ariaLabel) return ariaLabel.slice(0, 80);
+
+  const textContent = element.textContent?.trim().slice(0, 80);
+  if (textContent) return textContent;
+
+  return element.tagName.toLowerCase();
+}

--- a/lib/feedback/tickets/assign.ts
+++ b/lib/feedback/tickets/assign.ts
@@ -1,0 +1,70 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+type AssignResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export async function assignTicket(
+  ticketId: string,
+  assigneeId: string | null,
+  actorUserId: string,
+): Promise<AssignResult> {
+  const svc = getServiceRoleClient();
+
+  // Verify the ticket exists and get current assignee for event log.
+  const { data: ticket, error: ticketErr } = await svc
+    .from("feedback_tickets")
+    .select("id, assignee_id, company_id")
+    .eq("id", ticketId)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (ticketErr || !ticket) {
+    return { ok: false, error: "Ticket not found." };
+  }
+
+  // If assigning (not clearing), the assignee must be Opollo staff.
+  if (assigneeId !== null) {
+    const { data: assignee, error: ae } = await svc
+      .from("platform_users")
+      .select("id, is_opollo_staff")
+      .eq("id", assigneeId)
+      .maybeSingle();
+    if (ae || !assignee) return { ok: false, error: "Assignee not found." };
+    if (!assignee.is_opollo_staff) {
+      return { ok: false, error: "Assignee must be Opollo staff." };
+    }
+  }
+
+  const prevAssigneeId = ticket.assignee_id as string | null;
+  const eventType = prevAssigneeId ? "reassigned" : "assigned";
+
+  const { error: updateErr } = await svc
+    .from("feedback_tickets")
+    .update({ assignee_id: assigneeId, updated_by: actorUserId })
+    .eq("id", ticketId);
+  if (updateErr) {
+    logger.error("feedback.assign.failed", { ticket_id: ticketId, err: updateErr.message });
+    return { ok: false, error: updateErr.message };
+  }
+
+  await svc.from("feedback_ticket_events").insert({
+    ticket_id: ticketId,
+    event_type: eventType,
+    from_value: prevAssigneeId,
+    to_value: assigneeId,
+    actor_id: actorUserId,
+    actor_kind: "human-staff",
+  });
+
+  logger.info("feedback.assign.ok", {
+    ticket_id: ticketId,
+    prev_assignee: prevAssigneeId,
+    new_assignee: assigneeId,
+    actor: actorUserId,
+  });
+
+  return { ok: true };
+}

--- a/lib/feedback/tickets/comments.ts
+++ b/lib/feedback/tickets/comments.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { isOpolloStaff } from "@/lib/platform/auth";
+import { logger } from "@/lib/logger";
+
+import type { FeedbackTicketComment } from "../types";
+
+type AddCommentResult =
+  | { ok: true; comment: FeedbackTicketComment }
+  | { ok: false; error: string };
+
+export async function addComment(
+  ticketId: string,
+  body: string,
+  authorUserId: string,
+): Promise<AddCommentResult> {
+  const svc = getServiceRoleClient();
+
+  // Verify the ticket is accessible (not deleted).
+  const { data: ticket, error: ticketErr } = await svc
+    .from("feedback_tickets")
+    .select("id")
+    .eq("id", ticketId)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (ticketErr || !ticket) {
+    return { ok: false, error: "Ticket not found." };
+  }
+
+  // is_staff is derived server-side — never accepted from the client.
+  // We call is_opollo_staff() via a service-role-adjacent approach: look up
+  // the platform_users.is_opollo_staff column directly using service role.
+  const { data: user } = await svc
+    .from("platform_users")
+    .select("is_opollo_staff")
+    .eq("id", authorUserId)
+    .maybeSingle();
+  const isStaff = user?.is_opollo_staff === true;
+
+  const { data, error } = await svc
+    .from("feedback_ticket_comments")
+    .insert({
+      ticket_id: ticketId,
+      body,
+      author_id: authorUserId,
+      is_staff: isStaff,
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    logger.error("feedback.comments.add_failed", {
+      ticket_id: ticketId,
+      author: authorUserId,
+      err: error.message,
+    });
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true, comment: data as FeedbackTicketComment };
+}

--- a/lib/feedback/tickets/create.ts
+++ b/lib/feedback/tickets/create.ts
@@ -1,0 +1,91 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+import type { CreateTicketInput, FeedbackTicket } from "../types";
+
+type CreateResult =
+  | { ok: true; ticket: FeedbackTicket }
+  | { ok: false; error: string };
+
+export async function createTicket(
+  input: CreateTicketInput,
+  createdByUserId: string,
+): Promise<CreateResult> {
+  const svc = getServiceRoleClient();
+
+  // Assignee validation: if provided, the assignee must be Opollo staff.
+  if (input.assigneeId) {
+    const { data: assignee, error: assigneeErr } = await svc
+      .from("platform_users")
+      .select("id, is_opollo_staff")
+      .eq("id", input.assigneeId)
+      .maybeSingle();
+    if (assigneeErr || !assignee) {
+      return { ok: false, error: "Assignee not found." };
+    }
+    if (!assignee.is_opollo_staff) {
+      return { ok: false, error: "Assignee must be Opollo staff." };
+    }
+  }
+
+  const { data, error } = await svc
+    .from("feedback_tickets")
+    .insert({
+      company_id: input.companyId,
+      title: input.title,
+      description: input.description,
+      severity: input.severity,
+      priority: "medium",
+      status: "backlog",
+      tags: input.tags ?? [],
+      assignee_id: input.assigneeId ?? null,
+      page_url: input.pageUrl,
+      route_pattern: input.routePattern ?? null,
+      css_selector: input.cssSelector,
+      element_label: input.elementLabel ?? null,
+      click_x_pct: input.clickXPct,
+      click_y_pct: input.clickYPct,
+      viewport_w: input.viewportW,
+      viewport_h: input.viewportH,
+      device_pixel_ratio: input.devicePixelRatio ?? null,
+      user_agent: input.userAgent ?? null,
+      console_errors: input.consoleErrors ?? null,
+      screenshot_path: input.screenshotObjectPath ?? null,
+      created_by: createdByUserId,
+      updated_by: createdByUserId,
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    logger.error("feedback.create.failed", {
+      company_id: input.companyId,
+      created_by: createdByUserId,
+      err: error.message,
+    });
+    return { ok: false, error: error.message };
+  }
+
+  const ticket = data as FeedbackTicket;
+
+  // Append created event (service role; append-only).
+  await svc.from("feedback_ticket_events").insert({
+    ticket_id: ticket.id,
+    event_type: "created",
+    from_value: null,
+    to_value: "backlog",
+    actor_id: createdByUserId,
+    actor_kind: "human-staff",
+  });
+
+  logger.info("feedback.create.ok", {
+    ticket_id: ticket.id,
+    company_id: input.companyId,
+    severity: input.severity,
+    created_by: createdByUserId,
+  });
+
+  return { ok: true, ticket };
+}

--- a/lib/feedback/tickets/queries.ts
+++ b/lib/feedback/tickets/queries.ts
@@ -1,0 +1,91 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+import type { FeedbackTicket, FeedbackTicketComment, FeedbackTicketEvent } from "../types";
+
+// ---------------------------------------------------------------------------
+// Queries — list/get with RLS-appropriate scoping.
+// Service-role is used here so the caller can pass an explicit companyId
+// filter for members, or omit it for staff (cross-company). The RLS layer
+// is enforced at the API boundary; these functions are internal lib helpers.
+// ---------------------------------------------------------------------------
+
+export type ListTicketsOptions = {
+  companyId?: string;
+  status?: string;
+  severity?: string;
+  priority?: string;
+  assigneeId?: string;
+  hasPr?: boolean;
+};
+
+export async function listTickets(
+  opts: ListTicketsOptions,
+): Promise<FeedbackTicket[]> {
+  const svc = getServiceRoleClient();
+  let q = svc
+    .from("feedback_tickets")
+    .select("*")
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false });
+
+  if (opts.companyId) q = q.eq("company_id", opts.companyId);
+  if (opts.status) q = q.eq("status", opts.status);
+  if (opts.severity) q = q.eq("severity", opts.severity);
+  if (opts.priority) q = q.eq("priority", opts.priority);
+  if (opts.assigneeId) q = q.eq("assignee_id", opts.assigneeId);
+  if (opts.hasPr === true) q = q.not("linked_pr_url", "is", null);
+  if (opts.hasPr === false) q = q.is("linked_pr_url", null);
+
+  const { data, error } = await q;
+  if (error) {
+    logger.error("feedback.queries.list_failed", { err: error.message, opts });
+    return [];
+  }
+  return (data ?? []) as FeedbackTicket[];
+}
+
+export async function getTicket(id: string): Promise<FeedbackTicket | null> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("feedback_tickets")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) {
+    logger.error("feedback.queries.get_failed", { ticket_id: id, err: error.message });
+    return null;
+  }
+  return data as FeedbackTicket | null;
+}
+
+export async function listComments(ticketId: string): Promise<FeedbackTicketComment[]> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("feedback_ticket_comments")
+    .select("*")
+    .eq("ticket_id", ticketId)
+    .is("deleted_at", null)
+    .order("created_at", { ascending: true });
+  if (error) {
+    logger.error("feedback.queries.comments_failed", { ticket_id: ticketId, err: error.message });
+    return [];
+  }
+  return (data ?? []) as FeedbackTicketComment[];
+}
+
+export async function listEvents(ticketId: string): Promise<FeedbackTicketEvent[]> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("feedback_ticket_events")
+    .select("*")
+    .eq("ticket_id", ticketId)
+    .order("created_at", { ascending: true });
+  if (error) {
+    logger.error("feedback.queries.events_failed", { ticket_id: ticketId, err: error.message });
+    return [];
+  }
+  return (data ?? []) as FeedbackTicketEvent[];
+}

--- a/lib/feedback/tickets/update-status.ts
+++ b/lib/feedback/tickets/update-status.ts
@@ -1,0 +1,174 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+import type { CallerContext, TicketStatus } from "../types";
+
+// ---------------------------------------------------------------------------
+// State machine — single source of truth for all status transitions.
+//
+// Caller context guards (§1 of build spec, non-negotiable):
+//   human-staff    → any transition
+//   automation     → only in_progress | fixed
+//   customer-reporter → only {fixed,verified} → in_progress (controlled reopen)
+//
+// verified_by / verified_at are set ONLY on a human-staff transition to
+// verified. If any other caller attempts to set verified, the guard throws
+// and logs — it does NOT silently succeed.
+// ---------------------------------------------------------------------------
+
+const TERMINAL_STATUSES: TicketStatus[] = ["verified", "closed", "wont_fix"];
+
+// Allowed (from → to) pairs. Any unlisted pair is rejected.
+// Spec (§7): backlog → triaged → in_progress → fixed → verified → closed
+//            any → wont_fix → closed
+//            fixed|verified → in_progress  (reopen)
+// Notably: only verified → closed and wont_fix → closed lead to closed.
+// "any → wont_fix" means: backlog, triaged, in_progress, fixed, verified.
+const TRANSITIONS: Map<TicketStatus, TicketStatus[]> = new Map([
+  ["backlog",     ["triaged", "in_progress", "wont_fix"]],
+  ["triaged",     ["in_progress", "wont_fix"]],
+  ["in_progress", ["fixed", "wont_fix"]],
+  ["fixed",       ["in_progress", "verified", "wont_fix"]],
+  ["verified",    ["in_progress", "closed", "wont_fix"]],
+  ["wont_fix",    ["closed"]],
+  ["closed",      []],
+]);
+
+type UpdateStatusResult =
+  | { ok: true; status: TicketStatus }
+  | { ok: false; error: string };
+
+export async function updateTicketStatus(
+  ticketId: string,
+  toStatus: TicketStatus,
+  caller: CallerContext,
+): Promise<UpdateStatusResult> {
+  const svc = getServiceRoleClient();
+
+  // Load the current ticket.
+  const { data: ticket, error: ticketErr } = await svc
+    .from("feedback_tickets")
+    .select("id, status, company_id, assignee_id")
+    .eq("id", ticketId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (ticketErr || !ticket) {
+    return { ok: false, error: "Ticket not found." };
+  }
+
+  const fromStatus = ticket.status as TicketStatus;
+
+  // -------------------------------------------------------------------------
+  // 1. Validate the caller's permission to make this transition.
+  // -------------------------------------------------------------------------
+  if (caller.kind === "automation") {
+    // Automation may only move to in_progress or fixed.
+    if (toStatus !== "in_progress" && toStatus !== "fixed") {
+      const msg = `Automation caller rejected: cannot set status '${toStatus}' (only in_progress|fixed allowed).`;
+      logger.error("feedback.update_status.automation_terminal_rejected", {
+        ticket_id: ticketId,
+        to_status: toStatus,
+      });
+      throw new Error(msg);
+    }
+  }
+
+  if (caller.kind === "customer-reporter") {
+    // Customers may only perform the controlled reopen: {fixed,verified} → in_progress.
+    if (
+      toStatus !== "in_progress" ||
+      (fromStatus !== "fixed" && fromStatus !== "verified")
+    ) {
+      const msg = `Customer-reporter rejected: only {fixed,verified} → in_progress is allowed (attempted ${fromStatus} → ${toStatus}).`;
+      logger.error("feedback.update_status.customer_reporter_rejected", {
+        ticket_id: ticketId,
+        from_status: fromStatus,
+        to_status: toStatus,
+        actor: caller.userId,
+      });
+      throw new Error(msg);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 2. Validate the transition is in the state machine.
+  // -------------------------------------------------------------------------
+  const allowed = TRANSITIONS.get(fromStatus) ?? [];
+  if (!allowed.includes(toStatus)) {
+    return {
+      ok: false,
+      error: `Transition ${fromStatus} → ${toStatus} is not permitted.`,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // 3. Apply the transition.
+  // -------------------------------------------------------------------------
+  const actorId =
+    caller.kind === "automation" ? null : caller.userId;
+  const actorKind = caller.kind;
+
+  const updateFields: Record<string, unknown> = {
+    status: toStatus,
+    updated_by: actorId,
+  };
+
+  // verified_by / verified_at only on a human-staff → verified transition.
+  if (toStatus === "verified" && caller.kind === "human-staff") {
+    updateFields.verified_by = caller.userId;
+    updateFields.verified_at = new Date().toISOString();
+  }
+
+  // triaged_by / triaged_at on a human-staff → triaged transition.
+  if (toStatus === "triaged" && caller.kind === "human-staff") {
+    updateFields.triaged_by = caller.userId;
+    updateFields.triaged_at = new Date().toISOString();
+  }
+
+  const { error: updateErr } = await svc
+    .from("feedback_tickets")
+    .update(updateFields)
+    .eq("id", ticketId);
+
+  if (updateErr) {
+    logger.error("feedback.update_status.failed", {
+      ticket_id: ticketId,
+      err: updateErr.message,
+    });
+    return { ok: false, error: updateErr.message };
+  }
+
+  // -------------------------------------------------------------------------
+  // 4. Write audit event.
+  // -------------------------------------------------------------------------
+  const eventType =
+    caller.kind === "customer-reporter" ? "reopened_by_customer" :
+    toStatus === "verified"             ? "verified"             :
+    toStatus === "closed"               ? "closed"               :
+    "status_changed";
+
+  await svc.from("feedback_ticket_events").insert({
+    ticket_id: ticketId,
+    event_type: eventType,
+    from_value: fromStatus,
+    to_value: toStatus,
+    actor_id: actorId,
+    actor_kind: actorKind,
+  });
+
+  logger.info("feedback.update_status.ok", {
+    ticket_id: ticketId,
+    from_status: fromStatus,
+    to_status: toStatus,
+    actor_kind: actorKind,
+    actor_id: actorId,
+  });
+
+  return { ok: true, status: toStatus };
+}
+
+// Re-export for convenience.
+export { TERMINAL_STATUSES };

--- a/lib/feedback/types/index.ts
+++ b/lib/feedback/types/index.ts
@@ -1,0 +1,129 @@
+// lib/feedback/types/index.ts — shared types for the feedback module.
+// These mirror the feedback_tickets / feedback_ticket_comments /
+// feedback_ticket_events DB schema. Keep aligned with the migration.
+
+export type TicketStatus =
+  | "backlog"
+  | "triaged"
+  | "in_progress"
+  | "fixed"
+  | "verified"
+  | "wont_fix"
+  | "closed";
+
+export type TicketSeverity = "low" | "normal" | "high" | "blocker";
+export type TicketPriority = "low" | "medium" | "high" | "urgent";
+export type EventActorKind = "human-staff" | "automation" | "customer-reporter" | "system";
+export type EventType =
+  | "created"
+  | "assigned"
+  | "reassigned"
+  | "status_changed"
+  | "severity_changed"
+  | "priority_changed"
+  | "reopened_by_customer"
+  | "verified"
+  | "closed";
+
+// ---------------------------------------------------------------------------
+// CallerContext — the three contexts that may drive status transitions.
+// Enforced in update-status.ts; must be set at the call site, never inferred.
+// ---------------------------------------------------------------------------
+export type CallerContext =
+  | { kind: "human-staff"; userId: string }
+  | { kind: "automation" }
+  | { kind: "customer-reporter"; userId: string };
+
+// ---------------------------------------------------------------------------
+// DB row shapes (snake_case matching DB columns).
+// ---------------------------------------------------------------------------
+export type FeedbackTicket = {
+  id: string;
+  company_id: string;
+  title: string;
+  description: string;
+  severity: TicketSeverity;
+  priority: TicketPriority;
+  status: TicketStatus;
+  assignee_id: string | null;
+  triaged_by: string | null;
+  triaged_at: string | null;
+  verified_by: string | null;
+  verified_at: string | null;
+  tags: string[];
+  page_url: string;
+  route_pattern: string | null;
+  css_selector: string;
+  element_label: string | null;
+  click_x_pct: number;
+  click_y_pct: number;
+  viewport_w: number;
+  viewport_h: number;
+  device_pixel_ratio: number | null;
+  user_agent: string | null;
+  console_errors: unknown | null;
+  screenshot_path: string | null;
+  annotation: unknown | null;
+  repo_ref: string | null;
+  linked_pr_url: string | null;
+  created_by: string;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export type FeedbackTicketComment = {
+  id: string;
+  ticket_id: string;
+  body: string;
+  author_id: string;
+  is_staff: boolean;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export type FeedbackTicketEvent = {
+  id: string;
+  ticket_id: string;
+  event_type: EventType;
+  from_value: string | null;
+  to_value: string | null;
+  actor_id: string | null;
+  actor_kind: EventActorKind;
+  created_at: string;
+};
+
+// ---------------------------------------------------------------------------
+// API-layer shapes (camelCase for the wire format)
+// ---------------------------------------------------------------------------
+export type CreateTicketInput = {
+  companyId: string;
+  title: string;
+  description: string;
+  severity: TicketSeverity;
+  tags: string[];
+  assigneeId?: string | null;
+  pageUrl: string;
+  routePattern?: string | null;
+  cssSelector: string;
+  elementLabel?: string | null;
+  clickXPct: number;
+  clickYPct: number;
+  viewportW: number;
+  viewportH: number;
+  devicePixelRatio?: number | null;
+  userAgent?: string | null;
+  consoleErrors?: unknown[] | null;
+  screenshotObjectPath?: string | null;
+};
+
+export type UpdateTicketInput = {
+  ticketId: string;
+  status?: TicketStatus;
+  assigneeId?: string | null;
+  severity?: TicketSeverity;
+  priority?: TicketPriority;
+  tags?: string[];
+};

--- a/lib/platform/auth/permissions.ts
+++ b/lib/platform/auth/permissions.ts
@@ -35,6 +35,8 @@ const ACTION_MIN_ROLE: Record<PermissionAction, CompanyRole> = {
   receive_connection_alerts: "admin",
   view_insights: "viewer",
   manage_insights: "admin",
+  create_feedback: "viewer",
+  view_feedback: "viewer",
 };
 
 export function minRoleFor(action: PermissionAction): CompanyRole {

--- a/lib/platform/auth/types.ts
+++ b/lib/platform/auth/types.ts
@@ -26,7 +26,9 @@ export type PermissionAction =
   | "view_calendar"
   | "receive_connection_alerts"
   | "view_insights"
-  | "manage_insights";
+  | "manage_insights"
+  | "create_feedback"
+  | "view_feedback";
 
 export type CompanyMembership = {
   companyId: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "fabric": "^7.4.0",
         "fflate": "^0.8.2",
         "geist": "^1.7.0",
+        "html2canvas": "^1.4.1",
         "konva": "^10.3.0",
         "langfuse": "^3.38.20",
         "lucide-react": "^1.16.0",
@@ -8380,6 +8381,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -9445,6 +9455,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -12317,6 +12336,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -18493,6 +18525,15 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -19135,6 +19176,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "fabric": "^7.4.0",
     "fflate": "^0.8.2",
     "geist": "^1.7.0",
+    "html2canvas": "^1.4.1",
     "konva": "^10.3.0",
     "langfuse": "^3.38.20",
     "lucide-react": "^1.16.0",

--- a/supabase/migrations/0179_feedback_tracker.sql
+++ b/supabase/migrations/0179_feedback_tracker.sql
@@ -1,0 +1,199 @@
+-- 0179_feedback_tracker.sql
+-- In-App Feedback, Ticketing & Issue-Triage — v1 foundation.
+-- Creates feedback_tickets, feedback_ticket_comments, feedback_ticket_events
+-- tables plus RLS policies. Extends platform_notification_type enum with
+-- five feedback events. Creates the feedback-screenshots storage bucket.
+--
+-- Auth helpers used in RLS policies:
+--   is_opollo_staff()         — defined in 0070_platform_foundation.sql
+--   is_company_member(uuid)   — defined in 0070_platform_foundation.sql
+-- These are the correct helpers for company-scoped customer data (not auth_role()).
+
+-- ---------------------------------------------------------------------------
+-- Extend the notification type enum (forward-only; IF NOT EXISTS prevents
+-- replay failures on subsequent applies).
+-- ---------------------------------------------------------------------------
+ALTER TYPE platform_notification_type ADD VALUE IF NOT EXISTS 'ticket_created';
+ALTER TYPE platform_notification_type ADD VALUE IF NOT EXISTS 'ticket_assigned';
+ALTER TYPE platform_notification_type ADD VALUE IF NOT EXISTS 'ticket_comment_added';
+ALTER TYPE platform_notification_type ADD VALUE IF NOT EXISTS 'ticket_status_changed';
+ALTER TYPE platform_notification_type ADD VALUE IF NOT EXISTS 'ticket_reopened_by_customer';
+
+-- ---------------------------------------------------------------------------
+-- feedback_tickets
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS feedback_tickets (
+  id                  uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id          uuid        NOT NULL REFERENCES platform_companies(id),
+  title               text        NOT NULL,
+  description         text        NOT NULL CHECK (char_length(description) <= 2000),
+  severity            text        NOT NULL DEFAULT 'normal'
+                                    CHECK (severity IN ('low','normal','high','blocker')),
+  priority            text        NOT NULL DEFAULT 'medium'
+                                    CHECK (priority IN ('low','medium','high','urgent')),
+  status              text        NOT NULL DEFAULT 'backlog'
+                                    CHECK (status IN ('backlog','triaged','in_progress','fixed',
+                                                      'verified','wont_fix','closed')),
+  assignee_id         uuid        REFERENCES platform_users(id),
+  triaged_by          uuid        REFERENCES platform_users(id),
+  triaged_at          timestamptz,
+  verified_by         uuid        REFERENCES platform_users(id),
+  verified_at         timestamptz,
+  tags                text[]      NOT NULL DEFAULT '{}',
+  page_url            text        NOT NULL,
+  route_pattern       text,
+  css_selector        text        NOT NULL,
+  element_label       text,
+  click_x_pct         numeric     NOT NULL CHECK (click_x_pct BETWEEN 0 AND 100),
+  click_y_pct         numeric     NOT NULL CHECK (click_y_pct BETWEEN 0 AND 100),
+  viewport_w          integer     NOT NULL,
+  viewport_h          integer     NOT NULL,
+  device_pixel_ratio  numeric,
+  user_agent          text,
+  console_errors      jsonb,
+  screenshot_path     text,
+  annotation          jsonb,
+  repo_ref            text,
+  linked_pr_url       text,
+  created_by          uuid        NOT NULL REFERENCES platform_users(id),
+  updated_by          uuid        REFERENCES platform_users(id),
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now(),
+  deleted_at          timestamptz,
+  deleted_by          uuid        REFERENCES platform_users(id)
+);
+
+CREATE INDEX IF NOT EXISTS feedback_tickets_company_idx
+  ON feedback_tickets (company_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS feedback_tickets_status_idx
+  ON feedback_tickets (status)     WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS feedback_tickets_assignee_idx
+  ON feedback_tickets (assignee_id);
+
+-- Reuse the shared updated_at trigger function (defined in 0070); one
+-- trigger per table, named consistently.
+CREATE OR REPLACE TRIGGER feedback_tickets_updated_at
+  BEFORE UPDATE ON feedback_tickets
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+ALTER TABLE feedback_tickets ENABLE ROW LEVEL SECURITY;
+
+-- Service role: full access (for bugs:push + signed uploads)
+CREATE POLICY feedback_tickets_service ON feedback_tickets
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Read: staff see all; members see their company; soft-deleted rows are staff-only
+CREATE POLICY feedback_tickets_read ON feedback_tickets FOR SELECT USING (
+  (deleted_at IS NULL AND (is_opollo_staff() OR is_company_member(company_id)))
+  OR (deleted_at IS NOT NULL AND is_opollo_staff())
+);
+
+-- Insert: any company member or Opollo staff
+CREATE POLICY feedback_tickets_insert ON feedback_tickets FOR INSERT WITH CHECK (
+  is_opollo_staff() OR is_company_member(company_id)
+);
+
+-- Update: Opollo staff only. The controlled customer reopen (§4) runs via
+-- the service-role path in update-status.ts after validating membership —
+-- it does NOT widen this policy.
+CREATE POLICY feedback_tickets_update ON feedback_tickets FOR UPDATE USING (
+  is_opollo_staff()
+);
+
+-- ---------------------------------------------------------------------------
+-- feedback_ticket_comments
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS feedback_ticket_comments (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  ticket_id   uuid        NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
+  body        text        NOT NULL,
+  author_id   uuid        NOT NULL REFERENCES platform_users(id),
+  is_staff    boolean     NOT NULL DEFAULT false,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  deleted_at  timestamptz,
+  deleted_by  uuid        REFERENCES platform_users(id)
+);
+
+CREATE INDEX IF NOT EXISTS feedback_ticket_comments_ticket_idx
+  ON feedback_ticket_comments (ticket_id) WHERE deleted_at IS NULL;
+
+CREATE OR REPLACE TRIGGER feedback_ticket_comments_updated_at
+  BEFORE UPDATE ON feedback_ticket_comments
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+ALTER TABLE feedback_ticket_comments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY feedback_comments_service ON feedback_ticket_comments
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY feedback_comments_read ON feedback_ticket_comments FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM feedback_tickets t
+    WHERE t.id = ticket_id
+      AND (is_opollo_staff() OR is_company_member(t.company_id))
+  )
+);
+
+CREATE POLICY feedback_comments_insert ON feedback_ticket_comments FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM feedback_tickets t
+    WHERE t.id = ticket_id
+      AND (is_opollo_staff() OR is_company_member(t.company_id))
+  )
+);
+
+-- ---------------------------------------------------------------------------
+-- feedback_ticket_events (append-only audit trail)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS feedback_ticket_events (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  ticket_id   uuid        NOT NULL REFERENCES feedback_tickets(id) ON DELETE CASCADE,
+  event_type  text        NOT NULL
+                            CHECK (event_type IN ('created','assigned','reassigned',
+                                   'status_changed','severity_changed','priority_changed',
+                                   'reopened_by_customer','verified','closed')),
+  from_value  text,
+  to_value    text,
+  actor_id    uuid        REFERENCES platform_users(id),
+  actor_kind  text        NOT NULL DEFAULT 'human-staff'
+                            CHECK (actor_kind IN ('human-staff','automation','customer-reporter','system')),
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS feedback_ticket_events_ticket_idx
+  ON feedback_ticket_events (ticket_id, created_at);
+
+ALTER TABLE feedback_ticket_events ENABLE ROW LEVEL SECURITY;
+
+-- Events are written server-side (service role) only — authenticated clients
+-- get read access via the parent ticket's visibility; no client insert/update/delete.
+CREATE POLICY feedback_events_service ON feedback_ticket_events
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY feedback_events_read ON feedback_ticket_events FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM feedback_tickets t
+    WHERE t.id = ticket_id
+      AND (is_opollo_staff() OR is_company_member(t.company_id))
+  )
+);
+
+-- ---------------------------------------------------------------------------
+-- Storage bucket: feedback-screenshots (private; sign on read)
+-- ---------------------------------------------------------------------------
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('feedback-screenshots', 'feedback-screenshots', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- Service role can read/write; authenticated users can insert (upload via
+-- signed URL) but not read directly — reads always go through the signed-URL
+-- endpoint. The bucket is private so anonymous reads return 403.
+CREATE POLICY feedback_screenshots_service ON storage.objects
+  FOR ALL TO service_role
+  USING (bucket_id = 'feedback-screenshots')
+  WITH CHECK (bucket_id = 'feedback-screenshots');
+
+CREATE POLICY feedback_screenshots_upload ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'feedback-screenshots');

--- a/tests/regressions/feedback-governance.test.ts
+++ b/tests/regressions/feedback-governance.test.ts
@@ -1,0 +1,250 @@
+// tests/regressions/feedback-governance.test.ts
+// §1 Governance invariants for the feedback/bug-tracker module.
+//
+// Critical assertions (non-negotiable per the build spec):
+//   A. automation caller is rejected on each terminal transition
+//      (verified, closed, wont_fix); throws + logs.
+//   B. customer-reporter is rejected on every transition except the
+//      controlled reopen ({fixed|verified} → in_progress).
+//   C. The click-marker percentage math is preserved across viewports.
+//
+// Layer 1 — unit tests; mocked Supabase, no DB or network required.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CallerContext } from "@/lib/feedback/types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const TICKET_ID = "aaaaaaaa-0000-4000-8000-000000000001";
+const ACTOR_ID = "bbbbbbbb-0000-4000-8000-000000000001";
+
+function makeSvcMock(status: string) {
+  return {
+    from: (table: string) => {
+      if (table === "feedback_tickets") {
+        return {
+          select: () => ({
+            eq: () => ({
+              is: () => ({
+                maybeSingle: async () => ({
+                  data: { id: TICKET_ID, status, company_id: "company-1", assignee_id: null },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+          update: () => ({
+            eq: () => Promise.resolve({ error: null }),
+          }),
+        };
+      }
+      if (table === "feedback_ticket_events") {
+        return {
+          insert: () => Promise.resolve({ error: null }),
+        };
+      }
+      return {};
+    },
+  };
+}
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+async function callUpdateStatus(
+  status: string,
+  toStatus: string,
+  caller: CallerContext,
+) {
+  const { getServiceRoleClient } = await import("@/lib/supabase");
+  vi.mocked(getServiceRoleClient).mockReturnValue(makeSvcMock(status) as never);
+  const { updateTicketStatus } = await import("@/lib/feedback/tickets/update-status");
+  return updateTicketStatus(TICKET_ID, toStatus as never, caller);
+}
+
+// ---------------------------------------------------------------------------
+// A. automation caller — terminal transitions must throw
+// ---------------------------------------------------------------------------
+describe("A. automation caller — terminal transition guard", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.clearAllMocks());
+
+  const TERMINAL = ["verified", "closed", "wont_fix"] as const;
+  const AUTOMATION: CallerContext = { kind: "automation" };
+
+  TERMINAL.forEach((target) => {
+    it(`throws when automation attempts → ${target}`, async () => {
+      await expect(
+        callUpdateStatus("in_progress", target, AUTOMATION),
+      ).rejects.toThrow(/Automation caller rejected/);
+    });
+  });
+
+  it("succeeds when automation sets → in_progress", async () => {
+    const result = await callUpdateStatus("backlog", "in_progress", AUTOMATION);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.status).toBe("in_progress");
+  });
+
+  it("succeeds when automation sets → fixed", async () => {
+    const result = await callUpdateStatus("in_progress", "fixed", AUTOMATION);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.status).toBe("fixed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B. customer-reporter — only controlled reopen allowed
+// ---------------------------------------------------------------------------
+describe("B. customer-reporter — only controlled reopen", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.clearAllMocks());
+
+  const REPORTER: CallerContext = { kind: "customer-reporter", userId: ACTOR_ID };
+
+  it("succeeds: fixed → in_progress (controlled reopen)", async () => {
+    const result = await callUpdateStatus("fixed", "in_progress", REPORTER);
+    expect(result.ok).toBe(true);
+  });
+
+  it("succeeds: verified → in_progress (controlled reopen)", async () => {
+    const result = await callUpdateStatus("verified", "in_progress", REPORTER);
+    expect(result.ok).toBe(true);
+  });
+
+  it("throws when customer-reporter attempts → triaged", async () => {
+    await expect(
+      callUpdateStatus("backlog", "triaged", REPORTER),
+    ).rejects.toThrow(/Customer-reporter rejected/);
+  });
+
+  it("throws when customer-reporter attempts → fixed", async () => {
+    await expect(
+      callUpdateStatus("in_progress", "fixed", REPORTER),
+    ).rejects.toThrow(/Customer-reporter rejected/);
+  });
+
+  it("throws when customer-reporter attempts → verified", async () => {
+    await expect(
+      callUpdateStatus("fixed", "verified", REPORTER),
+    ).rejects.toThrow(/Customer-reporter rejected/);
+  });
+
+  it("throws when customer-reporter attempts → closed", async () => {
+    await expect(
+      callUpdateStatus("verified", "closed", REPORTER),
+    ).rejects.toThrow(/Customer-reporter rejected/);
+  });
+
+  it("throws when customer-reporter attempts → wont_fix", async () => {
+    await expect(
+      callUpdateStatus("backlog", "wont_fix", REPORTER),
+    ).rejects.toThrow(/Customer-reporter rejected/);
+  });
+
+  it("throws when customer-reporter tries in_progress → in_progress (not from fixed/verified)", async () => {
+    await expect(
+      callUpdateStatus("in_progress", "in_progress", REPORTER),
+    ).rejects.toThrow(/Customer-reporter rejected/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C. human-staff — can perform all legal transitions
+// ---------------------------------------------------------------------------
+describe("C. human-staff — legal transitions", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.clearAllMocks());
+
+  const STAFF: CallerContext = { kind: "human-staff", userId: ACTOR_ID };
+
+  it("backlog → triaged", async () => {
+    const r = await callUpdateStatus("backlog", "triaged", STAFF);
+    expect(r.ok).toBe(true);
+  });
+
+  it("triaged → in_progress", async () => {
+    const r = await callUpdateStatus("triaged", "in_progress", STAFF);
+    expect(r.ok).toBe(true);
+  });
+
+  it("in_progress → fixed", async () => {
+    const r = await callUpdateStatus("in_progress", "fixed", STAFF);
+    expect(r.ok).toBe(true);
+  });
+
+  it("fixed → verified", async () => {
+    const r = await callUpdateStatus("fixed", "verified", STAFF);
+    expect(r.ok).toBe(true);
+  });
+
+  it("verified → closed", async () => {
+    const r = await callUpdateStatus("verified", "closed", STAFF);
+    expect(r.ok).toBe(true);
+  });
+
+  it("any → wont_fix", async () => {
+    const r = await callUpdateStatus("backlog", "wont_fix", STAFF);
+    expect(r.ok).toBe(true);
+  });
+
+  it("returns ok:false on invalid transition (backlog → closed direct)", async () => {
+    // backlog → closed is not in TRANSITIONS map
+    const r = await callUpdateStatus("backlog", "closed", STAFF);
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D. Click-marker percentage math
+// ---------------------------------------------------------------------------
+describe("D. click-marker percentage coordinates", () => {
+  it("percentage coords survive viewport resize", () => {
+    // A click at 42.1% × 71.0% on a 390×844 viewport...
+    const clickXPct = 42.1;
+    const clickYPct = 71.0;
+
+    // ...on a 390×844 screen → pixel coords
+    const originalW = 390, originalH = 844;
+    const pxX = (clickXPct / 100) * originalW;
+    const pxY = (clickYPct / 100) * originalH;
+    expect(pxX).toBeCloseTo(164.19, 1);
+    expect(pxY).toBeCloseTo(599.24, 1);
+
+    // ...on a 1280×900 replay screen → same percentages, different pixels
+    const replayW = 1280, replayH = 900;
+    const replayPxX = (clickXPct / 100) * replayW;
+    const replayPxY = (clickYPct / 100) * replayH;
+    expect(replayPxX).toBeCloseTo(538.88, 1);
+    expect(replayPxY).toBeCloseTo(639.0, 1);
+
+    // Percentages are identical — the marker lands at the right spot.
+    expect(clickXPct).toBe(clickXPct);
+    expect(clickYPct).toBe(clickYPct);
+  });
+
+  it("boundary: 0% coords are at the top-left corner", () => {
+    const pxX = (0 / 100) * 1280;
+    const pxY = (0 / 100) * 900;
+    expect(pxX).toBe(0);
+    expect(pxY).toBe(0);
+  });
+
+  it("boundary: 100% coords are at the bottom-right corner", () => {
+    const pxX = (100 / 100) * 1280;
+    const pxY = (100 / 100) * 900;
+    expect(pxX).toBe(1280);
+    expect(pxY).toBe(900);
+  });
+});

--- a/tests/regressions/feedback-p1-schema-types.test.ts
+++ b/tests/regressions/feedback-p1-schema-types.test.ts
@@ -1,0 +1,150 @@
+// tests/regressions/feedback-p1-schema-types.test.ts
+// P1 acceptance: verify the CallerContext + TicketStatus type contracts and
+// the migration-expected field shapes compile and match their DB constraints.
+// Layer 1 — pure TypeScript, no DB or network required.
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  CallerContext,
+  EventActorKind,
+  FeedbackTicket,
+  TicketPriority,
+  TicketSeverity,
+  TicketStatus,
+} from "@/lib/feedback/types";
+
+// ---------------------------------------------------------------------------
+// 1. CallerContext — the three legal kinds
+// ---------------------------------------------------------------------------
+describe("CallerContext", () => {
+  it("human-staff carries a userId", () => {
+    const ctx: CallerContext = { kind: "human-staff", userId: "user-1" };
+    expect(ctx.kind).toBe("human-staff");
+    if (ctx.kind === "human-staff") {
+      expect(ctx.userId).toBe("user-1");
+    }
+  });
+
+  it("automation has no userId", () => {
+    const ctx: CallerContext = { kind: "automation" };
+    expect(ctx.kind).toBe("automation");
+  });
+
+  it("customer-reporter carries a userId", () => {
+    const ctx: CallerContext = { kind: "customer-reporter", userId: "user-2" };
+    expect(ctx.kind).toBe("customer-reporter");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. TicketStatus — all seven values
+// ---------------------------------------------------------------------------
+describe("TicketStatus", () => {
+  const VALID: TicketStatus[] = [
+    "backlog",
+    "triaged",
+    "in_progress",
+    "fixed",
+    "verified",
+    "wont_fix",
+    "closed",
+  ];
+
+  it("has exactly 7 statuses", () => {
+    expect(VALID).toHaveLength(7);
+  });
+
+  VALID.forEach((s) => {
+    it(`accepts ${s}`, () => {
+      const status: TicketStatus = s;
+      expect(typeof status).toBe("string");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. TicketSeverity, TicketPriority
+// ---------------------------------------------------------------------------
+describe("TicketSeverity", () => {
+  const VALUES: TicketSeverity[] = ["low", "normal", "high", "blocker"];
+  it("has 4 values", () => expect(VALUES).toHaveLength(4));
+});
+
+describe("TicketPriority", () => {
+  const VALUES: TicketPriority[] = ["low", "medium", "high", "urgent"];
+  it("has 4 values", () => expect(VALUES).toHaveLength(4));
+});
+
+// ---------------------------------------------------------------------------
+// 4. EventActorKind
+// ---------------------------------------------------------------------------
+describe("EventActorKind", () => {
+  const VALUES: EventActorKind[] = [
+    "human-staff",
+    "automation",
+    "customer-reporter",
+    "system",
+  ];
+  it("has 4 values", () => expect(VALUES).toHaveLength(4));
+});
+
+// ---------------------------------------------------------------------------
+// 5. FeedbackTicket shape — required numeric fields are numbers
+// ---------------------------------------------------------------------------
+describe("FeedbackTicket field shapes", () => {
+  const stub: FeedbackTicket = {
+    id: "uuid-1",
+    company_id: "company-uuid",
+    title: "Test bug",
+    description: "Something broke",
+    severity: "high",
+    priority: "urgent",
+    status: "backlog",
+    assignee_id: null,
+    triaged_by: null,
+    triaged_at: null,
+    verified_by: null,
+    verified_at: null,
+    tags: [],
+    page_url: "https://app.opollo.com/company",
+    route_pattern: null,
+    css_selector: "[data-testid='hero-cta']",
+    element_label: "Get started",
+    click_x_pct: 42.1,
+    click_y_pct: 71.0,
+    viewport_w: 390,
+    viewport_h: 844,
+    device_pixel_ratio: 2,
+    user_agent: "Mozilla/5.0",
+    console_errors: null,
+    screenshot_path: null,
+    annotation: null,
+    repo_ref: null,
+    linked_pr_url: null,
+    created_by: "user-1",
+    updated_by: null,
+    created_at: "2026-06-03T00:00:00Z",
+    updated_at: "2026-06-03T00:00:00Z",
+    deleted_at: null,
+  };
+
+  it("click_x_pct is a number between 0 and 100", () => {
+    expect(typeof stub.click_x_pct).toBe("number");
+    expect(stub.click_x_pct).toBeGreaterThanOrEqual(0);
+    expect(stub.click_x_pct).toBeLessThanOrEqual(100);
+  });
+
+  it("click_y_pct is a number between 0 and 100", () => {
+    expect(typeof stub.click_y_pct).toBe("number");
+    expect(stub.click_y_pct).toBeGreaterThanOrEqual(0);
+    expect(stub.click_y_pct).toBeLessThanOrEqual(100);
+  });
+
+  it("viewport_w and viewport_h are integers > 0", () => {
+    expect(Number.isInteger(stub.viewport_w)).toBe(true);
+    expect(stub.viewport_w).toBeGreaterThan(0);
+    expect(Number.isInteger(stub.viewport_h)).toBe(true);
+    expect(stub.viewport_h).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **`FeedbackWidget.tsx`**: tab (collapsed) → rail → element-picker mode → screenshot+pin → create popup → submit. Installs console ring buffer (last 50 `console.error`/`warn`/`unhandledrejection`) at mount. All required `data-testid` attributes present.
- **`ElementPicker.tsx`**: crosshair cursor overlay; tracks hovered element via `getBoundingClientRect()`; records percentage coords (not pixels — survives viewport resize); never mutates page styles.
- **`CreateTaskPopup.tsx`**: description + 0/2000 counter; screenshot thumbnail with click pin at percentage position; severity selector; tags; submit flow (screenshot-url → PUT → POST /tickets).
- **`lib/feedback/capture/selector.ts`**: `resolveSelector()` (data-testid → id → tag chain) + `elementLabel()`.
- **`lib/feedback/capture/annotate.ts`**: shape types for P9 annotation (deferred).
- Adds `html2canvas@^1.4.1` for best-effort page screenshots.

## P3 acceptance criteria ✓

| Check | Status |
|---|---|
| Logged ticket has selector, click_%_pct, viewport, console, screenshot_path | ✓ (all fields in POST payload) |
| data-testids present | ✓ feedback-tab, feedback-rail, feedback-picker, feedback-create-popup, feedback-submit |
| Picker never mutates page styles | ✓ overlay-only div; `pointer-events-none` on the highlight |
| Percentage coords, not pixels | ✓ `clickXPct = ((e.clientX - rect.left) / rect.width) * 100` |
| Screenshot signed on read, path stored | ✓ objectPath stored; signed URL from screenshot-url endpoint |

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| html2canvas cross-origin iframe fails | Spec permits this; submit anyway with null screenshot (selector+coords are load-bearing forensics) |
| Console ring buffer leaks after unmount | Originals restored in `useEffect` cleanup |
| Non-staff sets assigneeId | `create.ts` strips assigneeId from non-staff callers (P2) |

**Stack: P1 (#1284) → P2 (#1285) → P3 (this). Merge in order.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)