### PR TITLE
feat(feedback): backlog 2 — don't show again on intro modal

### DIFF
--- a/app/(platform)/layout.tsx
+++ b/app/(platform)/layout.tsx
@@ -87,6 +87,21 @@ export default async function PlatformLayout({
       ? platformSession.company.companyId
       : null;
 
+  // Read the per-user "skip intro" preference from platform_users.preferences.
+  // Only fetched when the widget will actually be mounted (avoids an extra DB
+  // call for every authenticated page render when the feature is off).
+  let skipFeedbackIntro = false;
+  if (feedbackCompanyId && platformSession?.userId) {
+    const svc = getServiceRoleClient();
+    const { data: prefRow } = await svc
+      .from("platform_users")
+      .select("preferences")
+      .eq("id", platformSession.userId)
+      .maybeSingle();
+    const prefs = prefRow?.preferences as Record<string, unknown> | null;
+    skipFeedbackIntro = prefs?.feedback_skip_intro === true;
+  }
+
   return (
     <NavShell navContext={navContext}>
       {themeStyleBlock && (
@@ -97,7 +112,12 @@ export default async function PlatformLayout({
       <BreadcrumbProvider />
       {children}
       <Toaster />
-      {feedbackCompanyId && <FeedbackWidget companyId={feedbackCompanyId} />}
+      {feedbackCompanyId && (
+        <FeedbackWidget
+          companyId={feedbackCompanyId}
+          skipIntro={skipFeedbackIntro}
+        />
+      )}
     </NavShell>
   );
 }

--- a/app/api/feedback/preferences/route.ts
+++ b/app/api/feedback/preferences/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { createRouteAuthClient } from "@/lib/auth";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { readJsonBody, validationError, internalError } from "@/lib/http";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// POST /api/feedback/preferences
+//
+// Merges a preference key into platform_users.preferences JSONB for the
+// authenticated user.  Currently supports { skip_intro: boolean } only.
+//
+// Auth: authenticated session required.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  skip_intro: z.boolean(),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResp?.user) {
+    return NextResponse.json({ ok: false, error: { code: "UNAUTHORIZED" } }, { status: 401 });
+  }
+  const userId = userResp.user.id;
+
+  const body = await readJsonBody(req);
+  const parsed = BodySchema.safeParse(body ?? {});
+  if (!parsed.success) {
+    return validationError("Body must be { skip_intro: boolean }.", { issues: parsed.error.issues });
+  }
+
+  const svc = getServiceRoleClient();
+
+  // Read current preferences, merge key, write back.
+  const { data: current, error: readErr } = await svc
+    .from("platform_users")
+    .select("preferences")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (readErr) {
+    logger.error("feedback.preferences.read_failed", { userId, err: readErr.message });
+    return internalError(readErr.message);
+  }
+
+  const merged = {
+    ...(current?.preferences as Record<string, unknown> ?? {}),
+    feedback_skip_intro: parsed.data.skip_intro,
+  };
+
+  const { error: writeErr } = await svc
+    .from("platform_users")
+    .update({ preferences: merged })
+    .eq("id", userId);
+
+  if (writeErr) {
+    logger.error("feedback.preferences.write_failed", { userId, err: writeErr.message });
+    return internalError(writeErr.message);
+  }
+
+  logger.info("feedback.preferences.updated", { userId, skip_intro: parsed.data.skip_intro });
+  return NextResponse.json({ ok: true, timestamp: new Date().toISOString() }, { status: 200 });
+}

--- a/components/feedback/FeedbackWidget.tsx
+++ b/components/feedback/FeedbackWidget.tsx
@@ -37,14 +37,18 @@ type Mode = "collapsed" | "intro" | "picking" | "creating" | "submitted";
 
 type Props = {
   companyId: string;
+  /** Server-resolved from platform_users.preferences.feedback_skip_intro.
+   *  When true, tab click bypasses the intro modal and goes straight to picker. */
+  skipIntro?: boolean;
 };
 
 const MAX_CONSOLE_ERRORS = 50;
 
 type ConsoleLine = { level: "error" | "warn"; msg: string; at: string };
 
-export function FeedbackWidget({ companyId }: Props) {
+export function FeedbackWidget({ companyId, skipIntro = false }: Props) {
   const [mode, setMode] = useState<Mode>("collapsed");
+  const [dontShowAgain, setDontShowAgain] = useState(false);
   const [pick, setPick] = useState<PickResult | null>(null);
   const [screenshotDataUrl, setScreenshotDataUrl] = useState<string | null>(null);
   const [pageUrl, setPageUrl] = useState("");
@@ -120,9 +124,21 @@ export function FeedbackWidget({ companyId }: Props) {
     setTimeout(() => setMode("collapsed"), 2000);
   }, []);
 
+  // Save the "don't show again" preference then start picking.
+  const handleStartPicking = useCallback(async () => {
+    if (dontShowAgain) {
+      // Fire-and-forget — don't block the user interaction.
+      void fetch("/api/feedback/preferences", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ skip_intro: true }),
+      }).catch(() => {});
+    }
+    startPicking();
+  }, [dontShowAgain, startPicking]);
+
   if (mode === "intro") {
     return (
-      // Dialog open state is controlled by mode — Esc handled by Radix.
       <Dialog
         open
         onOpenChange={(open) => {
@@ -131,9 +147,7 @@ export function FeedbackWidget({ companyId }: Props) {
       >
         <DialogContent
           data-testid="feedback-intro-modal"
-          // Override default z-50 to sit above all app chrome (DebugFooter z-50).
           className="z-[10200] max-w-md"
-          // Esc key is handled by Radix (calls onOpenChange(false) → collapsed).
         >
           <DialogHeader>
             <DialogTitle className="text-lg font-semibold">
@@ -145,9 +159,21 @@ export function FeedbackWidget({ companyId }: Props) {
             </DialogDescription>
           </DialogHeader>
 
+          {/* "Don't show again" checkbox */}
+          <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-500">
+            <input
+              type="checkbox"
+              checked={dontShowAgain}
+              onChange={(e) => setDontShowAgain(e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 accent-emerald-600"
+              data-testid="feedback-intro-skip-checkbox"
+            />
+            Don&apos;t show this again
+          </label>
+
           <DialogFooter className="mt-2 flex gap-2 sm:flex-row-reverse">
             <Button
-              onClick={startPicking}
+              onClick={handleStartPicking}
               className="min-h-[44px] bg-emerald-600 text-white hover:bg-emerald-700"
             >
               Start picking
@@ -196,11 +222,12 @@ export function FeedbackWidget({ companyId }: Props) {
     );
   }
 
-  // Collapsed pill — tab click opens intro modal.
+  // Collapsed pill — tab click opens intro modal UNLESS the user has set
+  // "don't show again", in which case we go straight to picker.
   return (
     <button
       data-testid="feedback-tab"
-      onClick={() => setMode("intro")}
+      onClick={() => skipIntro ? startPicking() : setMode("intro")}
       className="fixed left-20 bottom-4 z-[9997] flex min-h-[44px] items-center gap-2 rounded-full bg-emerald-600 px-5 py-2 text-sm font-semibold text-white shadow-lg transition-all hover:bg-emerald-700 hover:shadow-xl active:scale-[0.98]"
       title="Report an issue"
       aria-label="Open issue reporter"

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -511,14 +511,17 @@ function check4_migrationOrdering(): Issue[] {
   const createRe =
     /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:public\.)?["']?([a-zA-Z_][a-zA-Z0-9_]*)["']?/gi;
   const refRe =
-    /REFERENCES\s+(?:public\.)?["']?([a-zA-Z_][a-zA-Z0-9_]*)["']?/gi;
+    /\bREFERENCES\s+(?:public\.)?["']?([a-zA-Z_][a-zA-Z0-9_]*)["']?/gi;
 
   // Reserved SQL keywords / common prose words that follow "REFERENCES"
   // in comment text. Filtering by lowercase to catch any case mix.
+  // Also includes SQL type keywords that appear after column names containing
+  // "references" as a substring (e.g. "preferences JSONB" → false positive).
   const PROSE_TOKENS = new Set([
     "the", "this", "that", "these", "those", "it", "its",
     "resolve", "resolves", "table", "row", "column", "user",
     "users", "to", "above", "below", "earlier", "later",
+    "jsonb", "is", "not", "null", "default",
   ]);
 
   for (const f of files) {

--- a/supabase/migrations/0183_platform_user_preferences.sql
+++ b/supabase/migrations/0183_platform_user_preferences.sql
@@ -1,0 +1,13 @@
+-- 0183_platform_user_preferences.sql
+-- Additive: adds preferences JSONB column to platform_users.
+-- Stores per-user UI preferences such as feedback widget intro skip.
+-- Mirrors the existing settings JSONB column on platform_companies.
+--
+-- Schema: { "feedback_skip_intro": true, ... }
+-- Written by the platform-owned /api/feedback/preferences endpoint.
+
+ALTER TABLE platform_users
+  ADD COLUMN IF NOT EXISTS preferences JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN platform_users.preferences IS
+  'Per-user UI preferences. Keys: feedback_skip_intro (bool).';

--- a/tests/regressions/feedback-intro-skip.test.ts
+++ b/tests/regressions/feedback-intro-skip.test.ts
@@ -1,0 +1,139 @@
+// tests/regressions/feedback-intro-skip.test.ts
+//
+// Backlog item 2: "don't show again" on the intro modal.
+// Verifies the preference API route and the skip-intro flow.
+//
+// Layer 1 — unit tests; all I/O mocked.
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Preferences API route tests
+// ---------------------------------------------------------------------------
+describe("POST /api/feedback/preferences — skip_intro preference", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  async function callRoute(body: object, userId: string | null = "user-1") {
+    const { createRouteAuthClient } = await import("@/lib/auth");
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+
+    vi.mocked(createRouteAuthClient).mockReturnValue({
+      auth: {
+        getUser: vi.fn(async () =>
+          userId
+            ? { data: { user: { id: userId } }, error: null }
+            : { data: { user: null }, error: { message: "no user" } },
+        ),
+      },
+    } as never);
+
+    const updateFn = vi.fn(() => ({ eq: vi.fn(() => ({ error: null })) }));
+    vi.mocked(getServiceRoleClient).mockReturnValue({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({
+              data: { preferences: { other_key: true } },
+              error: null,
+            }),
+          }),
+        }),
+        update: updateFn,
+      }),
+    } as never);
+
+    vi.resetModules();
+    const { POST } = await import("@/app/api/feedback/preferences/route");
+    const req = new Request("http://localhost/api/feedback/preferences", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const res = await POST(req as never);
+    return { res, updateFn };
+  }
+
+  it("returns 401 when unauthenticated", async () => {
+    const { res } = await callRoute({ skip_intro: true }, null);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on invalid body (not boolean)", async () => {
+    const { res } = await callRoute({ skip_intro: "yes" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when skip_intro is missing", async () => {
+    const { res } = await callRoute({});
+    expect(res.status).toBe(400);
+  });
+
+  it("merges skip_intro=true into existing preferences without losing other keys", async () => {
+    const { res, updateFn } = await callRoute({ skip_intro: true });
+    expect(res.status).toBe(200);
+    // The update call must preserve { other_key: true } and add feedback_skip_intro.
+    expect(updateFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preferences: expect.objectContaining({
+          other_key: true,
+          feedback_skip_intro: true,
+        }),
+      }),
+    );
+  });
+
+  it("can save skip_intro=false to re-enable the intro modal", async () => {
+    const { res, updateFn } = await callRoute({ skip_intro: false });
+    expect(res.status).toBe(200);
+    expect(updateFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preferences: expect.objectContaining({ feedback_skip_intro: false }),
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Widget skip-intro logic (pure logic test — no React rendering)
+// ---------------------------------------------------------------------------
+describe("FeedbackWidget skipIntro prop — mode transition", () => {
+  it("skipIntro=true causes tab click to go to picking, not intro", () => {
+    // Test the logic directly: when skipIntro is true, onClick calls startPicking.
+    let calledMode: string | null = null;
+    const setMode = (m: string) => { calledMode = m; };
+    const startPicking = () => { calledMode = "picking"; };
+
+    // Simulate the onClick handler
+    const skipIntro = true;
+    const onClick = () => skipIntro ? startPicking() : setMode("intro");
+    onClick();
+
+    expect(calledMode).toBe("picking");
+  });
+
+  it("skipIntro=false causes tab click to open intro modal", () => {
+    let calledMode: string | null = null;
+    const setMode = (m: string) => { calledMode = m; };
+    const startPicking = () => { calledMode = "picking"; };
+
+    const skipIntro = false;
+    const onClick = () => skipIntro ? startPicking() : setMode("intro");
+    onClick();
+
+    expect(calledMode).toBe("intro");
+  });
+});


### PR DESCRIPTION
Per-user preference to bypass the "Show us where it's not working" intro modal.

**Migration 0183:** `preferences JSONB NOT NULL DEFAULT '{}'` added to `platform_users`.

**Flow:**
1. Intro modal shows a "Don't show this again" checkbox.
2. When checked + "Start picking" → preference saved via `POST /api/feedback/preferences` (fire-and-forget), picker opens immediately.
3. On next page load the layout reads `platform_users.preferences.feedback_skip_intro`; if `true`, tab click bypasses the modal and goes straight to picker.

**Tests:** 7 unit tests — API auth/validation/merge, logic that skipIntro=true routes to picker and skipIntro=false shows modal. No SKIP_PRECOMMIT_TESTS.

Do NOT merge.
🤖 Generated with [Claude Code](https://claude.com/claude-code)