### PR TITLE
feat(feedback): backlog 4 — company name on admin board

### DIFF
--- a/app/(platform)/admin/feedback/[id]/page.tsx
+++ b/app/(platform)/admin/feedback/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   listEvents,
   listOpolloStaff,
   resolveActorNames,
+  resolveCompanyNames,
 } from "@/lib/feedback/tickets/queries";
 import { resolveSignedUrl } from "@/lib/feedback/capture/screenshot";
 import { BugReplayOverlay } from "@/components/feedback/BugReplayOverlay";
@@ -95,7 +96,11 @@ export default async function AdminTicketDetailPage({
   if (!ticket) notFound();
 
   const actorIds = events.map((e) => e.actor_id);
-  const actorNames = await resolveActorNames(actorIds);
+  const [actorNames, companyNamesMap] = await Promise.all([
+    resolveActorNames(actorIds),
+    resolveCompanyNames([ticket.company_id]),
+  ]);
+  const companyName = companyNamesMap.get(ticket.company_id) ?? null;
 
   const screenshotUrl = ticket.screenshot_path
     ? await resolveSignedUrl(ticket.screenshot_path)
@@ -127,6 +132,9 @@ export default async function AdminTicketDetailPage({
               </span>
             </h1>
             <p className="mt-1 text-sm text-gray-500">
+              {companyName && (
+                <span className="font-medium text-gray-700 mr-1">{companyName} ·</span>
+              )}
               {formatDate(ticket.created_at)}
             </p>
           </div>

--- a/app/(platform)/admin/feedback/page.tsx
+++ b/app/(platform)/admin/feedback/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { isOpolloStaff } from "@/lib/platform/auth";
 import { createRouteAuthClient } from "@/lib/auth";
-import { listTickets } from "@/lib/feedback/tickets/queries";
+import { listTickets, resolveCompanyNames } from "@/lib/feedback/tickets/queries";
 import { resolveSignedUrl } from "@/lib/feedback/capture/screenshot";
 import type { TicketPriority, TicketSeverity, TicketStatus } from "@/lib/feedback/types";
 
@@ -75,14 +75,17 @@ export default async function AdminFeedbackPage() {
       (PRIORITY_ORDER[a.priority as TicketPriority] ?? 0),
   );
 
-  // §6 — Resolve screenshot signed URLs for thumbnails (server-side, parallel).
-  const screenshotUrls = await Promise.all(
-    sorted.map((t) =>
-      t.screenshot_path
-        ? resolveSignedUrl(t.screenshot_path).catch(() => null)
-        : Promise.resolve(null),
+  // Resolve company names and screenshot URLs in parallel.
+  const [screenshotUrls, companyNamesMap] = await Promise.all([
+    Promise.all(
+      sorted.map((t) =>
+        t.screenshot_path
+          ? resolveSignedUrl(t.screenshot_path).catch(() => null)
+          : Promise.resolve(null),
+      ),
     ),
-  );
+    resolveCompanyNames(sorted.map((t) => t.company_id)),
+  ]);
 
   return (
     <div data-testid="admin-feedback-board" className="p-6">
@@ -155,7 +158,6 @@ export default async function AdminFeedbackPage() {
                       href={`/admin/feedback/${t.id}`}
                       className="block font-medium text-gray-900 group-hover:text-emerald-700"
                     >
-                      {/* §3: show #n + first line of description as the label */}
                       {(t as Record<string, unknown>).ticket_number
                         ? `#${(t as Record<string, unknown>).ticket_number}`
                         : `#${t.id.slice(0, 8)}`}
@@ -165,6 +167,11 @@ export default async function AdminFeedbackPage() {
                       </span>
                     </Link>
                     <p className="text-xs text-gray-400">
+                      {/* Show company name for external companies; nothing for Opollo-internal. */}
+                      {companyNamesMap.get(t.company_id)
+                        ? <span className="font-medium text-gray-500">{companyNamesMap.get(t.company_id)}</span>
+                        : null}
+                      {companyNamesMap.get(t.company_id) ? " · " : ""}
                       {new Date(t.created_at).toLocaleDateString("en-AU", { day: "numeric", month: "short" })}
                     </p>
                   </td>

--- a/lib/feedback/tickets/queries.ts
+++ b/lib/feedback/tickets/queries.ts
@@ -76,6 +76,29 @@ export async function listComments(ticketId: string): Promise<FeedbackTicketComm
   return (data ?? []) as FeedbackTicketComment[];
 }
 
+// The Opollo-internal company sentinel UUID (migration 0070).
+// Tickets from this company are filed by Opollo staff; no company label needed.
+const OPOLLO_INTERNAL_COMPANY_ID = "00000000-0000-0000-0000-000000000001";
+
+// Resolve company_ids to display names for the admin board.
+// Returns an empty string for the Opollo-internal sentinel (label not needed).
+export async function resolveCompanyNames(
+  companyIds: string[],
+): Promise<Map<string, string>> {
+  const unique = [...new Set(companyIds.filter((id) => id !== OPOLLO_INTERNAL_COMPANY_ID))];
+  if (unique.length === 0) return new Map();
+  const svc = getServiceRoleClient();
+  const { data } = await svc
+    .from("platform_companies")
+    .select("id, name")
+    .in("id", unique);
+  const map = new Map<string, string>();
+  for (const row of data ?? []) {
+    map.set(row.id as string, row.name as string);
+  }
+  return map;
+}
+
 // All Opollo staff — used to populate the assignee picker on ticket detail.
 export async function listOpolloStaff(): Promise<
   Array<{ id: string; fullName: string | null; email: string }>

--- a/tests/regressions/feedback-company-names.test.ts
+++ b/tests/regressions/feedback-company-names.test.ts
@@ -1,0 +1,86 @@
+// tests/regressions/feedback-company-names.test.ts
+//
+// Backlog item 4: company name on the admin board.
+// Verifies resolveCompanyNames skips the Opollo-internal sentinel and
+// correctly maps external company IDs to names.
+//
+// Layer 1 — unit tests; DB mocked.
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+const OPOLLO_SENTINEL = "00000000-0000-0000-0000-000000000001";
+const EXTERNAL_A = "aaaaaaaa-0000-0000-0000-000000000001";
+const EXTERNAL_B = "bbbbbbbb-0000-0000-0000-000000000001";
+
+async function callResolveCompanyNames(companyIds: string[]) {
+  const { getServiceRoleClient } = await import("@/lib/supabase");
+  const inFn = vi.fn(() => ({
+    data: [
+      { id: EXTERNAL_A, name: "Acme Corp" },
+      { id: EXTERNAL_B, name: "Beta Ltd" },
+    ],
+    error: null,
+  }));
+  vi.mocked(getServiceRoleClient).mockReturnValue({
+    from: () => ({ select: () => ({ in: inFn }) }),
+  } as never);
+
+  vi.resetModules();
+  const { resolveCompanyNames } = await import("@/lib/feedback/tickets/queries");
+  const result = await resolveCompanyNames(companyIds);
+  return { result, inFn };
+}
+
+describe("resolveCompanyNames", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns empty map when all IDs are the Opollo sentinel", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue({} as never);
+    vi.resetModules();
+    const { resolveCompanyNames } = await import("@/lib/feedback/tickets/queries");
+    const result = await resolveCompanyNames([OPOLLO_SENTINEL, OPOLLO_SENTINEL]);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty map for empty input", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue({} as never);
+    vi.resetModules();
+    const { resolveCompanyNames } = await import("@/lib/feedback/tickets/queries");
+    const result = await resolveCompanyNames([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("resolves external company IDs to names", async () => {
+    const { result } = await callResolveCompanyNames([EXTERNAL_A, EXTERNAL_B]);
+    expect(result.get(EXTERNAL_A)).toBe("Acme Corp");
+    expect(result.get(EXTERNAL_B)).toBe("Beta Ltd");
+  });
+
+  it("filters out the Opollo sentinel before querying the DB", async () => {
+    const { result, inFn } = await callResolveCompanyNames([OPOLLO_SENTINEL, EXTERNAL_A]);
+    // Sentinel must not appear in the DB query
+    const queriedIds = inFn.mock.calls[0]?.[1] as string[] ?? [];
+    expect(queriedIds).not.toContain(OPOLLO_SENTINEL);
+    expect(queriedIds).toContain(EXTERNAL_A);
+    // Sentinel not in result
+    expect(result.has(OPOLLO_SENTINEL)).toBe(false);
+    expect(result.get(EXTERNAL_A)).toBe("Acme Corp");
+  });
+
+  it("deduplicates repeated IDs before querying", async () => {
+    const { inFn } = await callResolveCompanyNames([EXTERNAL_A, EXTERNAL_A, EXTERNAL_A]);
+    const queriedIds = inFn.mock.calls[0]?.[1] as string[] ?? [];
+    // Should only appear once
+    expect(queriedIds.filter((id) => id === EXTERNAL_A)).toHaveLength(1);
+  });
+});

--- a/tests/regressions/feedback-company-names.test.ts
+++ b/tests/regressions/feedback-company-names.test.ts
@@ -69,7 +69,7 @@ describe("resolveCompanyNames", () => {
   it("filters out the Opollo sentinel before querying the DB", async () => {
     const { result, inFn } = await callResolveCompanyNames([OPOLLO_SENTINEL, EXTERNAL_A]);
     // Sentinel must not appear in the DB query
-    const queriedIds = inFn.mock.calls[0]?.[1] as string[] ?? [];
+    const queriedIds = ((inFn.mock.calls[0] as unknown[])?.[1] ?? []) as string[];
     expect(queriedIds).not.toContain(OPOLLO_SENTINEL);
     expect(queriedIds).toContain(EXTERNAL_A);
     // Sentinel not in result
@@ -79,7 +79,7 @@ describe("resolveCompanyNames", () => {
 
   it("deduplicates repeated IDs before querying", async () => {
     const { inFn } = await callResolveCompanyNames([EXTERNAL_A, EXTERNAL_A, EXTERNAL_A]);
-    const queriedIds = inFn.mock.calls[0]?.[1] as string[] ?? [];
+    const queriedIds = ((inFn.mock.calls[0] as unknown[])?.[1] ?? []) as string[];
     // Should only appear once
     expect(queriedIds.filter((id) => id === EXTERNAL_A)).toHaveLength(1);
   });


### PR DESCRIPTION
Resolves and shows the company name for tickets from external (non-Opollo) companies.

**Before:** Ticket row shows `#abc · 4 Jun` — no company label.  
**After:** Ticket row shows `Acme Corp · 4 Jun` for external companies; same `4 Jun` for Opollo-internal tickets (sentinel `00000000-…-0001` is skipped).

The sentinel filtering and dedup happen before the DB query, so no unnecessary round-trips. Company name also appears in the ticket detail header subtitle.

⚠️ **Untested against real external data** — only the Opollo-internal sentinel path has been exercised. Will be validated when a UAT company files a ticket, as noted in the spec.

**Tests:** 5 unit tests — sentinel skip, empty input, correct name mapping, sentinel filtered before query, deduplication. No SKIP_PRECOMMIT_TESTS. Governance guard tests still green (37/37).

Do NOT merge.
🤖 Generated with [Claude Code](https://claude.com/claude-code)