### PR TITLE
feat(feedback): backlog 3 — customer-facing staff names in timeline + thread

### DIFF
--- a/app/(platform)/feedback/[id]/FeedbackDetailClient.tsx
+++ b/app/(platform)/feedback/[id]/FeedbackDetailClient.tsx
@@ -28,17 +28,23 @@ const STATUS_LABELS: Record<TicketStatus, string> = {
   closed: "Closed",
 };
 
-function eventLabel(e: FeedbackTicketEvent): string {
+function eventLabel(
+  e: FeedbackTicketEvent,
+  actorNames: Record<string, string>,
+): string {
+  // Resolve the actor's display name; fall back to "Opollo" for known staff
+  // events where actor_id is null (system/automation) or unknown.
+  const actor = e.actor_id ? (actorNames[e.actor_id] ?? "Opollo") : "Opollo";
   switch (e.event_type) {
     case "created": return "Reported";
-    case "assigned": return "Assigned to support team";
-    case "reassigned": return "Reassigned";
+    case "assigned": return `Assigned to ${actor}`;
+    case "reassigned": return `Reassigned to ${actor}`;
     case "status_changed": return `Status updated: ${e.from_value} → ${e.to_value}`;
     case "severity_changed": return `Severity updated: ${e.from_value} → ${e.to_value}`;
-    case "priority_changed": return "Priority updated";
+    case "priority_changed": return `Priority updated by ${actor}`;
     case "reopened_by_customer": return "You reported this is still broken";
-    case "verified": return "Marked as resolved by the team";
-    case "closed": return "Ticket closed";
+    case "verified": return `Marked as resolved by ${actor}`;
+    case "closed": return `Closed by ${actor}`;
     default: return e.event_type;
   }
 }
@@ -55,9 +61,11 @@ type Props = {
   comments: FeedbackTicketComment[];
   events: FeedbackTicketEvent[];
   screenshotUrl: string | null;
+  /** actor_id → display name for event timeline + staff comment authors. */
+  actorNames?: Record<string, string>;
 };
 
-export function FeedbackDetailClient({ ticket: initial, comments, events, screenshotUrl }: Props) {
+export function FeedbackDetailClient({ ticket: initial, comments, events, screenshotUrl, actorNames = {} }: Props) {
   const [ticket, setTicket] = useState(initial);
   const [stillBrokenPending, setStillBrokenPending] = useState(false);
   const [stillBrokenError, setStillBrokenError] = useState<string | null>(null);
@@ -138,7 +146,11 @@ export function FeedbackDetailClient({ ticket: initial, comments, events, screen
       {/* Thread */}
       <div className="mb-6">
         <h2 className="mb-3 text-sm font-semibold text-gray-700">Messages</h2>
-        <TicketThread ticketId={ticket.id} comments={comments} />
+        <TicketThread
+          ticketId={ticket.id}
+          comments={comments}
+          authorNames={actorNames}
+        />
       </div>
 
       {/* Event timeline (read-only for customers) */}
@@ -147,7 +159,7 @@ export function FeedbackDetailClient({ ticket: initial, comments, events, screen
         <ol data-testid="ticket-event-timeline" className="border-l-2 border-gray-200 pl-4">
           {events.map((e) => (
             <li key={e.id} className="mb-3 last:mb-0">
-              <div className="text-xs font-medium text-gray-700">{eventLabel(e)}</div>
+              <div className="text-xs font-medium text-gray-700">{eventLabel(e, actorNames)}</div>
               <div className="text-xs text-gray-400">{formatDate(e.created_at)}</div>
             </li>
           ))}

--- a/app/(platform)/feedback/[id]/page.tsx
+++ b/app/(platform)/feedback/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { getCurrentPlatformSession } from "@/lib/platform/auth";
 import { isCompanyMember } from "@/lib/platform/auth";
 import { createRouteAuthClient } from "@/lib/auth";
-import { getTicket, listComments, listEvents } from "@/lib/feedback/tickets/queries";
+import { getTicket, listComments, listEvents, resolveActorNames } from "@/lib/feedback/tickets/queries";
 import { resolveSignedUrl } from "@/lib/feedback/capture/screenshot";
 import { FeedbackDetailClient } from "./FeedbackDetailClient";
 
@@ -41,6 +41,14 @@ export default async function FeedbackDetailPage({
   const isStaff = session.isOpolloStaff;
   if (!isMember && !isStaff) notFound();
 
+  // Resolve actor display names for the event timeline and comment thread.
+  // Collect all user IDs: event actors + staff comment authors.
+  const actorIds = [
+    ...events.map((e) => e.actor_id),
+    ...comments.filter((c) => c.is_staff).map((c) => c.author_id),
+  ];
+  const actorNames = await resolveActorNames(actorIds);
+
   const screenshotUrl = ticket.screenshot_path
     ? await resolveSignedUrl(ticket.screenshot_path)
     : null;
@@ -51,6 +59,7 @@ export default async function FeedbackDetailPage({
       comments={comments}
       events={events}
       screenshotUrl={screenshotUrl}
+      actorNames={Object.fromEntries(actorNames)}
     />
   );
 }

--- a/components/feedback/TicketThread.tsx
+++ b/components/feedback/TicketThread.tsx
@@ -10,6 +10,8 @@ type Props = {
   ticketId: string;
   comments: FeedbackTicketComment[];
   onCommentPosted?: (comment: FeedbackTicketComment) => void;
+  /** author_id → display name for staff comments. Falls back to "Opollo". */
+  authorNames?: Record<string, string>;
 };
 
 // ---------------------------------------------------------------------------
@@ -32,7 +34,7 @@ function formatDate(iso: string): string {
   });
 }
 
-export function TicketThread({ ticketId, comments: initial, onCommentPosted }: Props) {
+export function TicketThread({ ticketId, comments: initial, onCommentPosted, authorNames = {} }: Props) {
   const [comments, setComments] = useState(initial);
   const [reply, setReply] = useState("");
   const [posting, setPosting] = useState(false);
@@ -93,7 +95,7 @@ export function TicketThread({ ticketId, comments: initial, onCommentPosted }: P
                   c.is_staff ? "text-emerald-100" : "text-gray-400"
                 }`}
               >
-                {c.is_staff ? "Opollo" : "Reporter"} · {formatDate(c.created_at)}
+                {c.is_staff ? (authorNames[c.author_id] ?? "Opollo") : "Reporter"} · {formatDate(c.created_at)}
               </p>
             </div>
           </div>

--- a/tests/regressions/feedback-customer-names.test.ts
+++ b/tests/regressions/feedback-customer-names.test.ts
@@ -1,0 +1,122 @@
+// tests/regressions/feedback-customer-names.test.ts
+//
+// Backlog item 3: customer-facing timeline + thread shows real staff names.
+// Verifies the eventLabel resolution and TicketThread author name logic.
+//
+// Layer 1 — pure TypeScript logic tests; no DB or render required.
+
+import { describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// eventLabel resolution helpers (mirrors FeedbackDetailClient logic)
+// ---------------------------------------------------------------------------
+
+type EventType =
+  | "created" | "assigned" | "reassigned" | "status_changed"
+  | "severity_changed" | "priority_changed" | "reopened_by_customer"
+  | "verified" | "closed";
+
+function eventLabel(
+  e: { event_type: EventType; actor_id: string | null; from_value?: string | null; to_value?: string | null },
+  actorNames: Record<string, string>,
+): string {
+  const actor = e.actor_id ? (actorNames[e.actor_id] ?? "Opollo") : "Opollo";
+  switch (e.event_type) {
+    case "created": return "Reported";
+    case "assigned": return `Assigned to ${actor}`;
+    case "reassigned": return `Reassigned to ${actor}`;
+    case "status_changed": return `Status updated: ${e.from_value} → ${e.to_value}`;
+    case "severity_changed": return `Severity updated: ${e.from_value} → ${e.to_value}`;
+    case "priority_changed": return `Priority updated by ${actor}`;
+    case "reopened_by_customer": return "You reported this is still broken";
+    case "verified": return `Marked as resolved by ${actor}`;
+    case "closed": return `Closed by ${actor}`;
+    default: return e.event_type;
+  }
+}
+
+function threadAuthorLabel(
+  isStaff: boolean,
+  authorId: string,
+  authorNames: Record<string, string>,
+): string {
+  if (!isStaff) return "Reporter";
+  return authorNames[authorId] ?? "Opollo";
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const ACTOR_NAMES: Record<string, string> = {
+  "staff-1": "Steven Morey",
+  "staff-2": "Jane Smith",
+};
+
+describe("eventLabel — resolves actor_id to display name", () => {
+  it("created → always 'Reported' (no actor)", () => {
+    expect(eventLabel({ event_type: "created", actor_id: null }, ACTOR_NAMES)).toBe("Reported");
+  });
+
+  it("assigned → shows resolved staff name", () => {
+    expect(eventLabel({ event_type: "assigned", actor_id: "staff-1" }, ACTOR_NAMES))
+      .toBe("Assigned to Steven Morey");
+  });
+
+  it("assigned → falls back to 'Opollo' when actor_id unknown", () => {
+    expect(eventLabel({ event_type: "assigned", actor_id: "unknown-id" }, ACTOR_NAMES))
+      .toBe("Assigned to Opollo");
+  });
+
+  it("assigned → falls back to 'Opollo' when actor_id is null", () => {
+    expect(eventLabel({ event_type: "assigned", actor_id: null }, ACTOR_NAMES))
+      .toBe("Assigned to Opollo");
+  });
+
+  it("verified → shows name", () => {
+    expect(eventLabel({ event_type: "verified", actor_id: "staff-2" }, ACTOR_NAMES))
+      .toBe("Marked as resolved by Jane Smith");
+  });
+
+  it("closed → shows name", () => {
+    expect(eventLabel({ event_type: "closed", actor_id: "staff-1" }, ACTOR_NAMES))
+      .toBe("Closed by Steven Morey");
+  });
+
+  it("reopened_by_customer → always the same string (no actor needed)", () => {
+    expect(eventLabel({ event_type: "reopened_by_customer", actor_id: "user-1" }, ACTOR_NAMES))
+      .toBe("You reported this is still broken");
+  });
+
+  it("status_changed → shows from/to values, not actor name", () => {
+    expect(eventLabel({
+      event_type: "status_changed",
+      actor_id: "staff-1",
+      from_value: "backlog",
+      to_value: "in_progress",
+    }, ACTOR_NAMES)).toBe("Status updated: backlog → in_progress");
+  });
+
+  it("empty actorNames map → all staff labels fall back to 'Opollo'", () => {
+    expect(eventLabel({ event_type: "assigned", actor_id: "staff-1" }, {}))
+      .toBe("Assigned to Opollo");
+  });
+});
+
+describe("threadAuthorLabel — TicketThread author display", () => {
+  it("non-staff comment always shows 'Reporter'", () => {
+    expect(threadAuthorLabel(false, "user-1", ACTOR_NAMES)).toBe("Reporter");
+  });
+
+  it("staff comment shows resolved name when available", () => {
+    expect(threadAuthorLabel(true, "staff-1", ACTOR_NAMES)).toBe("Steven Morey");
+  });
+
+  it("staff comment falls back to 'Opollo' when name not in map", () => {
+    expect(threadAuthorLabel(true, "unknown", ACTOR_NAMES)).toBe("Opollo");
+  });
+
+  it("staff comment falls back to 'Opollo' with empty map", () => {
+    expect(threadAuthorLabel(true, "staff-1", {})).toBe("Opollo");
+  });
+});


### PR DESCRIPTION
Resolves staff `actor_id` to real display names on the customer `/feedback/[id]` page, matching what the admin detail already does.

**Before:** Event timeline showed "Assigned to support team"; thread showed "Opollo".  
**After:** Event timeline shows "Assigned to Steven Morey"; thread shows the actual staff member's name. Falls back to "Opollo" when the actor is null/unknown.

**Data flow:** Server component batches all actor_ids (events + staff comment authors) into one `resolveActorNames()` call, passes the map down as a plain object prop.

**Tests:** 13 unit tests — eventLabel resolution, null/unknown fallback, empty map, threadAuthorLabel for staff/reporter. No SKIP_PRECOMMIT_TESTS.

Do NOT merge.
🤖 Generated with [Claude Code](https://claude.com/claude-code)