### PR TITLE
fix(health-alert): suppress stale re-alerts; 4h cooldown; auto-clear on sync

### DIFF
--- a/app/api/cron/social-connections-health/route.ts
+++ b/app/api/cron/social-connections-health/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/optimiser/sync/cron-shared";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { syncBundlesocialConnections } from "@/lib/platform/social/connections/sync";
+import { recordRecovery } from "@/lib/platform/service-health/record";
 
 // ---------------------------------------------------------------------------
 // F1 — GET /api/cron/social-connections-health
@@ -76,6 +77,25 @@ async function handle(req: NextRequest): Promise<NextResponse> {
 
   const data = { companies_synced, companies_failed, ...totals };
   logger.info("social.connections.health.cron_ok", data);
+
+  // Fix 3 — stale health event auto-clear.
+  //
+  // A successful sync proves bundle.social is reachable from Vercel. If a
+  // previous publish attempt created a connection_failure health event but
+  // there are no scheduled posts to publish (so withHealthMonitoring never
+  // fires on the success path), the event accumulates indefinitely.
+  //
+  // One successful company sync is enough evidence to resolve stale events.
+  // recordRecovery resolves ALL unresolved events for the service — if bundle.
+  // social is actually still down, the next sync (or next publish attempt)
+  // would re-raise immediately, so this is safe to call on partial success.
+  if (companies_synced > 0) {
+    void recordRecovery("bundle.social").catch((err) =>
+      logger.warn("social.connections.health.cron_recovery_failed", {
+        err: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
 
   return NextResponse.json(
     { ok: true, data, timestamp: new Date().toISOString() },

--- a/app/api/internal/cron/health-check/route.ts
+++ b/app/api/internal/cron/health-check/route.ts
@@ -12,9 +12,16 @@ export const dynamic = "force-dynamic";
 // POST /api/internal/cron/health-check
 // Schedule: */5 * * * *
 //
-// Finds unresolved critical service_health_events with
-// notified_at IS NULL OR notified_at < NOW() - 30min.
-// Fires notifications for each qualifying event.
+// Finds unresolved critical service_health_events that need a notification.
+// An event qualifies when:
+//   (a) notified_at IS NULL — never notified, alert fires immediately; OR
+//   (b) notified_at < NOW() - 4h   — re-notification cooldown has elapsed
+//       AND last_seen_at > notified_at — new failures have occurred since
+//       the last notification (prevents stale events from re-alerting forever).
+//
+// The last_seen_at > notified_at gate is the core correctness fix:
+// without it a stale event re-notifies every 30 min indefinitely even
+// when the underlying service recovered and no new failures occurred.
 // ---------------------------------------------------------------------------
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
@@ -25,13 +32,25 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   return handleCron(req);
 }
 
+// Re-notification cooldown: how long must pass before we re-alert on a
+// persistent active failure. 4 h is intentionally longer than the old 30 min
+// — once the on-call team is paged, hourly re-pages add no value until the
+// issue is progressing again (which last_seen_at > notified_at detects).
+const RENOTIFY_COOLDOWN_MS = 4 * 60 * 60 * 1000;
+
 async function handleCron(req: NextRequest): Promise<NextResponse> {
   if (!authorisedCronRequest(req)) return unauthorisedResponse();
 
   const svc = getServiceRoleClient();
-  const cooldownCutoff = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+  // All events past the re-notification cooldown window (including never-notified).
+  const cooldownCutoff = new Date(Date.now() - RENOTIFY_COOLDOWN_MS).toISOString();
 
-  const { data: events, error } = await svc
+  // Fetch candidates: never notified OR cooldown has elapsed.
+  // We then filter in TypeScript on last_seen_at > notified_at to skip
+  // stale events that haven't had new failures since the last notification.
+  // PostgREST does not support column-to-column comparisons in filter syntax,
+  // so the final gate lives here.
+  const { data: candidates, error } = await svc
     .from("service_health_events")
     .select("*")
     .eq("severity", "critical")
@@ -40,6 +59,14 @@ async function handleCron(req: NextRequest): Promise<NextResponse> {
     .order("first_seen_at", { ascending: true })
     .limit(20);
 
+  // Fix 1 — stale suppression: only notify when there are new failures since
+  // the last notification, or when the event has never been notified.
+  // A stale event (last_seen_at ≤ notified_at) means no new occurrences were
+  // recorded after we already alerted; re-alerting adds no signal.
+  const events = (candidates ?? []).filter(
+    (e) => e.notified_at === null || (e.last_seen_at as string) > (e.notified_at as string),
+  );
+
   if (error) {
     logger.error("health_check.query_failed", { err: error.message });
     return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
@@ -47,7 +74,7 @@ async function handleCron(req: NextRequest): Promise<NextResponse> {
 
   let notified = 0;
 
-  for (const event of events ?? []) {
+  for (const event of events) {
     try {
       await notifyHealthAlert(event as Parameters<typeof notifyHealthAlert>[0]);
       await svc
@@ -64,7 +91,12 @@ async function handleCron(req: NextRequest): Promise<NextResponse> {
 
   return NextResponse.json({
     ok: true,
-    data: { checked: (events ?? []).length, notified },
+    data: {
+      candidates: (candidates ?? []).length,  // fetched by query
+      stale_suppressed: (candidates ?? []).length - events.length,  // dropped by last_seen_at gate
+      checked: events.length,   // passed the filter
+      notified,
+    },
     timestamp: new Date().toISOString(),
   });
 }

--- a/tests/regressions/health-alert-stale-dedup.test.ts
+++ b/tests/regressions/health-alert-stale-dedup.test.ts
@@ -1,0 +1,263 @@
+// tests/regressions/health-alert-stale-dedup.test.ts
+//
+// Regression tests for the health-check cron dedup fix.
+//
+// Root cause being tested: the old query
+//   `notified_at IS NULL OR notified_at < NOW() - 30min`
+// re-alerted every 30 min regardless of whether new failures had occurred.
+// A stale event (last_seen_at frozen since the original incident) would
+// re-notify forever — confirmed in prod: one 2-minute bundle.social blip
+// on 2026-06-03 09:00 produced ~49 identical alerts over 24 h.
+//
+// Fix: add `last_seen_at > notified_at` as a gate on re-notifications.
+// A never-notified event always fires (notified_at IS NULL).
+//
+// Tests:
+//   1. NEW failure (never notified) → alert fires immediately regardless of service
+//   2. STALE event (last_seen_at == notified_at) → suppressed
+//   3. ACTIVE event (last_seen_at > notified_at, cooldown elapsed) → fires again
+//   4. Active event within cooldown → suppressed
+//   5. New failure on a DIFFERENT service (sendgrid) still fires immediately
+//      — the dedup must never suppress a first alert on any service
+//
+// Layer 1 — unit tests. No real DB or network.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@/lib/platform/service-health/notify", () => ({
+  notifyHealthAlert: vi.fn(async () => {}),
+}));
+vi.mock("@/lib/platform/cron/cron-shared", () => ({
+  authorisedCronRequest: vi.fn(() => true),
+  unauthorisedResponse: vi.fn(),
+  updateHeartbeat: vi.fn(async () => {}),
+}));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal ServiceHealthEvent-like object for the mock DB. */
+function makeEvent(overrides: {
+  id: string;
+  service_name?: string;
+  operation?: string;
+  notified_at: string | null;
+  last_seen_at: string;
+}) {
+  return {
+    id: overrides.id,
+    service_name: overrides.service_name ?? "bundle.social",
+    operation: overrides.operation ?? "publish",
+    event_type: "connection_failure",
+    severity: "critical",
+    occurrence_count: 3,
+    first_seen_at: "2026-06-03T09:00:00.000Z",
+    last_seen_at: overrides.last_seen_at,
+    notified_at: overrides.notified_at,
+    resolved_at: null,
+    details: { status: null, message: "fetch failed" },
+    raised_by_user_id: null,
+  };
+}
+
+/** The re-notification cooldown in the cron is 4 hours. */
+const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
+
+function makeSvcMock(events: ReturnType<typeof makeEvent>[]) {
+  const updateFn = vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ error: null })) }));
+  const svc = {
+    from: (table: string) => {
+      if (table === "service_health_events") {
+        return {
+          select: () => ({
+            eq: () => ({
+              is: () => ({
+                or: () => ({
+                  order: () => ({
+                    limit: () => Promise.resolve({ data: events, error: null }),
+                  }),
+                }),
+              }),
+            }),
+            update: updateFn,
+          }),
+          update: updateFn,
+        };
+      }
+      return {};
+    },
+  };
+  return { svc, updateFn };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("health-check cron — stale-dedup filter", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.clearAllMocks());
+
+  it("1 — NEW failure (notified_at IS NULL) → notifyHealthAlert fires immediately", async () => {
+    const now = Date.now();
+    const event = makeEvent({
+      id: "evt-new",
+      notified_at: null,   // never notified
+      last_seen_at: new Date(now - 60_000).toISOString(),  // 1 min ago
+    });
+
+    const { svc } = makeSvcMock([event]);
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(svc as never);
+
+    vi.resetModules();
+    const { POST } = await import("@/app/api/internal/cron/health-check/route");
+    const { notifyHealthAlert } = await import("@/lib/platform/service-health/notify");
+
+    const req = new Request("http://localhost/api/internal/cron/health-check", { method: "POST" });
+    const resp = await POST(req as never);
+    const body = await resp.json();
+
+    expect(vi.mocked(notifyHealthAlert)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(notifyHealthAlert)).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "evt-new" }),
+    );
+    expect(body.data.notified).toBe(1);
+    expect(body.data.stale_suppressed).toBe(0);
+  });
+
+  it("2 — STALE event (last_seen_at == notified_at, no new failures) → suppressed", async () => {
+    const now = Date.now();
+    // Notified 5 hours ago, but last_seen_at is ALSO 5 hours ago.
+    // No new failures have occurred since the last notification.
+    const ts = new Date(now - 5 * 60 * 60 * 1000).toISOString();
+    const event = makeEvent({
+      id: "evt-stale",
+      notified_at: ts,
+      last_seen_at: ts,  // equal → no new failures since last notification
+    });
+
+    const { svc } = makeSvcMock([event]);
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(svc as never);
+
+    vi.resetModules();
+    const { POST } = await import("@/app/api/internal/cron/health-check/route");
+    const { notifyHealthAlert } = await import("@/lib/platform/service-health/notify");
+
+    const req = new Request("http://localhost/api/internal/cron/health-check", { method: "POST" });
+    const resp = await POST(req as never);
+    const body = await resp.json();
+
+    // Suppressed — no new failures since last notification.
+    expect(vi.mocked(notifyHealthAlert)).not.toHaveBeenCalled();
+    expect(body.data.notified).toBe(0);
+    expect(body.data.stale_suppressed).toBe(1);
+  });
+
+  it("3 — ACTIVE event (last_seen_at > notified_at, 4h cooldown elapsed) → fires again", async () => {
+    const now = Date.now();
+    // Notified 5 hours ago, but new failures came in 10 minutes ago.
+    const notifiedAt = new Date(now - 5 * 60 * 60 * 1000).toISOString();
+    const lastSeenAt = new Date(now - 10 * 60 * 1000).toISOString();  // 10 min ago
+    const event = makeEvent({
+      id: "evt-active",
+      notified_at: notifiedAt,
+      last_seen_at: lastSeenAt,  // newer than notified_at → new failures occurred
+    });
+
+    const { svc } = makeSvcMock([event]);
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(svc as never);
+
+    vi.resetModules();
+    const { POST } = await import("@/app/api/internal/cron/health-check/route");
+    const { notifyHealthAlert } = await import("@/lib/platform/service-health/notify");
+
+    const req = new Request("http://localhost/api/internal/cron/health-check", { method: "POST" });
+    const resp = await POST(req as never);
+    const body = await resp.json();
+
+    // Active incident with new failures → re-alert fires.
+    expect(vi.mocked(notifyHealthAlert)).toHaveBeenCalledTimes(1);
+    expect(body.data.notified).toBe(1);
+    expect(body.data.stale_suppressed).toBe(0);
+  });
+
+  it("4 — Active event within cooldown window → query never returns it (time gate)", async () => {
+    const now = Date.now();
+    // Notified 30 min ago — inside the 4h cooldown. The SQL query won't
+    // return this event (notified_at >= cutoff), so it never reaches the
+    // TypeScript filter. DB mock returns empty.
+    const { svc } = makeSvcMock([]);  // query returns nothing for within-cooldown events
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(svc as never);
+
+    vi.resetModules();
+    const { POST } = await import("@/app/api/internal/cron/health-check/route");
+    const { notifyHealthAlert } = await import("@/lib/platform/service-health/notify");
+
+    const req = new Request("http://localhost/api/internal/cron/health-check", { method: "POST" });
+    const resp = await POST(req as never);
+    const body = await resp.json();
+
+    expect(vi.mocked(notifyHealthAlert)).not.toHaveBeenCalled();
+    expect(body.data.notified).toBe(0);
+    expect(body.data.candidates).toBe(0);
+  });
+
+  it("5 — NEW failure on a DIFFERENT service (sendgrid) fires immediately — dedup never suppresses first alerts on any service", async () => {
+    const now = Date.now();
+    // sendgrid has a brand-new critical event, never notified.
+    const sendgridEvent = makeEvent({
+      id: "evt-sendgrid-new",
+      service_name: "sendgrid",
+      operation: "notify_approver",
+      notified_at: null,   // never notified
+      last_seen_at: new Date(now - 30_000).toISOString(),  // 30s ago
+    });
+    // bundle.social has a STALE event — should be suppressed.
+    const staleTs = new Date(now - 5 * 60 * 60 * 1000).toISOString();
+    const bundleStaleEvent = makeEvent({
+      id: "evt-bundle-stale",
+      service_name: "bundle.social",
+      operation: "publish",
+      notified_at: staleTs,
+      last_seen_at: staleTs,  // equal → stale
+    });
+
+    const { svc } = makeSvcMock([sendgridEvent, bundleStaleEvent]);
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(svc as never);
+
+    vi.resetModules();
+    const { POST } = await import("@/app/api/internal/cron/health-check/route");
+    const { notifyHealthAlert } = await import("@/lib/platform/service-health/notify");
+
+    const req = new Request("http://localhost/api/internal/cron/health-check", { method: "POST" });
+    const resp = await POST(req as never);
+    const body = await resp.json();
+
+    // sendgrid alert fires; bundle.social stale alert is suppressed.
+    expect(vi.mocked(notifyHealthAlert)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(notifyHealthAlert)).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "evt-sendgrid-new", service_name: "sendgrid" }),
+    );
+    expect(vi.mocked(notifyHealthAlert)).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: "evt-bundle-stale" }),
+    );
+    expect(body.data.notified).toBe(1);
+    expect(body.data.stale_suppressed).toBe(1);
+  });
+});


### PR DESCRIPTION
## Root cause (confirmed in prod)

A 2-minute bundle.social network blip on 2026-06-03 09:00–09:02 AEST (3 failures, `occurrence_count=3`, `last_seen_at` frozen at 09:02:48) generated ~49 identical critical email alerts over 24 h. Production query on 2026-06-04 confirmed: 1 unresolved row, `last_seen_at` was 25 h stale.

The old health-check cron query:
```sql
notified_at IS NULL OR notified_at < NOW() - 30min
```
re-notified the event every 30 min regardless of whether **any new failures had occurred** since the last notification. A stale frozen event re-alerts forever until manually resolved.

## Fix 1 — core correctness (`app/api/internal/cron/health-check/route.ts`)

Add `last_seen_at > notified_at` gate on re-notifications (TypeScript filter, since PostgREST does not support column-to-column comparisons):

```typescript
// OLD — re-notifies every 30 min regardless of new failures
.or(`notified_at.is.null,notified_at.lt.${cooldownCutoff}`)

// NEW — fetch candidates by time, then filter:
const events = candidates.filter(
  (e) => e.notified_at === null || e.last_seen_at > e.notified_at
);
// notified_at IS NULL → first alert, always fires
// last_seen_at > notified_at → new failures since last notification → re-alert
// last_seen_at ≤ notified_at → stale, suppressed
```

Response body gains `candidates` / `stale_suppressed` / `checked` for observability.

## Fix 2 — cooldown (`app/api/internal/cron/health-check/route.ts`)

Increase re-notification cooldown from 30 min → **4 h**. With Fix 1, the cooldown only matters for active incidents (new failures every minute). Hourly re-pages add no value once on-call is notified; 4 h is a reasonable escalation cadence for a persistent failure.

## Fix 3 — stale event auto-clear (`app/api/cron/social-connections-health/route.ts`)

After a successful daily sync (`companies_synced > 0`), call `recordRecovery("bundle.social")` (fire-and-forget). The successful sync proves bundle.social is reachable from Vercel. Without this, stale events can only be cleared when `publishPost` or `fetchAnalytics` succeeds — which never happens if there are no scheduled posts.

## Regression tests (5 passing)

| Test | Assertion |
|---|---|
| 1. New failure (notified_at IS NULL) | `notifyHealthAlert` called once immediately |
| 2. Stale event (last_seen_at == notified_at) | suppressed, `stale_suppressed=1` |
| 3. Active event (last_seen_at > notified_at, 4h elapsed) | re-alert fires |
| 4. Active event within cooldown | query-gate suppresses (mock returns []) |
| **5. New failure on a different service (sendgrid) + stale bundle.social** | **sendgrid fires immediately; bundle.social suppressed — dedup never silences a new alert on any service** |

Test 5 is the key regression proof: the dedup must never suppress a genuinely new alert regardless of which service it's on.

## Pre-PR checklist

- [x] Lint, typecheck, build green
- [x] test:unit: 5 regression tests pass, no SKIP_PRECOMMIT_TESTS
- [x] Explicit file paths only (3 files)
- [x] 0 HIGH static audit findings
- [x] No schema changes

**Do NOT merge — human review required.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)