### PR TITLE
feat(feedback): mount FeedbackWidget for Opollo staff on /admin/* routes

### DIFF
--- a/app/(platform)/layout.tsx
+++ b/app/(platform)/layout.tsx
@@ -9,6 +9,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { BreadcrumbProvider } from "@/components/error-reporting/BreadcrumbProvider";
 import { getCompanyTheme, buildThemeStyleBlock } from "@/lib/platform/theming";
 import { FeedbackWidget } from "@/components/feedback/FeedbackWidget";
+import { resolveFeedbackCompanyId } from "@/lib/feedback/resolve-company-id";
 
 // ---------------------------------------------------------------------------
 // PlatformLayout — single shared authenticated layout that renders NavShell
@@ -79,13 +80,18 @@ export default async function PlatformLayout({
     companyName,
   };
 
-  // FeedbackWidget: mount once for authenticated company members when
-  // FEATURE_FEEDBACK_WIDGET is set. Never for logged-out users.
-  // Staff without a company assignment don't get the widget.
-  const feedbackCompanyId =
-    process.env.FEATURE_FEEDBACK_WIDGET === "1" && platformSession?.company?.companyId
-      ? platformSession.company.companyId
-      : null;
+  // FeedbackWidget: mount when FEATURE_FEEDBACK_WIDGET=1 for:
+  //   1. Company members on any route — their company scope.
+  //   2. Opollo staff on /admin/* — internal sentinel company so tickets land
+  //      on the staff board without a customer label. Enables staff to file
+  //      bugs found during staging-first verification of admin pages.
+  // Never for logged-out users. Feature flag gates both paths.
+  const feedbackCompanyId = resolveFeedbackCompanyId({
+    featureEnabled: process.env.FEATURE_FEEDBACK_WIDGET === "1",
+    companyId: platformSession?.company?.companyId,
+    isOpolloStaff,
+    pathname,
+  });
 
   // Read the per-user "skip intro" preference from platform_users.preferences.
   // Only fetched when the widget will actually be mounted (avoids an extra DB

--- a/components/__tests__/feedback-resolve-company-id.test.ts
+++ b/components/__tests__/feedback-resolve-company-id.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveFeedbackCompanyId,
+  OPOLLO_INTERNAL_COMPANY_ID,
+} from "@/lib/feedback/resolve-company-id";
+
+const CUSTOMER_COMPANY_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+
+describe("resolveFeedbackCompanyId", () => {
+  // ── Feature flag off ──────────────────────────────────────────────────────
+
+  it("returns null when feature flag is off regardless of session", () => {
+    expect(
+      resolveFeedbackCompanyId({
+        featureEnabled: false,
+        companyId: CUSTOMER_COMPANY_ID,
+        isOpolloStaff: false,
+        pathname: "/company/something",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when feature flag is off even for staff on /admin", () => {
+    expect(
+      resolveFeedbackCompanyId({
+        featureEnabled: false,
+        companyId: null,
+        isOpolloStaff: true,
+        pathname: "/admin/feedback",
+      }),
+    ).toBeNull();
+  });
+
+  // ── Company members ───────────────────────────────────────────────────────
+
+  it("returns companyId for a company member on any route", () => {
+    expect(
+      resolveFeedbackCompanyId({
+        featureEnabled: true,
+        companyId: CUSTOMER_COMPANY_ID,
+        isOpolloStaff: false,
+        pathname: "/company/something/social",
+      }),
+    ).toBe(CUSTOMER_COMPANY_ID);
+  });
+
+  // ── Opollo staff on /admin/* ──────────────────────────────────────────────
+
+  it("returns internal sentinel for staff on /admin/feedback", () => {
+    expect(
+      resolveFeedbackCompanyId({
+        featureEnabled: true,
+        companyId: null,
+        isOpolloStaff: true,
+        pathname: "/admin/feedback",
+      }),
+    ).toBe(OPOLLO_INTERNAL_COMPANY_ID);
+  });
+
+  it("returns internal sentinel for staff on any /admin/* sub-route", () => {
+    expect(
+      resolveFeedbackCompanyId({
+        featureEnabled: true,
+        companyId: null,
+        isOpolloStaff: true,
+        pathname: "/admin/companies/some-id/social-profiles",
+      }),
+    ).toBe(OPOLLO_INTERNAL_COMPANY_ID);
+  });
+
+  it("prefers explicit companyId over sentinel even for staff", () => {
+    // Staff visiting /company/* have a company context — use it, not the sentinel.
+    expect(
+      resolveFeedbackCompanyId({
+        featureEnabled: true,
+        companyId: CUSTOMER_COMPANY_ID,
+        isOpolloStaff: true,
+        pathname: "/company/something",
+      }),
+    ).toBe(CUSTOMER_COMPANY_ID);
+  });
+
+  // ── Staff on non-admin routes with no company context ────────────────────
+
+  it("returns null for staff on /account with no company context", () => {
+    expect(
+      resolveFeedbackCompanyId({
+        featureEnabled: true,
+        companyId: null,
+        isOpolloStaff: true,
+        pathname: "/account/settings",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for staff on /optimiser with no company context", () => {
+    expect(
+      resolveFeedbackCompanyId({
+        featureEnabled: true,
+        companyId: null,
+        isOpolloStaff: true,
+        pathname: "/optimiser",
+      }),
+    ).toBeNull();
+  });
+
+  // ── Non-staff with no company on admin route (shouldn't happen but guard) ─
+
+  it("returns null for non-staff user with no company on /admin route", () => {
+    expect(
+      resolveFeedbackCompanyId({
+        featureEnabled: true,
+        companyId: null,
+        isOpolloStaff: false,
+        pathname: "/admin/feedback",
+      }),
+    ).toBeNull();
+  });
+});

--- a/lib/feedback/resolve-company-id.ts
+++ b/lib/feedback/resolve-company-id.ts
@@ -1,0 +1,31 @@
+// Sentinel UUID for the Opollo-internal company row (migration 0070,
+// is_opollo_internal=true). Tickets filed against this company land on the
+// staff board without a customer company label.
+export const OPOLLO_INTERNAL_COMPANY_ID = "00000000-0000-0000-0000-000000000001";
+
+/**
+ * Resolves which companyId to pass to FeedbackWidget, or null if the widget
+ * should not mount.
+ *
+ * Resolution order:
+ *  1. Feature flag off or no authenticated session → null
+ *  2. User has a company context (company member or staff inside /company/*) → their company
+ *  3. Opollo staff on /admin/* → internal sentinel so tickets land on the staff board
+ *  4. All other cases (no company, not staff, or non-admin route) → null
+ */
+export function resolveFeedbackCompanyId({
+  featureEnabled,
+  companyId,
+  isOpolloStaff,
+  pathname,
+}: {
+  featureEnabled: boolean;
+  companyId: string | null | undefined;
+  isOpolloStaff: boolean;
+  pathname: string;
+}): string | null {
+  if (!featureEnabled) return null;
+  if (companyId) return companyId;
+  if (isOpolloStaff && pathname.startsWith("/admin")) return OPOLLO_INTERNAL_COMPANY_ID;
+  return null;
+}

--- a/scripts/seed-staging.ts
+++ b/scripts/seed-staging.ts
@@ -201,7 +201,7 @@ async function main() {
   } else {
     const { data: newCo, error: coErr } = await supa
       .from("platform_companies")
-      .insert({ name: TEST_COMPANY_NAME })
+      .insert({ name: TEST_COMPANY_NAME, slug: "staging-test-co" })
       .select("id")
       .single();
     if (coErr) throw new Error(`insert platform_companies: ${coErr.message}`);


### PR DESCRIPTION
## Summary

- Staff filing bugs on `/admin/*` pages (e.g. `/admin/feedback`) were excluded from the FeedbackWidget because the mount condition required a `company.companyId` in the platform session, which admin routes don't supply
- Adds a second mount path: Opollo staff on `/admin/*` get the internal sentinel company (`00000000-0000-0000-0000-000000000001`) so tickets land on the staff board without a customer company label
- Company-route behaviour (company members, staff inside `/company/*`) is unchanged

## Working analog

**Working analog**: `lib/feedback/tickets/queries.ts:108` — `OPOLLO_INTERNAL_COMPANY_ID` sentinel already used to suppress company labels on internal tickets. The new path uses the same UUID to scope staff tickets.
**Diff**: layout mount condition only checked `platformSession.company.companyId`; admin routes never set that.
**Fix**: `resolveFeedbackCompanyId()` helper adds the staff+admin path. Layout calls helper.

## Changes

- `lib/feedback/resolve-company-id.ts` — pure helper `resolveFeedbackCompanyId()` + exported sentinel constant
- `app/(platform)/layout.tsx` — uses helper, updated comment to describe both mount paths
- `components/__tests__/feedback-resolve-company-id.test.ts` — 9 component test cases covering all resolution branches

## Risks identified and mitigated

- **Sentinel UUID hardcoded in two places**: `queries.ts` has its own private copy; the new file exports a second copy. Acceptable for now — a future cleanup can import from one place. Not a correctness risk.
- **Admin routes should NOT supply company context**: confirmed by reading the layout — `companyId` is explicitly `null` for non-`/company/*` routes. The new path only fires when `companyId` is null, so no risk of overriding a real company scope.
- **FEATURE_FEEDBACK_WIDGET=1 gates both paths**: flag off → widget never mounts for anyone. No change to flag behaviour.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (pre-commit), `test:components` (9/9 pass)
- [x] Working-analog block above
- [x] Risks identified and mitigated section above
- [x] PR is under 500 net lines

## Verification (staging)

1. Add `FEATURE_FEEDBACK_WIDGET=1` to the Vercel Preview env
2. Visit `https://opollo-site-builder-git-staging-opollo5.vercel.app/admin/feedback` as `steven.m@opollo.com`
3. Confirm the feedback widget tab appears in the middle-right of the screen
4. File a test ticket — confirm it lands on the board under the Opollo-internal company scope