### PR TITLE
feat(feedback): v1.2 reporter + triage polish

### DIFF
--- a/app/(platform)/admin/feedback/[id]/page.tsx
+++ b/app/(platform)/admin/feedback/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { redirect, notFound } from "next/navigation";
-import Link from "next/link";
 
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { isOpolloStaff } from "@/lib/platform/auth";
@@ -8,23 +7,27 @@ import {
   getTicket,
   listComments,
   listEvents,
+  listOpolloStaff,
   resolveActorNames,
 } from "@/lib/feedback/tickets/queries";
 import { resolveSignedUrl } from "@/lib/feedback/capture/screenshot";
 import { BugReplayOverlay } from "@/components/feedback/BugReplayOverlay";
 import { TicketThread } from "@/components/feedback/TicketThread";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
-import { TicketTriageActions } from "@/components/feedback/TicketTriageActions";
+import { TicketTriagePanel } from "@/components/feedback/TicketTriagePanel";
 import type {
   FeedbackTicketEvent,
+  TicketPriority,
   TicketStatus,
 } from "@/lib/feedback/types";
 
 // ---------------------------------------------------------------------------
 // Admin ticket detail — /admin/feedback/[id]
 //
-// data-testid: bug-replay-marker (on BugReplayOverlay), ticket-thread,
-//              ticket-reply, ticket-event-timeline
+// §6 BUG fix: removed raw company_id from subtitle (was showing sentinel UUID).
+// §4: shows both "what happened" and "expected behavior" fields.
+// §7: full triage panel (status/assignee/priority/delete).
+// data-testid: bug-replay-marker, ticket-thread, ticket-reply, ticket-event-timeline
 // ---------------------------------------------------------------------------
 
 export const dynamic = "force-dynamic";
@@ -34,14 +37,12 @@ function eventLabel(
   e: FeedbackTicketEvent,
   actorNames: Map<string, string>,
 ): string {
-  // §2: resolve actor_id to a display name; fall back to "Opollo staff" for
-  // null actor (automation/system events) or unknown ids.
   const actor = e.actor_id
     ? (actorNames.get(e.actor_id) ?? "Opollo staff")
     : "system";
 
   switch (e.event_type) {
-    case "created": return `Reported`;
+    case "created": return "Reported";
     case "assigned": return `Assigned by ${actor}`;
     case "reassigned": return `Reassigned by ${actor}`;
     case "status_changed": return `Status: ${e.from_value} → ${e.to_value} by ${actor}`;
@@ -65,7 +66,7 @@ const STATUS_COLOURS: Record<TicketStatus, string> = {
   backlog: "bg-gray-100 text-gray-600",
   triaged: "bg-blue-100 text-blue-700",
   in_progress: "bg-yellow-100 text-yellow-700",
-  fixed: "bg-emerald-100 text-emerald-700",
+  fixed: "bg-[--color-success-bg] text-[--color-success-fg]",
   verified: "bg-green-100 text-green-700",
   wont_fix: "bg-gray-100 text-gray-400",
   closed: "bg-gray-50 text-gray-400",
@@ -84,15 +85,15 @@ export default async function AdminTicketDetailPage({
   const isStaff = await isOpolloStaff(supabase);
   if (!isStaff) redirect("/admin");
 
-  const [ticket, comments, events] = await Promise.all([
+  const [ticket, comments, events, staffList] = await Promise.all([
     getTicket(id),
     listComments(id),
     listEvents(id),
+    listOpolloStaff(),
   ]);
 
   if (!ticket) notFound();
 
-  // §2 — resolve all actor_ids in the event list to display names
   const actorIds = events.map((e) => e.actor_id);
   const actorNames = await resolveActorNames(actorIds);
 
@@ -102,7 +103,7 @@ export default async function AdminTicketDetailPage({
 
   return (
     <div className="mx-auto max-w-5xl p-6">
-      {/* §4 — Breadcrumb */}
+      {/* Breadcrumb */}
       <div className="mb-4">
         <Breadcrumbs
           crumbs={[
@@ -113,13 +114,14 @@ export default async function AdminTicketDetailPage({
         />
       </div>
 
-      {/* Header */}
-      <div className="mb-6">
+      {/* Header — §6 fix: no raw company_id UUID in subtitle */}
+      <div className="mb-4">
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1">
             <h1 className="text-xl font-semibold text-gray-900">{ticket.title}</h1>
+            {/* §6: show short id + date only; company_id was the zero-UUID sentinel */}
             <p className="mt-1 text-sm text-gray-500">
-              #{id.slice(0, 8)} · {ticket.company_id} · {formatDate(ticket.created_at)}
+              #{id.slice(0, 8)} · {formatDate(ticket.created_at)}
             </p>
           </div>
           <div className="flex flex-shrink-0 items-center gap-2">
@@ -133,19 +135,36 @@ export default async function AdminTicketDetailPage({
             </span>
           </div>
         </div>
-        <p className="mt-3 whitespace-pre-wrap text-sm text-gray-700">{ticket.description}</p>
+
+        {/* §4 — What happened */}
+        <div className="mt-3">
+          <p className="mb-1 text-xs font-medium text-gray-500">What happened</p>
+          <p className="whitespace-pre-wrap text-sm text-gray-700">{ticket.description}</p>
+        </div>
+
+        {/* §4 — Expected behavior */}
+        {ticket.expected_behavior && (
+          <div className="mt-3 rounded-lg border border-gray-100 bg-gray-50 px-3 py-2">
+            <p className="mb-1 text-xs font-medium text-gray-500">Expected</p>
+            <p className="whitespace-pre-wrap text-sm text-gray-700">{ticket.expected_behavior}</p>
+          </div>
+        )}
       </div>
 
-      {/* §5 — Staff triage actions */}
-      <TicketTriageActions
-        ticketId={id}
-        currentStatus={ticket.status as TicketStatus}
-      />
+      {/* §7 — Full triage panel: status / priority / assignee / delete */}
+      <div className="mb-6">
+        <TicketTriagePanel
+          ticketId={id}
+          currentStatus={ticket.status as TicketStatus}
+          currentAssigneeId={ticket.assignee_id}
+          currentPriority={ticket.priority as TicketPriority}
+          staffList={staffList}
+        />
+      </div>
 
-      <div className="mt-6 grid gap-6 lg:grid-cols-2">
+      <div className="grid gap-6 lg:grid-cols-2">
         {/* Left: screenshot replay */}
         <div className="flex flex-col gap-4">
-          {/* §9 naming: "Bug Replay" → "Screenshot replay" */}
           <h2 className="text-sm font-semibold text-gray-700">Screenshot replay</h2>
           <BugReplayOverlay
             screenshotUrl={screenshotUrl}
@@ -178,7 +197,7 @@ export default async function AdminTicketDetailPage({
             </div>
           </details>
 
-          {/* §7 — Fix attempt panel */}
+          {/* Fix attempt panel */}
           <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
             <h3 className="mb-2 text-xs font-semibold text-gray-700">Fix attempt</h3>
             {ticket.linked_pr_url || ticket.resolution_notes ? (
@@ -206,7 +225,7 @@ export default async function AdminTicketDetailPage({
                 )}
               </div>
             ) : (
-              <p className="text-xs text-gray-400 italic">No fix attempt yet.</p>
+              <p className="text-xs italic text-gray-400">No fix attempt yet.</p>
             )}
           </div>
         </div>
@@ -218,13 +237,11 @@ export default async function AdminTicketDetailPage({
             <TicketThread ticketId={id} comments={comments} />
           </div>
 
-          {/* Event timeline */}
           <div>
             <h2 className="mb-3 text-sm font-semibold text-gray-700">Event Timeline</h2>
             <ol data-testid="ticket-event-timeline" className="border-l-2 border-gray-200 pl-4">
               {events.map((e) => (
                 <li key={e.id} className="mb-3 last:mb-0">
-                  {/* §2: shows resolved actor name, not actor_kind */}
                   <div className="text-xs font-medium text-gray-800">
                     {eventLabel(e, actorNames)}
                   </div>

--- a/app/(platform)/admin/feedback/page.tsx
+++ b/app/(platform)/admin/feedback/page.tsx
@@ -5,16 +5,15 @@ import { checkAdminAccess } from "@/lib/admin-gate";
 import { isOpolloStaff } from "@/lib/platform/auth";
 import { createRouteAuthClient } from "@/lib/auth";
 import { listTickets } from "@/lib/feedback/tickets/queries";
+import { resolveSignedUrl } from "@/lib/feedback/capture/screenshot";
 import type { TicketPriority, TicketSeverity, TicketStatus } from "@/lib/feedback/types";
 
 // ---------------------------------------------------------------------------
 // Admin feedback board — /admin/feedback
-//
-// Opollo staff only (403 otherwise — enforced here + by admin layout).
-// Cross-company queue sorted by priority desc, then created_at asc
-// (urgent/high priority surfaces first).
-//
 // data-testid: admin-feedback-board
+//
+// §6 BUG fix: removed raw company_id (sentinel 00000000-…) from row subtitle.
+// §6 POLISH: screenshot thumbnails, route path column.
 // ---------------------------------------------------------------------------
 
 export const dynamic = "force-dynamic";
@@ -38,7 +37,7 @@ const STATUS_COLOURS: Record<TicketStatus, string> = {
   backlog: "bg-gray-100 text-gray-600",
   triaged: "bg-blue-100 text-blue-700",
   in_progress: "bg-yellow-100 text-yellow-700",
-  fixed: "bg-emerald-100 text-emerald-700",
+  fixed: "bg-[--color-success-bg] text-[--color-success-fg]",
   verified: "bg-green-100 text-green-700",
   wont_fix: "bg-gray-100 text-gray-400",
   closed: "bg-gray-50 text-gray-400",
@@ -49,6 +48,16 @@ function age(iso: string): string {
   const h = ms / 3600000;
   if (h < 24) return `${Math.floor(h)}h`;
   return `${Math.floor(h / 24)}d`;
+}
+
+function routeDisplay(routePattern: string | null, pageUrl: string): { display: string; full: string } {
+  const full = routePattern ?? pageUrl;
+  try {
+    const u = new URL(pageUrl);
+    return { display: u.pathname || full, full };
+  } catch {
+    return { display: full, full };
+  }
 }
 
 export default async function AdminFeedbackPage() {
@@ -66,17 +75,25 @@ export default async function AdminFeedbackPage() {
       (PRIORITY_ORDER[a.priority as TicketPriority] ?? 0),
   );
 
+  // §6 — Resolve screenshot signed URLs for thumbnails (server-side, parallel).
+  const screenshotUrls = await Promise.all(
+    sorted.map((t) =>
+      t.screenshot_path
+        ? resolveSignedUrl(t.screenshot_path).catch(() => null)
+        : Promise.resolve(null),
+    ),
+  );
+
   return (
     <div data-testid="admin-feedback-board" className="p-6">
       <div className="mb-6 flex items-center justify-between">
         <div>
-          {/* §9 naming: "Bug Tracker" → "Feedback" */}
           <h1 className="text-xl font-semibold text-gray-900">Feedback</h1>
           <p className="text-sm text-gray-500">{tickets.length} open tickets</p>
         </div>
       </div>
 
-      {/* §8 — How fixes happen (pull-based explainer) */}
+      {/* How fixes happen explainer */}
       <div className="mb-6 rounded-lg border border-gray-100 bg-gray-50 px-4 py-3 text-xs text-gray-500">
         <p className="font-medium text-gray-600">How fixes happen</p>
         <p className="mt-1 leading-relaxed">
@@ -93,6 +110,7 @@ export default async function AdminFeedbackPage() {
         <table className="min-w-full divide-y divide-gray-100 text-sm">
           <thead className="bg-gray-50 text-left text-xs font-medium uppercase tracking-wide text-gray-500">
             <tr>
+              <th className="px-3 py-3 w-10" aria-label="Screenshot" />
               <th className="px-4 py-3">Title</th>
               <th className="px-4 py-3">Severity</th>
               <th className="px-4 py-3">Priority</th>
@@ -104,52 +122,85 @@ export default async function AdminFeedbackPage() {
           <tbody className="divide-y divide-gray-50">
             {sorted.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-4 py-8 text-center text-gray-400">
+                <td colSpan={7} className="px-4 py-8 text-center text-gray-400">
                   No open tickets — nice work.
                 </td>
               </tr>
             )}
-            {sorted.map((t) => (
-              <tr
-                key={t.id}
-                className="group cursor-pointer transition-colors hover:bg-gray-50"
-              >
-                <td className="max-w-xs px-4 py-3">
-                  <Link
-                    href={`/admin/feedback/${t.id}`}
-                    className="block font-medium text-gray-900 group-hover:text-emerald-700"
-                  >
-                    {t.title}
-                  </Link>
-                  <p className="truncate text-xs text-gray-400">{t.company_id}</p>
-                </td>
-                <td className="px-4 py-3">
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs font-medium ${SEVERITY_COLOURS[t.severity as TicketSeverity] ?? ""}`}
-                  >
-                    {t.severity}
-                  </span>
-                </td>
-                <td className="px-4 py-3">
-                  <span className="rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700">
-                    {t.priority}
-                  </span>
-                </td>
-                <td className="px-4 py-3">
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLOURS[t.status as TicketStatus] ?? ""}`}
-                  >
-                    {t.status.replace(/_/g, " ")}
-                  </span>
-                </td>
-                <td className="max-w-[160px] truncate px-4 py-3 font-mono text-xs text-gray-500">
-                  {t.route_pattern ?? t.page_url}
-                </td>
-                <td className="whitespace-nowrap px-4 py-3 text-xs text-gray-400">
-                  {age(t.created_at)}
-                </td>
-              </tr>
-            ))}
+            {sorted.map((t, idx) => {
+              const thumbUrl = screenshotUrls[idx];
+              const { display: routeDisplay_, full: routeFull } = routeDisplay(t.route_pattern, t.page_url);
+              return (
+                <tr
+                  key={t.id}
+                  className="group cursor-pointer transition-colors hover:bg-gray-50"
+                >
+                  {/* §6 — thumbnail */}
+                  <td className="px-3 py-2">
+                    {thumbUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={thumbUrl}
+                        alt=""
+                        loading="lazy"
+                        className="h-8 w-12 rounded object-cover object-top opacity-90"
+                      />
+                    ) : (
+                      <div className="h-8 w-12 rounded bg-gray-100" />
+                    )}
+                  </td>
+
+                  <td className="max-w-xs px-4 py-3">
+                    <Link
+                      href={`/admin/feedback/${t.id}`}
+                      className="block font-medium text-gray-900 group-hover:text-emerald-700"
+                    >
+                      {t.title}
+                    </Link>
+                    {/* §6 fix: show short id + date, NOT raw company_id UUID */}
+                    <p className="text-xs text-gray-400">
+                      #{t.id.slice(0, 8)} · {new Date(t.created_at).toLocaleDateString("en-AU", { day: "numeric", month: "short" })}
+                    </p>
+                  </td>
+
+                  <td className="px-4 py-3">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${SEVERITY_COLOURS[t.severity as TicketSeverity] ?? ""}`}
+                    >
+                      {t.severity}
+                    </span>
+                  </td>
+
+                  <td className="px-4 py-3">
+                    <span className="rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700">
+                      {t.priority}
+                    </span>
+                  </td>
+
+                  <td className="px-4 py-3">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLOURS[t.status as TicketStatus] ?? ""}`}
+                    >
+                      {t.status.replace(/_/g, " ")}
+                    </span>
+                  </td>
+
+                  {/* §6 — show path only; title tooltip shows full URL */}
+                  <td className="max-w-[180px] px-4 py-3">
+                    <span
+                      className="block truncate font-mono text-xs text-gray-500"
+                      title={routeFull}
+                    >
+                      {routeDisplay_}
+                    </span>
+                  </td>
+
+                  <td className="whitespace-nowrap px-4 py-3 text-xs text-gray-400">
+                    {age(t.created_at)}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/app/api/feedback/tickets/route.ts
+++ b/app/api/feedback/tickets/route.ts
@@ -41,6 +41,7 @@ const CreateSchema = z.object({
   userAgent: z.string().nullable().optional(),
   consoleErrors: z.array(z.unknown()).nullable().optional(),
   screenshotObjectPath: z.string().nullable().optional(),
+  expectedBehavior: z.string().max(2000).nullable().optional(),
 });
 
 export async function POST(req: NextRequest): Promise<NextResponse> {

--- a/components/feedback/BugReplayOverlay.tsx
+++ b/components/feedback/BugReplayOverlay.tsx
@@ -26,6 +26,8 @@ type Props = {
   elementLabel: string | null;
 };
 
+// §7 — Larger, high-contrast pin marker so it pops on any screenshot.
+// Three layers: outer halo ring, inner pulsing ring, solid pin core.
 function Marker({ clickXPct, clickYPct }: { clickXPct: number; clickYPct: number }) {
   return (
     <div
@@ -37,9 +39,13 @@ function Marker({ clickXPct, clickYPct }: { clickXPct: number; clickYPct: number
         transform: "translate(-50%, -50%)",
       }}
     >
-      <div className="relative flex h-6 w-6 items-center justify-center">
-        <div className="absolute h-6 w-6 animate-ping rounded-full bg-emerald-500 opacity-75" />
-        <div className="relative h-4 w-4 rounded-full border-2 border-white bg-emerald-500 shadow-lg" />
+      {/* Outer halo — static translucent ring for contrast on any background */}
+      <div className="relative flex h-10 w-10 items-center justify-center">
+        <div className="absolute h-10 w-10 rounded-full bg-white opacity-30" />
+        {/* Pulsing ring */}
+        <div className="absolute h-8 w-8 animate-ping rounded-full bg-emerald-400 opacity-60" />
+        {/* Solid pin core */}
+        <div className="relative h-5 w-5 rounded-full border-[3px] border-white bg-emerald-500 shadow-xl" />
       </div>
     </div>
   );

--- a/components/feedback/CreateTaskPopup.tsx
+++ b/components/feedback/CreateTaskPopup.tsx
@@ -20,9 +20,8 @@ type Props = {
 // ---------------------------------------------------------------------------
 // CreateTaskPopup — capture popup that appears after element pick.
 //
-// Left: description textarea + screenshot thumbnail with click-pin.
-// Right: Severity selector, tags.
-// Submit → POST /api/feedback/tickets (screenshot already uploaded by parent).
+// §4 two fields: "What happened?" (description) + "What did you expect?" (expectedBehavior)
+// §5 naming: "Report an issue" / "Send report"
 // ---------------------------------------------------------------------------
 
 export function CreateTaskPopup({
@@ -36,6 +35,7 @@ export function CreateTaskPopup({
 }: Props) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [expectedBehavior, setExpectedBehavior] = useState("");
   const [severity, setSeverity] = useState<TicketSeverity>("normal");
   const [tags, setTagsRaw] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -47,15 +47,14 @@ export function CreateTaskPopup({
   }, []);
 
   const handleSubmit = useCallback(async () => {
-    if (!title.trim() || !description.trim()) {
-      setError("Title and description are required.");
+    if (!title.trim() || !description.trim() || !expectedBehavior.trim()) {
+      setError("Title, what happened, and expected behavior are all required.");
       return;
     }
     setError(null);
     setSubmitting(true);
 
     try {
-      // Upload screenshot if we have one.
       let screenshotObjectPath: string | null = null;
       if (screenshotDataUrl) {
         const urlResp = await fetch("/api/feedback/tickets/screenshot-url", {
@@ -65,7 +64,6 @@ export function CreateTaskPopup({
         });
         if (urlResp.ok) {
           const { data } = await urlResp.json();
-          // Convert data URL to blob.
           const res = await fetch(screenshotDataUrl);
           const blob = await res.blob();
           await fetch(data.uploadUrl, { method: "PUT", body: blob });
@@ -77,6 +75,7 @@ export function CreateTaskPopup({
         companyId,
         title: title.trim(),
         description: description.trim(),
+        expectedBehavior: expectedBehavior.trim(),
         severity,
         tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
         pageUrl,
@@ -100,30 +99,30 @@ export function CreateTaskPopup({
 
       if (!resp.ok) {
         const body = await resp.json().catch(() => ({}));
-        setError(body?.error?.message ?? "Failed to submit ticket.");
+        setError(body?.error?.message ?? "Failed to submit report.");
         return;
       }
 
       const { data } = await resp.json();
       onSubmitted(data.id);
-    } catch (err) {
+    } catch {
       setError("An unexpected error occurred. Please try again.");
     } finally {
       setSubmitting(false);
     }
-  }, [companyId, consoleErrors, description, pageUrl, pick, screenshotDataUrl, severity, tags, title, onSubmitted]);
+  }, [companyId, consoleErrors, description, expectedBehavior, pageUrl, pick, screenshotDataUrl, severity, tags, title, onSubmitted]);
 
   return (
     <div
       data-testid="feedback-create-popup"
-      className="fixed right-16 bottom-16 z-[10001] flex w-[640px] flex-col rounded-xl border border-gray-200 bg-white shadow-2xl"
+      className="fixed right-16 bottom-16 z-[10001] flex w-[680px] flex-col rounded-xl border border-gray-200 bg-white shadow-2xl"
     >
-      {/* Header */}
+      {/* Header — §5: "Report an issue" */}
       <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
-        <h2 className="text-sm font-semibold text-gray-900">Send feedback</h2>
+        <h2 className="text-sm font-semibold text-gray-900">Report an issue</h2>
         <button
           onClick={onClose}
-          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+          className="flex h-8 w-8 items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-600"
           aria-label="Close"
         >
           ✕
@@ -132,7 +131,7 @@ export function CreateTaskPopup({
 
       {/* Body */}
       <div className="flex gap-4 p-4">
-        {/* Left: description + screenshot */}
+        {/* Left: two-field description + screenshot */}
         <div className="flex flex-1 flex-col gap-3">
           <input
             ref={titleRef}
@@ -143,17 +142,39 @@ export function CreateTaskPopup({
             className="rounded-md border border-gray-200 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-emerald-500"
           />
 
+          {/* §4 field 1: what happened */}
           <div className="relative">
+            <label className="mb-1 block text-xs font-medium text-gray-600">
+              What happened?<span className="ml-0.5 text-red-500">*</span>
+            </label>
             <Textarea
-              placeholder="Describe what you expected vs. what happened…"
+              placeholder="Describe what you did and what went wrong…"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               maxLength={2000}
-              rows={5}
+              rows={3}
               className="resize-none text-sm"
             />
             <span className="absolute right-2 bottom-2 text-xs text-gray-400">
               {description.length}/2000
+            </span>
+          </div>
+
+          {/* §4 field 2: expected behavior */}
+          <div className="relative">
+            <label className="mb-1 block text-xs font-medium text-gray-600">
+              What did you expect to happen?<span className="ml-0.5 text-red-500">*</span>
+            </label>
+            <Textarea
+              placeholder="Describe what you expected instead…"
+              value={expectedBehavior}
+              onChange={(e) => setExpectedBehavior(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              className="resize-none text-sm"
+            />
+            <span className="absolute right-2 bottom-2 text-xs text-gray-400">
+              {expectedBehavior.length}/2000
             </span>
           </div>
 
@@ -164,10 +185,9 @@ export function CreateTaskPopup({
               <img
                 src={screenshotDataUrl}
                 alt="Screenshot"
-                className="w-full object-contain"
-                style={{ maxHeight: 200 }}
+                className="w-full"
+                style={{ maxHeight: 180 }}
               />
-              {/* Click-position pin */}
               <div
                 className="pointer-events-none absolute h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-emerald-500 shadow"
                 style={{
@@ -180,13 +200,13 @@ export function CreateTaskPopup({
         </div>
 
         {/* Right: metadata */}
-        <div className="flex w-48 flex-col gap-3">
+        <div className="flex w-44 flex-col gap-3">
           <div>
             <label className="mb-1 block text-xs font-medium text-gray-600">Severity</label>
             <select
               value={severity}
               onChange={(e) => setSeverity(e.target.value as TicketSeverity)}
-              className="w-full rounded-md border border-gray-200 px-2 py-1 text-xs outline-none focus:ring-2 focus:ring-emerald-500"
+              className="w-full rounded-md border border-gray-200 px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-emerald-500"
             >
               <option value="low">Low</option>
               <option value="normal">Normal</option>
@@ -196,13 +216,13 @@ export function CreateTaskPopup({
           </div>
 
           <div>
-            <label className="mb-1 block text-xs font-medium text-gray-600">Tags (comma-separated)</label>
+            <label className="mb-1 block text-xs font-medium text-gray-600">Tags</label>
             <input
               type="text"
               value={tags}
               onChange={(e) => setTagsRaw(e.target.value)}
-              placeholder="ui, navigation…"
-              className="w-full rounded-md border border-gray-200 px-2 py-1 text-xs outline-none focus:ring-2 focus:ring-emerald-500"
+              placeholder="ui, login…"
+              className="w-full rounded-md border border-gray-200 px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-emerald-500"
             />
           </div>
 
@@ -213,9 +233,9 @@ export function CreateTaskPopup({
         </div>
       </div>
 
-      {/* Footer */}
+      {/* Footer — §5: "Send report" */}
       <div className="flex items-center justify-between border-t border-gray-100 px-4 py-3">
-        {error && <p className="text-xs text-red-500">{error}</p>}
+        {error && <p className="flex-1 text-xs text-red-500">{error}</p>}
         <div className="ml-auto flex gap-2">
           <Button variant="ghost" size="sm" onClick={onClose}>
             Cancel
@@ -227,7 +247,7 @@ export function CreateTaskPopup({
             disabled={submitting}
             className="bg-emerald-600 text-white hover:bg-emerald-700"
           >
-            {submitting ? "Submitting…" : "Submit bug report"}
+            {submitting ? "Sending…" : "Send report"}
           </Button>
         </div>
       </div>

--- a/components/feedback/FeedbackWidget.tsx
+++ b/components/feedback/FeedbackWidget.tsx
@@ -13,19 +13,16 @@ type Props = {
 };
 
 // ---------------------------------------------------------------------------
-// FeedbackWidget — tab → rail → picker → create popup flow.
+// FeedbackWidget — pill → rail → picker → create popup flow.
 //
-// Mounted ONCE in the authenticated app shell. Not rendered:
-//   - before auth resolves
-//   - for logged-out users
-//   - on public/magic-link routes
+// §1 Collapsed tab: horizontal pill (emerald filled, floating bottom-right,
+//    "Report an issue" label + icon, depth shadow, ≥44px touch target).
+// §2 Rail: real Button primitive, "Report an issue" label, ≥44px.
+// §3 No count badge (removed entirely — admin info only).
+// §5 Naming: "Report an issue" everywhere customer-facing.
 //
-// The component installs a console ring buffer at mount time to capture
-// the last N console.error / console.warn / window.onerror events.
-//
-// data-testid surface:
-//   feedback-tab, feedback-rail, feedback-picker (on ElementPicker),
-//   feedback-create-popup, feedback-submit (on CreateTaskPopup)
+// data-testid: feedback-tab, feedback-rail, feedback-picker,
+//              feedback-create-popup, feedback-submit
 // ---------------------------------------------------------------------------
 
 const MAX_CONSOLE_ERRORS = 50;
@@ -34,7 +31,6 @@ type ConsoleLine = { level: "error" | "warn"; msg: string; at: string };
 
 export function FeedbackWidget({ companyId }: Props) {
   const [mode, setMode] = useState<Mode>("collapsed");
-  const [openCount, setOpenCount] = useState<number | null>(null);
   const [pick, setPick] = useState<PickResult | null>(null);
   const [screenshotDataUrl, setScreenshotDataUrl] = useState<string | null>(null);
   const [pageUrl, setPageUrl] = useState("");
@@ -71,17 +67,6 @@ export function FeedbackWidget({ companyId }: Props) {
     };
   }, []);
 
-  // Fetch open ticket count for this company when rail opens.
-  useEffect(() => {
-    if (mode !== "rail") return;
-    fetch(`/api/feedback/tickets?companyId=${companyId}&status=backlog`)
-      .then((r) => r.json())
-      .then((body) => {
-        if (body.ok) setOpenCount(body.data.tickets.length);
-      })
-      .catch(() => {});
-  }, [mode, companyId]);
-
   const startPicking = useCallback(() => {
     setPageUrl(window.location.href);
     setMode("picking");
@@ -91,7 +76,6 @@ export function FeedbackWidget({ companyId }: Props) {
     setMode("creating");
     setPick(result);
 
-    // Capture screenshot with html2canvas (best-effort; cross-origin iframes may fail).
     try {
       const canvas = await html2canvas(document.body, {
         useCORS: true,
@@ -99,7 +83,6 @@ export function FeedbackWidget({ companyId }: Props) {
         scale: 1,
         logging: false,
       });
-      // Draw the click pin.
       const ctx = canvas.getContext("2d");
       if (ctx) {
         const pinX = (result.clickXPct / 100) * canvas.width;
@@ -118,7 +101,7 @@ export function FeedbackWidget({ companyId }: Props) {
     }
   }, []);
 
-  const onSubmitted = useCallback((ticketId: string) => {
+  const onSubmitted = useCallback((_ticketId: string) => {
     setMode("submitted");
     setTimeout(() => setMode("collapsed"), 2000);
   }, []);
@@ -148,8 +131,8 @@ export function FeedbackWidget({ companyId }: Props) {
 
   if (mode === "submitted") {
     return (
-      <div className="fixed right-4 bottom-4 z-[10001] rounded-md bg-emerald-600 px-4 py-2 text-sm text-white shadow-lg">
-        ✓ Bug report submitted
+      <div className="fixed right-6 bottom-6 z-[10001] rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-medium text-white shadow-lg">
+        ✓ Report submitted
       </div>
     );
   }
@@ -158,52 +141,73 @@ export function FeedbackWidget({ companyId }: Props) {
     return (
       <div
         data-testid="feedback-rail"
-        className="fixed right-0 bottom-12 z-[9997] flex flex-col items-center rounded-l-xl border border-r-0 border-gray-200 bg-white shadow-xl"
+        className="fixed right-4 bottom-4 z-[9997] flex flex-col items-stretch gap-2 rounded-2xl border border-gray-200 bg-white p-3 shadow-xl"
+        style={{ minWidth: 180 }}
       >
-        {/* Brand mark */}
-        <div className="px-3 py-2 text-xs font-semibold tracking-widest text-gray-400">
-          Feedback
-        </div>
-
-        {/* + button */}
+        {/* §2 — Primary action: real filled button, ≥44px, labeled */}
         <button
           onClick={startPicking}
-          className="flex h-10 w-10 items-center justify-center rounded-lg text-lg text-gray-600 hover:bg-[--color-success-bg] hover:text-[--color-success-fg]"
-          title="Pick an element to report a bug"
+          className="flex min-h-[44px] items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-all hover:bg-emerald-700 hover:shadow-md active:scale-[0.98]"
+          title="Pick an element to report an issue"
         >
-          +
+          {/* Bug/flag icon */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+            <line x1="4" y1="22" x2="4" y2="15" />
+          </svg>
+          Report an issue
         </button>
 
-        {/* Open count badge */}
-        {openCount !== null && openCount > 0 && (
-          <div className="mb-1 h-5 w-5 rounded-full bg-emerald-600 text-center text-xs leading-5 text-white">
-            {openCount > 99 ? "99+" : openCount}
-          </div>
-        )}
-
-        {/* Collapse chevron */}
+        {/* Collapse control — ≥44px hit area */}
         <button
           onClick={() => setMode("collapsed")}
-          className="px-3 py-2 text-xs text-gray-400 hover:text-gray-600"
+          className="flex min-h-[44px] items-center justify-center rounded-xl text-xs text-gray-400 transition-colors hover:bg-gray-50 hover:text-gray-600"
           title="Collapse"
-          aria-label="Collapse feedback rail"
+          aria-label="Collapse issue reporter"
         >
-          ›
+          Close ×
         </button>
       </div>
     );
   }
 
-  // Collapsed: small tab.
+  // §1 — Collapsed: horizontal pill, floating, emerald filled, depth shadow.
   return (
     <button
       data-testid="feedback-tab"
       onClick={() => setMode("rail")}
-      className="fixed right-0 bottom-12 z-[9997] flex h-10 w-8 items-center justify-center rounded-l-md border border-r-0 border-gray-200 bg-white shadow-md hover:bg-[--color-success-bg]"
-      title="Send feedback"
-      aria-label="Open bug reporter"
+      className="fixed right-4 bottom-4 z-[9997] flex min-h-[44px] items-center gap-2 rounded-full bg-emerald-600 px-5 py-2 text-sm font-semibold text-white shadow-lg transition-all hover:bg-emerald-700 hover:shadow-xl active:scale-[0.98]"
+      title="Report an issue"
+      aria-label="Open issue reporter"
     >
-      <span className="rotate-90 text-xs font-semibold text-gray-500">Feedback</span>
+      {/* Bug/flag icon */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="15"
+        height="15"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+        <line x1="4" y1="22" x2="4" y2="15" />
+      </svg>
+      Report an issue
     </button>
   );
 }

--- a/components/feedback/TicketTriagePanel.tsx
+++ b/components/feedback/TicketTriagePanel.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type { TicketPriority, TicketStatus } from "@/lib/feedback/types";
+
+// ---------------------------------------------------------------------------
+// TicketTriagePanel — full triage controls for the admin ticket detail page.
+//
+// §7: status, assignee (Opollo staff only), priority — each writes a
+// feedback_ticket_events row via the existing PATCH endpoint. Automation
+// caller guard in update-status.ts is unchanged.
+// Soft-delete with confirm step also lives here.
+// ---------------------------------------------------------------------------
+
+type StaffOption = { id: string; fullName: string | null; email: string };
+
+type Props = {
+  ticketId: string;
+  currentStatus: TicketStatus;
+  currentAssigneeId: string | null;
+  currentPriority: TicketPriority;
+  staffList: StaffOption[];
+};
+
+const HUMAN_STATUSES: TicketStatus[] = [
+  "backlog",
+  "triaged",
+  "in_progress",
+  "fixed",
+  "verified",
+  "wont_fix",
+  "closed",
+];
+
+const PRIORITIES: TicketPriority[] = ["low", "medium", "high", "urgent"];
+
+export function TicketTriagePanel({
+  ticketId,
+  currentStatus,
+  currentAssigneeId,
+  currentPriority,
+  staffList,
+}: Props) {
+  const router = useRouter();
+  const [status, setStatus] = useState<TicketStatus>(currentStatus);
+  const [assigneeId, setAssigneeId] = useState<string | null>(currentAssigneeId);
+  const [priority, setPriority] = useState<TicketPriority>(currentPriority);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const patch = useCallback(
+    async (fields: Record<string, unknown>) => {
+      setSaving(true);
+      setError(null);
+      try {
+        const resp = await fetch(`/api/feedback/tickets/${ticketId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(fields),
+        });
+        if (!resp.ok) {
+          const body = await resp.json().catch(() => ({}));
+          setError(body?.error?.message ?? "Failed to save.");
+          return false;
+        }
+        router.refresh();
+        return true;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [ticketId, router],
+  );
+
+  const handleDelete = useCallback(async () => {
+    setDeleting(true);
+    setError(null);
+    try {
+      const resp = await fetch(`/api/feedback/tickets/${ticketId}`, { method: "DELETE" });
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({}));
+        setError(body?.error?.message ?? "Failed to delete.");
+        return;
+      }
+      router.push("/admin/feedback");
+    } finally {
+      setDeleting(false);
+      setDeleteConfirm(false);
+    }
+  }, [ticketId, router]);
+
+  return (
+    <div className="flex flex-wrap items-end gap-4 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+      {/* Status */}
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-gray-600">Status</label>
+        <select
+          value={status}
+          onChange={async (e) => {
+            const next = e.target.value as TicketStatus;
+            setStatus(next);
+            await patch({ status: next });
+          }}
+          disabled={saving}
+          className="min-h-[36px] rounded-md border border-gray-200 bg-white px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-60"
+        >
+          {HUMAN_STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {s.replace(/_/g, " ")}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Priority — admin-only */}
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-gray-600">Priority</label>
+        <select
+          value={priority}
+          onChange={async (e) => {
+            const next = e.target.value as TicketPriority;
+            setPriority(next);
+            await patch({ priority: next });
+          }}
+          disabled={saving}
+          className="min-h-[36px] rounded-md border border-gray-200 bg-white px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-60"
+        >
+          {PRIORITIES.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Assignee — Opollo staff only */}
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-gray-600">Assignee</label>
+        <select
+          value={assigneeId ?? ""}
+          onChange={async (e) => {
+            const next = e.target.value || null;
+            setAssigneeId(next);
+            await patch({ assigneeId: next });
+          }}
+          disabled={saving}
+          className="min-h-[36px] rounded-md border border-gray-200 bg-white px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-60"
+        >
+          <option value="">Unassigned</option>
+          {staffList.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.fullName ?? s.email}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Soft delete with confirm */}
+      <div className="ml-auto flex items-center gap-2">
+        {deleteConfirm ? (
+          <>
+            <span className="text-xs text-red-600">Delete this ticket?</span>
+            <button
+              onClick={handleDelete}
+              disabled={deleting}
+              className="min-h-[36px] rounded-md bg-red-600 px-3 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
+            >
+              {deleting ? "Deleting…" : "Confirm"}
+            </button>
+            <button
+              onClick={() => setDeleteConfirm(false)}
+              className="min-h-[36px] rounded-md bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-200"
+            >
+              Cancel
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={() => setDeleteConfirm(true)}
+            className="min-h-[36px] rounded-md px-3 py-1 text-xs font-medium text-red-500 hover:bg-red-50"
+          >
+            Delete
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <p className="w-full text-xs text-red-500">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/lib/feedback/repo-bridge/pull.ts
+++ b/lib/feedback/repo-bridge/pull.ts
@@ -146,9 +146,13 @@ reported_at: ${ticket.created_at}
 linked_pr_url: ${(ticket.linked_pr_url as string | null) ?? "null"}
 ---
 
-## Report
+## What happened
 
 ${ticket.description}
+
+## What was expected
+
+${(ticket.expected_behavior as string | null) ?? "_Not specified_"}
 
 ## Console errors
 

--- a/lib/feedback/tickets/create.ts
+++ b/lib/feedback/tickets/create.ts
@@ -54,6 +54,7 @@ export async function createTicket(
       user_agent: input.userAgent ?? null,
       console_errors: input.consoleErrors ?? null,
       screenshot_path: input.screenshotObjectPath ?? null,
+      expected_behavior: input.expectedBehavior ?? null,
       created_by: createdByUserId,
       updated_by: createdByUserId,
     })

--- a/lib/feedback/tickets/queries.ts
+++ b/lib/feedback/tickets/queries.ts
@@ -76,6 +76,23 @@ export async function listComments(ticketId: string): Promise<FeedbackTicketComm
   return (data ?? []) as FeedbackTicketComment[];
 }
 
+// All Opollo staff — used to populate the assignee picker on ticket detail.
+export async function listOpolloStaff(): Promise<
+  Array<{ id: string; fullName: string | null; email: string }>
+> {
+  const svc = getServiceRoleClient();
+  const { data } = await svc
+    .from("platform_users")
+    .select("id, full_name, email")
+    .eq("is_opollo_staff", true)
+    .order("full_name", { ascending: true });
+  return (data ?? []).map((u) => ({
+    id: u.id as string,
+    fullName: (u.full_name as string | null) ?? null,
+    email: u.email as string,
+  }));
+}
+
 // Resolve actor_id values to display names for the event timeline.
 // Goes through the platform layer (service-role client pattern) without
 // importing platform_users directly — consistent with the rest of lib/feedback.

--- a/lib/feedback/types/index.ts
+++ b/lib/feedback/types/index.ts
@@ -67,6 +67,7 @@ export type FeedbackTicket = {
   repo_ref: string | null;
   linked_pr_url: string | null;
   resolution_notes: string | null;
+  expected_behavior: string | null;
   created_by: string;
   updated_by: string | null;
   created_at: string;
@@ -118,6 +119,7 @@ export type CreateTicketInput = {
   userAgent?: string | null;
   consoleErrors?: unknown[] | null;
   screenshotObjectPath?: string | null;
+  expectedBehavior?: string | null;
 };
 
 export type UpdateTicketInput = {

--- a/supabase/migrations/0181_feedback_expected_behavior.sql
+++ b/supabase/migrations/0181_feedback_expected_behavior.sql
@@ -1,0 +1,10 @@
+-- 0181_feedback_expected_behavior.sql
+-- Additive: adds expected_behavior (nullable text) to feedback_tickets.
+-- Captures "what did you expect to happen?" separately from description
+-- ("what happened?"), so Claude Code sees expected-vs-actual in bugs:pull output.
+
+ALTER TABLE feedback_tickets
+  ADD COLUMN IF NOT EXISTS expected_behavior text;
+
+COMMENT ON COLUMN feedback_tickets.expected_behavior IS
+  'What the reporter expected to happen. Stored separately from description so both fields feed expected-vs-actual context to Claude Code via bugs:pull.';

--- a/tests/regressions/feedback-p1-schema-types.test.ts
+++ b/tests/regressions/feedback-p1-schema-types.test.ts
@@ -128,6 +128,7 @@ describe("FeedbackTicket field shapes", () => {
     updated_at: "2026-06-03T00:00:00Z",
     deleted_at: null,
     resolution_notes: null,
+    expected_behavior: null,
   };
 
   it("click_x_pct is a number between 0 and 100", () => {


### PR DESCRIPTION
## §6 Root cause — zero-UUID in subtitle

**Location:** `app/(platform)/admin/feedback/page.tsx:124` and `app/(platform)/admin/feedback/[id]/page.tsx:122`.

Both rendered `ticket.company_id` raw. The Opollo-internal company has the sentinel UUID `00000000-0000-0000-0000-000000000001` (defined in migration 0070, line enforcing `is_opollo_internal=true`). All tickets filed by Opollo staff through the widget carry this `company_id`. Since the widget is currently only mounted for company-member sessions and Opollo staff use the internal company, every ticket in the list shows the same sentinel.

**Fix:** replaced `{t.company_id}` with `#{t.id.slice(0,8)} · <short date>` in the listing, and removed the raw company_id from the detail header subtitle entirely. Deep links, `bugs:pull`, and the marker all key off `ticket.id` (not company_id) — confirmed unchanged.

## §4 Migration number

**`0181`** — `0181_feedback_expected_behavior.sql`: additive `expected_behavior TEXT` column on `feedback_tickets`.

## Changes by item

| § | Type | Change |
|---|---|---|
| §1 | POLISH | Collapsed tab: horizontal emerald pill, floating, "Report an issue" + icon, ≥44px, depth shadow |
| §2 | POLISH | Rail: real filled Button, "Report an issue", ≥44px, icon, hover states |
| §3 | POLISH | Count badge removed from tab and rail (admin board only) |
| §4 | FEATURE | Two-field capture: "What happened?" + "What did you expect?"; migration 0181; bugs:pull writes both; admin detail shows both |
| §5 | POLISH | "Report an issue" / "Send report" throughout customer surfaces |
| §6 | BUG | Zero-UUID removed; screenshot thumbnails on listing; route shows pathname only |
| §7 | FEATURE | `TicketTriagePanel`: status/priority/assignee dropdowns, each writes event; bigger 3-layer pin marker |

## Governance guard — unchanged, tests green

```
Test Files  6 passed (6)
      Tests  74 passed (74)
```

All existing governance tests (automation/customer-reporter guards, terminal state rejection, cross-tenant isolation, marker math, repo-bridge guards) green.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] test:unit: 74/74 pass — no SKIP_PRECOMMIT_TESTS
- [x] Explicit file paths only — no `git add -A`
- [x] 13 files staged (listed in commit)
- [x] 0 HIGH static audit findings
- [x] Migration 0181 additive only

## Screenshots

Pending browser session. Required per spec: §1 pill vs Feedbask reference, §2 rail button, §4 two-field popup, §6 listing with thumbnails, §7 detail with triage controls.

**Do NOT merge — human review required.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)